### PR TITLE
docs(keybinds): improve keybind docs with kbd tags and categories

### DIFF
--- a/docs/KEYBINDS.md
+++ b/docs/KEYBINDS.md
@@ -2,19 +2,38 @@
 
 Supported KeyBindings on Karbon
 
-- **CTRL+S**: Save the current file
-- **CTRL+X**: Cut selected text
-- **CTRL+C**: Copy selected text
-- **CTRL+V**: Paste copied or cut text
-- **CTRL+A**: Select all text in the document
-- **CTRL+Z**: Undo the last action
-- **CTRL+Y**: Redo the last undone action
-- **CTRL+F**: Find text in the document
-- **CTRL+H**: Find and replace text
-- **CTRL+P**: Print the document
-- **CTRL+W**: Close the current tab
-- **CTRL+K**: Switch to the previous tab
-- **CTRL+L**: Switch to the next tab 
-- **CTRL+SHIFT+S**: Save As
-- **CTRL+G**: Move the cursor to the beginning of the document
-- **CTRL+B**: Move the cursor to the end of the document
+## File Operations
+
+| Shortcut&emsp;&emsp;&emsp;&emsp;&emsp;        | Action                |
+| --------------------------------------------- | --------------------- |
+| <kbd>CTRL</kbd>+<kbd>S</kbd>                  | Save the current file |
+| <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>S</kbd> | Save As               |
+| <kbd>CTRL</kbd>+<kbd>P</kbd>                  | Print the document    |
+
+## Editing
+
+| Shortcut&emsp;&emsp;&emsp;&emsp;&emsp; | Action                          |
+| -------------------------------------- | ------------------------------- |
+| <kbd>CTRL</kbd>+<kbd>X</kbd>           | Cut selected text               |
+| <kbd>CTRL</kbd>+<kbd>C</kbd>           | Copy selected text              |
+| <kbd>CTRL</kbd>+<kbd>V</kbd>           | Paste copied or cut text        |
+| <kbd>CTRL</kbd>+<kbd>A</kbd>           | Select all text in the document |
+| <kbd>CTRL</kbd>+<kbd>Z</kbd>           | Undo the last action            |
+| <kbd>CTRL</kbd>+<kbd>Y</kbd>           | Redo the last undone action     |
+
+## Tab Navigation
+
+| Shortcut&emsp;&emsp;&emsp;&emsp;&emsp; | Action                     |
+| -------------------------------------- | -------------------------- |
+| <kbd>CTRL</kbd>+<kbd>K</kbd>           | Switch to the previous tab |
+| <kbd>CTRL</kbd>+<kbd>L</kbd>           | Switch to the next tab     |
+| <kbd>CTRL</kbd>+<kbd>W</kbd>           | Close the current tab      |
+
+## Text Navigation
+
+| Shortcut&emsp;&emsp;&emsp;&emsp;&emsp; | Action                                           |
+| -------------------------------------- | ------------------------------------------------ |
+| <kbd>CTRL</kbd>+<kbd>F</kbd>           | Find text in the document                        |
+| <kbd>CTRL</kbd>+<kbd>H</kbd>           | Find and replace text                            |
+| <kbd>CTRL</kbd>+<kbd>G</kbd>           | Move the cursor to the beginning of the document |
+| <kbd>CTRL</kbd>+<kbd>B</kbd>           | Move the cursor to the end of the document       |


### PR DESCRIPTION
## Description
This PR improves the keybinds documentation for Xed-Editor:

- Added `<kbd>` tags for better readability, especially for screen readers
- Reorganized keybindings into logical categories:
  - File Operations
  - Editing
  - Tab Navigation
  - Text Navigation
- Put shortcuts into tables

> [!NOTE]  
> Used `&emsp;` to make sure that the shortcut column has the same width for all tables

## Screenshots
<img width="640" height="1144" alt="grafik" src="https://github.com/user-attachments/assets/4cd3b3e9-e736-4abe-9012-5aa345a9a183" />