### PR TITLE
feat(settings): increase text size/zoom and implement proper error messages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,9 +61,10 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
-            isCrunchPngs = false
-            isShrinkResources = false
+            isMinifyEnabled = true
+            isCrunchPngs = true
+            isShrinkResources = true
+
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,10 +61,11 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = true
-            isCrunchPngs = true
-            isShrinkResources = true
+            isMinifyEnabled = false
+            isShrinkResources = false
 
+
+            isCrunchPngs = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
@@ -94,6 +95,8 @@ android {
 
         create("PlayStore") {
             dimension = "store"
+            applicationIdSuffix = ".play"
+            versionNameSuffix = "-PLAY"
             targetSdk = 35
         }
     }

--- a/core/main/build.gradle.kts
+++ b/core/main/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
     api(project(":core:extension"))
 
     api(libs.kotlin.reflect)
+    api(libs.androidx.material.icons.extended)
 
 }
 

--- a/core/main/build.gradle.kts
+++ b/core/main/build.gradle.kts
@@ -119,7 +119,6 @@ dependencies {
     api(libs.lsp4j)
     api(libs.kotlin.reflect)
     api(libs.androidx.documentfile)
-    api(libs.androidx.material.icons.extended)
 
     // Modules
     api(project(":editor"))

--- a/core/main/src/main/java/com/rk/libcommons/editor/KarbonEditor.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/KarbonEditor.kt
@@ -292,6 +292,10 @@ class KarbonEditor : CodeEditor {
         isDisableSoftKbdIfHardKbdAvailable = Settings.hide_soft_keyboard_if_hardware
         showSuggestions(keyboardSuggestion)
 
+        val minScaleSize: Float = 6f * resources.displayMetrics.scaledDensity
+        val maxScaleSize: Float = 100f * resources.displayMetrics.scaledDensity
+        setScaleTextSizes(minScaleSize, maxScaleSize)
+
         if (renderWhitespace) {
             nonPrintablePaintingFlags = FLAG_DRAW_LINE_SEPARATOR or
                                         FLAG_DRAW_WHITESPACE_LEADING or

--- a/core/main/src/main/java/com/rk/xededitor/ui/components/InputDialog.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/components/InputDialog.kt
@@ -48,8 +48,9 @@ fun InputDialog(
                         }
                     },
                     trailingIcon = {
-                        if (errorMessage != null)
+                        if (errorMessage != null) {
                             Icon(Icons.Filled.Error, "error", tint = MaterialTheme.colorScheme.error)
+                        }
                     },
                     keyboardActions = KeyboardActions(
                         onDone = { onConfirm() },

--- a/core/main/src/main/java/com/rk/xededitor/ui/components/InputDialog.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/components/InputDialog.kt
@@ -5,14 +5,17 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.rk.resources.drawables
 import com.rk.resources.strings
+import com.rk.xededitor.ui.icons.Error
+import com.rk.xededitor.ui.icons.XedIcons
 
 @Composable
 fun InputDialog(
@@ -49,7 +52,7 @@ fun InputDialog(
                     },
                     trailingIcon = {
                         if (errorMessage != null) {
-                            Icon(Icons.Filled.Error, "error", tint = MaterialTheme.colorScheme.error)
+                            Icon(XedIcons.Error, "error", tint = MaterialTheme.colorScheme.error)
                         }
                     },
                     keyboardActions = KeyboardActions(

--- a/core/main/src/main/java/com/rk/xededitor/ui/components/InputDialog.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/components/InputDialog.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -11,7 +13,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.rk.resources.strings
-import com.rk.xededitor.R
 
 @Composable
 fun InputDialog(
@@ -21,7 +22,8 @@ fun InputDialog(
     onInputValueChange: (String) -> Unit,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
-    singleLineMode:Boolean = true
+    singleLineMode: Boolean = true,
+    errorMessage: String? = null
 ) {
     AlertDialog(
         onDismissRequest = { onDismiss() },
@@ -35,6 +37,20 @@ fun InputDialog(
                     label = { Text(inputLabel) },
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(12.dp),
+                    isError = errorMessage != null,
+                    supportingText = {
+                        if (errorMessage != null) {
+                            Text(
+                                text = errorMessage,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    },
+                    trailingIcon = {
+                        if (errorMessage != null)
+                            Icon(Icons.Filled.Error, "error", tint = MaterialTheme.colorScheme.error)
+                    },
                     keyboardActions = KeyboardActions(
                         onDone = { onConfirm() },
                         onSearch = { onConfirm() }
@@ -47,6 +63,7 @@ fun InputDialog(
         },
         confirmButton = {
             Button(
+                enabled = errorMessage == null,
                 onClick = {
                     onConfirm()
                     onDismiss()

--- a/core/main/src/main/java/com/rk/xededitor/ui/icons/Error.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/icons/Error.kt
@@ -1,0 +1,71 @@
+package com.rk.xededitor.ui.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val XedIcons.Error: ImageVector
+    get() {
+        if (_Error != null) return _Error!!
+
+        _Error = ImageVector.Builder(
+            name = "Error",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 960f,
+            viewportHeight = 960f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFF000000))
+            ) {
+                moveTo(480f, 680f)
+                quadToRelative(17f, 0f, 28.5f, -11.5f)
+                reflectiveQuadTo(520f, 640f)
+                reflectiveQuadToRelative(-11.5f, -28.5f)
+                reflectiveQuadTo(480f, 600f)
+                reflectiveQuadToRelative(-28.5f, 11.5f)
+                reflectiveQuadTo(440f, 640f)
+                reflectiveQuadToRelative(11.5f, 28.5f)
+                reflectiveQuadTo(480f, 680f)
+                moveToRelative(-40f, -160f)
+                horizontalLineToRelative(80f)
+                verticalLineToRelative(-240f)
+                horizontalLineToRelative(-80f)
+                close()
+                moveToRelative(40f, 360f)
+                quadToRelative(-83f, 0f, -156f, -31.5f)
+                reflectiveQuadTo(197f, 763f)
+                reflectiveQuadToRelative(-85.5f, -127f)
+                reflectiveQuadTo(80f, 480f)
+                reflectiveQuadToRelative(31.5f, -156f)
+                reflectiveQuadTo(197f, 197f)
+                reflectiveQuadToRelative(127f, -85.5f)
+                reflectiveQuadTo(480f, 80f)
+                reflectiveQuadToRelative(156f, 31.5f)
+                reflectiveQuadTo(763f, 197f)
+                reflectiveQuadToRelative(85.5f, 127f)
+                reflectiveQuadTo(880f, 480f)
+                reflectiveQuadToRelative(-31.5f, 156f)
+                reflectiveQuadTo(763f, 763f)
+                reflectiveQuadToRelative(-127f, 85.5f)
+                reflectiveQuadTo(480f, 880f)
+                moveToRelative(0f, -80f)
+                quadToRelative(134f, 0f, 227f, -93f)
+                reflectiveQuadToRelative(93f, -227f)
+                reflectiveQuadToRelative(-93f, -227f)
+                reflectiveQuadToRelative(-227f, -93f)
+                reflectiveQuadToRelative(-227f, 93f)
+                reflectiveQuadToRelative(-93f, 227f)
+                reflectiveQuadToRelative(93f, 227f)
+                reflectiveQuadToRelative(227f, 93f)
+                moveToRelative(0f, -320f)
+            }
+        }.build()
+
+        return _Error!!
+    }
+
+private var _Error: ImageVector? = null
+

--- a/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/editor/SettingsEditorScreen.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/editor/SettingsEditorScreen.kt
@@ -277,10 +277,10 @@ fun SettingsEditorScreen(navController: NavController) {
                     if (textSizeValue.toIntOrNull() == null) {
                         toast(strings.invalid_v)
                         textSizeValue = Settings.editor_text_size.toString()
-                    } else if (textSizeValue.toInt() > 32) {
+                    } else if (textSizeValue.toInt() > 128) {
                         toast(context.getString(strings.v_large))
                         textSizeValue = Settings.editor_text_size.toString()
-                    } else if (textSizeValue.toInt() < 8) {
+                    } else if (textSizeValue.toInt() < 6) {
                         toast(context.getString(strings.v_small))
                         textSizeValue = Settings.editor_text_size.toString()
                     } else {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ android.useAndroidX=true
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=false
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=warn

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ profileinstaller = "1.4.1"
 benchmark = "1.2.4"
 runner = "1.5.2"
 benchmarkJunit4 = "1.2.4"
+materialIconsExtended = "1.7.8"
 
 [libraries]
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
@@ -188,6 +189,7 @@ androidx-benchmark-macro-junit4 = { group = "androidx.benchmark", name = "benchm
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }
 androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-junit4", version.ref = "benchmarkJunit4" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 
 
 


### PR DESCRIPTION
## Changes
- Change min text size from `8` to `6`
- Change max text size from `32` to `100` (the same value as in vscode)
- Set pinch zoom factor to the same values
- Implement error support for the `InputDialog`
- Show errors in input field instead of toast messages
- Reset value after clicking on `Cancel`

Closes #671 (I did not implement the zoom factor percentage number because I think that's not important)