### PR TITLE
refactor(strings): replace hardcoded strings with XML resources

### DIFF
--- a/core/main/src/main/java/com/rk/xededitor/ui/components/FileActionDialog.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/components/FileActionDialog.kt
@@ -76,7 +76,9 @@ fun FileActionDialog(
 
     if (showXedDialog){
         XedDialog(onDismissRequest = onDismissRequest) {
-            DividerColumn(modifier = Modifier.padding(0.dp).verticalScroll(rememberScrollState())) {
+            DividerColumn(modifier = Modifier
+                .padding(0.dp)
+                .verticalScroll(rememberScrollState())) {
 
                 if (fileTreeContext && root != null){
                     AddDialogItem(
@@ -416,7 +418,7 @@ fun RenameDialog(
     XedDialog(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                text = "Rename File",
+                text = stringResource(strings.rename_file),
                 style = MaterialTheme.typography.headlineSmall,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
@@ -424,7 +426,7 @@ fun RenameDialog(
             OutlinedTextField(
                 value = newName,
                 onValueChange = { newName = it },
-                label = { Text("New name") },
+                label = { Text(stringResource(strings.new_name)) },
                 modifier = Modifier.fillMaxWidth()
             )
 
@@ -435,14 +437,14 @@ fun RenameDialog(
                 horizontalArrangement = Arrangement.End
             ) {
                 TextButton(onClick = onDismiss) {
-                    Text("Cancel")
+                    Text(stringResource(strings.cancel))
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 TextButton(
                     onClick = { onConfirm(newName) },
                     enabled = newName.isNotBlank() && newName != currentName
                 ) {
-                    Text("Rename")
+                    Text(stringResource((strings.rename)))
                 }
             }
         }
@@ -518,7 +520,7 @@ fun DeleteConfirmationDialog(
             )
 
             Text(
-                text = "Are you sure you want to delete \"$fileName\"?",
+                text = String.format(stringResource(strings.ask_del), fileName),
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
@@ -527,7 +529,7 @@ fun DeleteConfirmationDialog(
                 horizontalArrangement = Arrangement.End
             ) {
                 TextButton(onClick = onDismiss) {
-                    Text("Cancel")
+                    Text(stringResource(strings.cancel))
                 }
                 Spacer(modifier = Modifier.width(8.dp))
                 TextButton(
@@ -536,7 +538,7 @@ fun DeleteConfirmationDialog(
                         contentColor = MaterialTheme.colorScheme.error
                     )
                 ) {
-                    Text("Delete")
+                    Text(stringResource(strings.delete))
                 }
             }
         }
@@ -552,21 +554,21 @@ fun FileInfoDialog(
     XedDialog(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                text = "File Information",
+                text = stringResource(strings.file_info),
                 style = MaterialTheme.typography.headlineSmall,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
 
-            InfoRow("Name", file.getName())
+            InfoRow(stringResource(strings.name), file.getName())
             if (file.isFile()){
-                InfoRow("Size", formatFileSize(file.length()))
+                InfoRow(stringResource(strings.file_size), formatFileSize(file.length()))
             }
-            InfoRow("Type", if (file.isDirectory()) "Directory" else "File")
-            InfoRow("Readable", if (file.canRead()) "Yes" else "No")
-            InfoRow("Writable", if (file.canWrite()) "Yes" else "No")
+            InfoRow(stringResource(strings.type), if (file.isDirectory()) stringResource(strings.folder) else stringResource(strings.file))
+            InfoRow(stringResource(strings.can_read), if (file.canRead()) stringResource(strings.yes) else stringResource(strings.no))
+            InfoRow(stringResource(strings.can_write), if (file.canWrite()) stringResource(strings.yes) else stringResource(strings.no))
 
-            InfoRow("FileType", file.javaClass.simpleName)
-            InfoRow("Path", file.getAbsolutePath())
+            InfoRow(stringResource(strings.file_type), file.javaClass.simpleName)
+            InfoRow(stringResource(strings.path), file.getAbsolutePath())
 
             Row(
                 modifier = Modifier
@@ -575,7 +577,7 @@ fun FileInfoDialog(
                 horizontalArrangement = Arrangement.End
             ) {
                 TextButton(onClick = onDismiss) {
-                    Text("Close")
+                    Text(stringResource(strings.close))
                 }
             }
         }

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="ask_enter_name">Please enter a name</string>
     <string name="already_exists">A document already exist with this name</string>
     <string name="attention">Attention</string>
-    <string name="ask_del">Are you sure you want to permanently delete</string>
+    <string name="ask_del">Are you sure you want to permanently delete %s?</string>
     <string name="redir">Please reselect the directory</string>
     <string name="canthandle">No app found to handle the file</string>
     <string name="clipboardempty">Clipboard is empty</string>
@@ -429,4 +429,9 @@
     <string name="seccomp_desc">Fix \"function not implemented\" error on some devices</string>
     <string name="non_native_filetype">Running code is not supported in this location. Consider moving your file to the terminal\'s home directory to run it.</string>
     <string name="sdcard_filetype">Running code is not recommended in this location. Consider moving your file to the terminal\'s home directory.</string>
+    <string name="rename_file">Rename File</string>
+    <string name="new_name">New name</string>
+    <string name="file_type">FileType</string>
+    <string name="type">Type</string>
+    <string name="name">Name</string>
 </resources>


### PR DESCRIPTION
## Description
This PR replaces hardcoded strings in the file action dialog with references to the appropriate XML string resources. This improves localization support.

## Changes:
- Replaced all hardcoded strings in UI components with XML resources.
- Added missing XML resources.
- Changed string `ask_del` to use placeholders (as suggested in #698)

## Clarification
1. However, I'm not sure about the `FileType` info row in the file info dialog. Why would you display the name of the file's corresponding Java class to the user? Isn't this unnecessary because the `Type` info row already exists?

<img width="458" height="492" alt="grafik" src="https://github.com/user-attachments/assets/f2d8033b-ff05-4e12-944c-008487b9df4c" />

2. I also used all the XML resources that already existed (_Were all these unused XML strings already prepared for this refactor?_), one of them is `file_size`, it might be better to abbreviate it to `size`, since all the other strings do not start with `file_` either.