### PR TITLE
feat:Add showInput method to EngineAPI interface

### DIFF
--- a/core/main/src/main/java/com/rk/mutator_engine/EngineAPI.java
+++ b/core/main/src/main/java/com/rk/mutator_engine/EngineAPI.java
@@ -32,6 +32,7 @@ public interface EngineAPI {
      */
     String http(String url, String options);
     void showDialog(String title,String content);
+    String showInput(String title, String hint, String prefill);
     void exit();
     void sleep(double millis);
 }

--- a/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/mutators/ImplAPI.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/mutators/ImplAPI.kt
@@ -175,6 +175,41 @@ class ImplAPI(val engine: Engine) : EngineAPI {
         }
 
     }
+    
+    override fun showInput(title: String?, hint: String?, prefill: String?): String {
+     var result: String? = null
+     runBlocking {
+         withContext(Dispatchers.Main) {
+             MainActivity.withContext {
+                 val editText = android.widget.EditText(this)
+                 editText.hint = hint ?: ""
+                 editText.setText(prefill ?: "")
+ 
+                 val latch = java.util.concurrent.CountDownLatch(1)
+
+                 val dialog = com.google.android.material.dialog.MaterialAlertDialogBuilder(this)
+                     .setTitle(title)
+                     .setView(editText)
+                     .setPositiveButton("OK") { _, _ ->
+                         result = editText.text.toString()
+                         latch.countDown()
+                     }
+                     .setNegativeButton("Cancel") { _, _ ->
+                         result = null
+                         latch.countDown()
+                     }
+                     .setOnCancelListener {
+                         result = null
+                         latch.countDown()
+                     }
+                     .show()
+
+                 latch.await()
+             }
+         }
+     }
+     return result ?: ""
+    }
 
     override fun exit() {
         engine.quickJS.close()

--- a/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/mutators/ImplAPI.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/mutators/ImplAPI.kt
@@ -7,6 +7,7 @@ import com.rk.libcommons.errorDialog
 import com.rk.libcommons.toast
 import com.rk.mutator_engine.Engine
 import com.rk.mutator_engine.EngineAPI
+import com.rk.resources.strings
 import com.rk.xededitor.MainActivity.Kee
 import com.rk.xededitor.MainActivity.MainActivity
 import com.rk.xededitor.MainActivity.tabs.editor.EditorFragment
@@ -179,22 +180,21 @@ class ImplAPI(val engine: Engine) : EngineAPI {
     override fun showInput(title: String?, hint: String?, prefill: String?): String {
      var result: String? = null
      runBlocking {
+         val latch = java.util.concurrent.CountDownLatch(1)
          withContext(Dispatchers.Main) {
              MainActivity.withContext {
                  val editText = android.widget.EditText(this)
                  editText.hint = hint ?: ""
                  editText.setText(prefill ?: "")
- 
-                 val latch = java.util.concurrent.CountDownLatch(1)
 
-                 val dialog = com.google.android.material.dialog.MaterialAlertDialogBuilder(this)
+                 MaterialAlertDialogBuilder(this)
                      .setTitle(title)
                      .setView(editText)
-                     .setPositiveButton("OK") { _, _ ->
+                     .setPositiveButton(strings.ok) { _, _ ->
                          result = editText.text.toString()
                          latch.countDown()
                      }
-                     .setNegativeButton("Cancel") { _, _ ->
+                     .setNegativeButton(strings.cancel) { _, _ ->
                          result = null
                          latch.countDown()
                      }
@@ -203,10 +203,9 @@ class ImplAPI(val engine: Engine) : EngineAPI {
                          latch.countDown()
                      }
                      .show()
-
-                 latch.await()
              }
          }
+         latch.await()
      }
      return result ?: ""
     }

--- a/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/mutators/ManageMutators.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/mutators/ManageMutators.kt
@@ -155,6 +155,9 @@ private fun onDone(name: String): Boolean {
             //${strings.script_showing_dialog.getString()}
             //showDialog(title,msg)
 
+            //show a input dialog 
+            //showInput(title, hint, prefill)
+
             //${strings.script_set_text.getString()}
             //setEditorText("${strings.script_text.getString()}")
             


### PR DESCRIPTION
This pull request introduces a new method, showInput, to the EngineAPI interface. The showInput method allows the engine to display an input dialog with a customizable title, hint, and pre-filled value, enabling enhanced user interaction for text input scenarios.

• Added: showInput(String title, String hint, String prefill) to EngineAPI.
• Purpose: Allows the editor to prompt users for input with context-specific hints and prefilled data
This change improves the flexibility and usability of the text editor’s user interface.
