### PR TITLE
feature(whitespace): add setting to render whitespace (Closes #660)

### DIFF
--- a/core/main/src/main/java/com/rk/libcommons/editor/KarbonEditor.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/KarbonEditor.kt
@@ -277,6 +277,7 @@ class KarbonEditor : CodeEditor {
         val wordWrap = Settings.wordwrap
         val keyboardSuggestion = Settings.show_suggestions
         val lineSpacing = Settings.line_spacing
+        val renderWhitespace = Settings.render_whitespace
 
         props.deleteMultiSpaces = tabSize
         tabWidth = tabSize
@@ -291,6 +292,14 @@ class KarbonEditor : CodeEditor {
         isDisableSoftKbdIfHardKbdAvailable = Settings.hide_soft_keyboard_if_hardware
         showSuggestions(keyboardSuggestion)
 
+        if (renderWhitespace) {
+            nonPrintablePaintingFlags = FLAG_DRAW_LINE_SEPARATOR or
+                                        FLAG_DRAW_WHITESPACE_LEADING or
+                                        FLAG_DRAW_WHITESPACE_INNER or
+                                        FLAG_DRAW_WHITESPACE_TRAILING or
+                                        FLAG_DRAW_WHITESPACE_FOR_EMPTY_LINE or
+                                        FLAG_DRAW_WHITESPACE_IN_SELECTION
+        }
     }
 
 

--- a/core/main/src/main/java/com/rk/libcommons/editor/KarbonEditor.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/KarbonEditor.kt
@@ -299,6 +299,8 @@ class KarbonEditor : CodeEditor {
                                         FLAG_DRAW_WHITESPACE_TRAILING or
                                         FLAG_DRAW_WHITESPACE_FOR_EMPTY_LINE or
                                         FLAG_DRAW_WHITESPACE_IN_SELECTION
+        } else {
+            nonPrintablePaintingFlags = 0
         }
     }
 

--- a/core/main/src/main/java/com/rk/settings/Settings.kt
+++ b/core/main/src/main/java/com/rk/settings/Settings.kt
@@ -25,6 +25,7 @@ object Settings {
     var show_arrow_keys by CachedPreference("arrow_keys", hasHardwareKeyboard(application!!).not())
     var keep_drawer_locked by CachedPreference("drawer_lock", false)
     var show_line_numbers by CachedPreference("show_line_number", true)
+    var render_whitespace by CachedPreference("render_whitespace", false)
     var auto_save by CachedPreference("auto_save", false)
     var show_suggestions by CachedPreference("show_suggestions", false)
     var check_for_update by CachedPreference("check_update", false)

--- a/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/editor/SettingsEditorScreen.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/editor/SettingsEditorScreen.kt
@@ -121,6 +121,15 @@ fun SettingsEditorScreen(navController: NavController) {
                     Settings.show_line_numbers = it
                 }
             )
+
+            EditorSettingsToggle(label = stringResource(id = strings.render_whitespace),
+                description = stringResource(id = strings.render_whitespace_desc),
+                default = Settings.render_whitespace,
+                sideEffect = {
+                    Settings.render_whitespace = it
+                }
+            )
+
             EditorSettingsToggle(label = stringResource(id = strings.show_suggestions),
                 description = stringResource(id = strings.show_suggestions),
                 default = Settings.show_suggestions,

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -405,4 +405,6 @@
     <string name="discord">Discord community</string>
     <string name="use_tabs">Insert tab character</string>
     <string name="use_tabs_desc">Use a real tab (\\t) instead of spaces for indentation</string>
+    <string name="render_whitespace">Render whitespace</string>
+    <string name="render_whitespace_desc">Render spaces, tabs, and line breaks as visible symbols</string>
 </resources>


### PR DESCRIPTION
## Description
This PR adds a new setting to Xed-Editor that, when enabled, shows all types of whitespace (newline, spaces, tabs) in the editor. It closes feature request #660 