### PR TITLE
sdk 28 for 34

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,7 +117,7 @@ android {
         applicationId = "com.rk.xededitor"
         minSdk = 26
         //noinspection ExpiredTargetSdkVersion
-        targetSdk = 28
+        targetSdk = 34
         versionCode = 34
         versionName = "2.7.4"
         vectorDrawables {


### PR DESCRIPTION
I changed the target SDK from 28 to 34 because annoying messages appear as a warning that it was not compiled for versions of Android 14, as in my case.