### PR TITLE
refactor(build): format build script and remove unused declarations in version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,6 @@ plugins {
     alias(libs.plugins.baselineprofile)
 }
 
-
 android {
     namespace = "com.rk.application"
     compileSdk = 36
@@ -60,7 +59,6 @@ android {
         }
     }
 
-
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -71,11 +69,13 @@ android {
             )
             signingConfig = signingConfigs.getByName("release")
         }
+
         debug {
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-DEBUG"
             resValue("string", "app_name", "Xed-Debug")
         }
+
         create("benchmark") {
             initWith(buildTypes.getByName("release"))
             matchingFallbacks += listOf("release")
@@ -97,7 +97,7 @@ android {
         }
     }
 
-    //values in this will be overridden by the flavours
+    // Values in this will be overridden by the flavours
     defaultConfig {
         applicationId = "com.rk.xededitor"
         minSdk = 26
@@ -125,18 +125,15 @@ android {
         buildConfig = true
     }
 
-
-
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.15"
     }
+
     packaging {
         jniLibs {
             useLegacyPackaging = true
         }
     }
-
-
 }
 
 fun downloadFile(localUrl: String, remoteUrl: String, expectedChecksum: String) {
@@ -152,7 +149,9 @@ fun downloadFile(localUrl: String, remoteUrl: String, expectedChecksum: String) 
             digest.update(buffer, 0, readBytes)
         }
         var checksum = BigInteger(1, digest.digest()).toString(16)
-        while (checksum.length < 64) { checksum = "0$checksum" }
+        while (checksum.length < 64) {
+            checksum = "0$checksum"
+        }
         if (checksum == expectedChecksum) {
             return
         } else {
@@ -172,7 +171,9 @@ fun downloadFile(localUrl: String, remoteUrl: String, expectedChecksum: String) 
     out.close()
 
     var checksum = BigInteger(1, digest.digest()).toString(16)
-    while (checksum.length < 64) { checksum = "0$checksum" }
+    while (checksum.length < 64) {
+        checksum = "0$checksum"
+    }
     if (checksum != expectedChecksum) {
         file.delete()
         throw GradleException("Wrong checksum for $remoteUrl:\n Expected: $expectedChecksum\n Actual:   $checksum")
@@ -183,24 +184,46 @@ tasks.register("downloadPrebuilt") {
     doLast {
         val prootTag = "proot-2025.01.15-r2"
         val prootVersion = "5.1.107-66"
-        var prootUrl = "https://github.com/termux-play-store/termux-packages/releases/download/${prootTag}/libproot-loader-ARCH-${prootVersion}.so"
+        var prootUrl =
+            "https://github.com/termux-play-store/termux-packages/releases/download/${prootTag}/libproot-loader-ARCH-${prootVersion}.so"
 
-        downloadFile("src/main/jniLibs/armeabi-v7a/libproot-loader.so", prootUrl.replace("ARCH", "arm"), "eb1d64e9ef875039534ce7a8eeffa61bbc4c0ae5722cb48c9112816b43646a3e")
-        downloadFile("src/main/jniLibs/arm64-v8a/libproot-loader.so", prootUrl.replace("ARCH", "aarch64"), "8814b72f760cd26afe5350a1468cabb6622b4871064947733fcd9cd06f1c8cb8")
-        downloadFile("src/main/jniLibs/x86_64/libproot-loader.so", prootUrl.replace("ARCH", "x86_64"), "1a52cc9cc5fdecbf4235659ffeac8c51e4fefd7c75cc205f52d4884a3a0a0ba1")
-        prootUrl = "https://github.com/termux-play-store/termux-packages/releases/download/${prootTag}/libproot-loader32-ARCH-${prootVersion}.so"
-        downloadFile("src/main/jniLibs/arm64-v8a/libproot-loader32.so", prootUrl.replace("ARCH", "aarch64"), "ff56a5e3a37104f6778420d912e3edf31395c15d1528d28f0eb7d13a64481b99")
-        downloadFile("src/main/jniLibs/x86_64/libproot-loader32.so", prootUrl.replace("ARCH", "x86_64"), "5460a597e473f57f0d33405891e35ca24709173ca0a38805d395e3544ab8b1b4")
+        downloadFile(
+            "src/main/jniLibs/armeabi-v7a/libproot-loader.so",
+            prootUrl.replace("ARCH", "arm"),
+            "eb1d64e9ef875039534ce7a8eeffa61bbc4c0ae5722cb48c9112816b43646a3e"
+        )
+        downloadFile(
+            "src/main/jniLibs/arm64-v8a/libproot-loader.so",
+            prootUrl.replace("ARCH", "aarch64"),
+            "8814b72f760cd26afe5350a1468cabb6622b4871064947733fcd9cd06f1c8cb8"
+        )
+        downloadFile(
+            "src/main/jniLibs/x86_64/libproot-loader.so",
+            prootUrl.replace("ARCH", "x86_64"),
+            "1a52cc9cc5fdecbf4235659ffeac8c51e4fefd7c75cc205f52d4884a3a0a0ba1"
+        )
+        prootUrl =
+            "https://github.com/termux-play-store/termux-packages/releases/download/${prootTag}/libproot-loader32-ARCH-${prootVersion}.so"
+        downloadFile(
+            "src/main/jniLibs/arm64-v8a/libproot-loader32.so",
+            prootUrl.replace("ARCH", "aarch64"),
+            "ff56a5e3a37104f6778420d912e3edf31395c15d1528d28f0eb7d13a64481b99"
+        )
+        downloadFile(
+            "src/main/jniLibs/x86_64/libproot-loader32.so",
+            prootUrl.replace("ARCH", "x86_64"),
+            "5460a597e473f57f0d33405891e35ca24709173ca0a38805d395e3544ab8b1b4"
+        )
     }
 }
 
-tasks.register("removeProotLoaders"){
-    fun rm(path:String){
-        val file = File(projectDir,path)
+tasks.register("removeProotLoaders") {
+    fun rm(path: String) {
+        val file = File(projectDir, path)
 
-        if(file.exists()){
+        if (file.exists()) {
             logger.quiet("Deleting $path")
-            if(file.delete().not()){
+            if (file.delete().not()) {
                 logger.error("Failed to delete $path")
             }
         }
@@ -217,19 +240,17 @@ afterEvaluate {
     android.applicationVariants.all { variant ->
         if (variant.flavorName == "PlayStore") {
             variant.javaCompileProvider.dependsOn("downloadPrebuilt")
-        }else{
+        } else {
             variant.javaCompileProvider.dependsOn("removeProotLoaders")
         }
         true
     }
 }
 
-
-
-
 dependencies {
     implementation(libs.androidx.profileinstaller)
-    "baselineProfile"(project(":baselineprofile"))
     coreLibraryDesugaring(libs.desugar.jdk.libs)
+
+    "baselineProfile"(project(":baselineprofile"))
     implementation(project(":core:main"))
 }

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -14,7 +14,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-
     defaultConfig {
         minSdk = 28
         targetSdk = 36
@@ -29,7 +28,6 @@ android {
         create("Fdroid") { dimension = "store" }
         create("PlayStore") { dimension = "store" }
     }
-
 }
 
 // This is the configuration block for the Baseline Profile plugin.

--- a/core/components/build.gradle.kts
+++ b/core/components/build.gradle.kts
@@ -29,12 +29,10 @@ android {
 }
 
 dependencies {
-    implementation(libs.material)
-    implementation(libs.appcompat)
-    
     implementation(platform(libs.compose.bom))
     implementation(libs.material3)
     implementation(libs.material)
+    implementation(libs.appcompat)
     implementation(libs.ui)
     implementation(libs.ui.graphics)
     implementation(libs.activity.compose)

--- a/core/main/build.gradle.kts
+++ b/core/main/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.io.ByteArrayOutputStream
-import java.io.File
 import groovy.json.JsonOutput
 
 plugins {
@@ -21,14 +19,13 @@ val gitCommitDate: Provider<String> = providers.exec {
     commandLine("git", "show", "-s", "--format=%cI", "HEAD")
 }.standardOutput.asText.map { it.trim() }
 
-
 android {
     namespace = "com.rk.xededitor"
+    compileSdk = 36
+
     buildFeatures {
         buildConfig = true
     }
-
-    compileSdk = 36
 
     defaultConfig {
         minSdk = 26
@@ -41,19 +38,21 @@ android {
             buildConfigField("String", "GIT_COMMIT_HASH", "\"${fullGitCommitHash.get()}\"")
             buildConfigField("String", "GIT_SHORT_COMMIT_HASH", "\"${gitCommitHash.get()}\"")
             buildConfigField("String", "GIT_COMMIT_DATE", "\"${gitCommitDate.get()}\"")
+
             isMinifyEnabled = false
             isShrinkResources = false
+
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
             )
         }
+
         debug {
             buildConfigField("String", "GIT_COMMIT_HASH", "\"${fullGitCommitHash.get()}\"")
             buildConfigField("String", "GIT_SHORT_COMMIT_HASH", "\"${gitCommitHash.get()}\"")
             buildConfigField("String", "GIT_COMMIT_DATE", "\"${gitCommitDate.get()}\"")
         }
     }
-
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -63,6 +62,7 @@ android {
     kotlin {
         jvmToolchain(17)
     }
+
     buildFeatures {
         viewBinding = true
         compose = true
@@ -86,8 +86,6 @@ tasks.named("preBuild") {
     dependsOn(runPrecompileScript)
 }
 
-
-
 dependencies {
     api(libs.appcompat)
     api(libs.material)
@@ -105,11 +103,8 @@ dependencies {
     api(libs.ui.graphics)
     api(libs.material3)
     api(libs.navigation.compose)
-    api(project(":core:terminal-view"))
-    api(project(":core:terminal-emulator"))
     api(libs.utilcode)
     api(libs.coil.compose)
-    //api(libs.org.eclipse.jgit)
     api(libs.gson)
     api(libs.commons.net)
     api(libs.okhttp)
@@ -122,12 +117,10 @@ dependencies {
     api(libs.quickjs.android)
     api(libs.anrwatchdog)
     api(libs.lsp4j)
-    api("androidx.documentfile:documentfile:1.1.0")
+    api(libs.kotlin.reflect)
+    api(libs.androidx.documentfile)
 
-    //debug libs these libs doesn't get added when creating release builds
-    //debugApi(libs.bsh)
-    //debugApi(libs.leakcanary.android)
-
+    // Modules
     api(project(":editor"))
     api(project(":editor-lsp"))
     api(project(":language-textmate"))
@@ -135,14 +128,11 @@ dependencies {
     api(project(":core:components"))
     api(project(":core:bridge"))
     api(project(":core:extension"))
-
-    api(libs.kotlin.reflect)
-
+    api(project(":core:terminal-view"))
+    api(project(":core:terminal-emulator"))
 }
 
-
 abstract class GenerateSupportedLocales : DefaultTask() {
-
     @get:InputDirectory
     abstract val resDir: DirectoryProperty
 
@@ -161,6 +151,7 @@ abstract class GenerateSupportedLocales : DefaultTask() {
                 folderName == "values" -> "en"
                 folderName.startsWith("values-") ->
                     folderName.removePrefix("values-").replace("-r", "-")
+
                 else -> null
             }
             locale?.let { locales.add(it) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,65 +1,38 @@
 [versions]
-accompanistDrawablepainter = "0.37.3"
-accompanistSwiperefresh = "0.36.0"
 agp = "8.13.0"
 annotation = "1.9.1"
 anrwatchdog = "1.4.0"
 appcompat = "1.7.1"
 browser = "1.9.0"
-bsh = "3.0.0-SNAPSHOT"
-collection = "1.5.0"
 commonsNet = "3.12.0"
-constraintlayoutCompose = "1.1.1"
-datastorePreferences = "1.1.7"
 desugar_jdk_libs = "2.1.5"
-eventbus = "3.3.1"
-foundation = "1.9.1"
+documentfile = "1.1.0"
 glide = "5.0.4"
 kotlinReflect = "2.2.20"
-ktsh = "1.0.0"
-leakcanaryAndroid = "2.14"
-library = "1.1.6"
 material = "1.13.0"
 constraintlayout = "2.2.1"
-material3 = "1.4.0-rc01"
-media3Exoplayer = "1.8.0"
-media3ExoplayerDash = "1.8.0"
 media3Ui = "1.8.0"
-modernandroidpreferences = "2.4.0-beta1"
 nanohttpd = "2.3.1"
 navigationFragment = "2.9.4"
 navigationUi = "2.9.4"
 kotlin = "2.2.20"
-asynclayoutinflater = "1.1.0"
 navigationFragmentKtx = "2.9.4"
 navigationUiKtx = "2.9.4"
 coreKtx = "1.17.0"
 activity = "1.11.0"
-nbJavacAndroid = "17.0.0.3"
 okhttp = "5.1.0"
-orgEclipseJgit = "6.2.0.202206071550-r"
 photoview = "2.3.0"
 quickjsAndroid = "0.9.2"
 composeRuntime = "1.9.0"
-sshj = "0.40.0"
-swiperefreshlayout = "1.1.0"
-terminalView = "0.118.3"
 kotlinPlugin = "2.2.20"
-junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
-coordinatorlayout = "1.3.0"
-lifecycleLivedataKtx = "2.9.3"
 lifecycleViewmodelKtx = "2.9.3"
 lifecycleRuntimeKtx = "2.9.3"
 activityCompose = "1.11.0"
 composeBom = "2025.09.00"
 coilCompose = "2.7.0"
 navigationCompose = "2.9.4"
-lifecycleViewmodelAndroid = "2.9.3"
-wordWrap = "0.1.13"
-coreAnimation = "1.0.0"
-runtimeAndroid = "1.9.1"
 
 tsBinding = "4.3.1"
 lsp4j = "0.24.0"
@@ -73,84 +46,44 @@ runner = "1.5.2"
 benchmarkJunit4 = "1.2.4"
 
 [libraries]
-accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanistDrawablepainter" }
-accompanist-swiperefresh = { module = "com.google.accompanist:accompanist-swiperefresh", version.ref = "accompanistSwiperefresh" }
-androidx-constraintlayout-compose = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraintlayoutCompose" }
-androidx-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
+androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "composeRuntime" }
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 anrwatchdog = { module = "com.github.anrwatchdog:anrwatchdog", version.ref = "anrwatchdog" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 browser = { module = "androidx.browser:browser", version.ref = "browser" }
-bsh = { module = "org.beanshell:bsh", version.ref = "bsh" }
-collection = { module = "androidx.collection:collection", version.ref = "collection" }
 commons-net = { module = "commons-net:commons-net", version.ref = "commonsNet" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
-eventbus = { module = "org.greenrobot:eventbus", version.ref = "eventbus" }
-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "foundation" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
-kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinReflect" }
-ktsh = { module = "com.jaredrummler:ktsh", version.ref = "ktsh" }
-leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanaryAndroid" }
-library = { module = "me.zhanghai.android.libarchive:library", version.ref = "library" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Ui" }
-media3-exoplayer-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "media3ExoplayerDash" }
-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3Exoplayer" }
 nanohttpd = { module = "org.nanohttpd:nanohttpd", version.ref = "nanohttpd" }
 navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "navigationFragment" }
 navigation-ui = { group = "androidx.navigation", name = "navigation-ui", version.ref = "navigationUi" }
-asynclayoutinflater = { group = "androidx.asynclayoutinflater", name = "asynclayoutinflater", version.ref = "asynclayoutinflater" }
 navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
-#lsp4j = { module = "org.eclipse.lsp4j:org.eclipse.lsp4j", version.ref = "lsp4j" }
-nb-javac-android = { module = "io.github.itsaky:nb-javac-android", version.ref = "nbJavacAndroid" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-org-eclipse-jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "orgEclipseJgit" }
-org-jetbrains-kotlin-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 photoview = { module = "com.github.chrisbanes:PhotoView", version.ref = "photoview" }
 quickjs-android = { module = "app.cash.quickjs:quickjs-android", version.ref = "quickjsAndroid" }
-sshj = { module = "com.hierynomus:sshj", version.ref = "sshj" }
-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
 utilcode = { module = "com.blankj:utilcodex", version = "1.31.1" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version = "1.10.2" }
-terminal-view = { group = "com.termux.termux-app", name = "terminal-view", version.ref = "terminalView" }
-terminal-emulator = { group = "com.termux.termux-app", name = "terminal-emulator", version.ref = "terminalView" }
 gson = { module = "com.google.code.gson:gson", version = "2.13.2" }
-#jcodings = { module = "org.jruby.jcodings:jcodings", version = "1.0.61" }
-#joni = { module = "org.jruby.joni:joni", version = "2.2.3" }
-#snakeyaml-engine = { module = "org.snakeyaml:snakeyaml-engine", version = "2.9" }
-#jdt-annotation = { module = "org.eclipse.jdt:org.eclipse.jdt.annotation", version = "2.4.0" }
-#junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-coordinatorlayout = { group = "androidx.coordinatorlayout", name = "coordinatorlayout", version.ref = "coordinatorlayout" }
-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycleLivedataKtx" }
 lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 ui = { group = "androidx.compose.ui", name = "ui" }
 ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-material-compose = { group = "androidx.compose.material", name = "material", version = "1.9.1" }
 material3 = { group = "androidx.compose.material3", name = "material3" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 material-motion-compose-core = { group = "io.github.fornewid", name = "material-motion-compose-core", version = "2.0.1" }
-lifecycle-viewmodel-android = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-android", version.ref = "lifecycleViewmodelAndroid" }
-word-wrap = { module = "com.github.davidmoten:word-wrap", version.ref = "wordWrap" }
-core-animation = { group = "androidx.core", name = "core-animation", version.ref = "coreAnimation" }
-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtimeAndroid" }
-
 
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }
 androidx-collection = { module = "androidx.collection:collection", version = "1.5.0" }
@@ -160,16 +93,13 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1
 androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.3.0" }
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version = "3.7.0" }
 desugar = { module = "com.android.tools:desugar_jdk_libs", version = "2.1.5" }
-#kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version = "1.10.2" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.9.3" }
-#material = { module = "com.google.android.material:material", version = "1.12.0" }
 tree-sitter-java = { module = "com.itsaky.androidide.treesitter:tree-sitter-java", version.ref = "tsBinding" }
 tree-sitter = { module = "com.itsaky.androidide.treesitter:android-tree-sitter", version.ref = "tsBinding" }
 lsp4j = { module = "org.eclipse.lsp4j:org.eclipse.lsp4j", version.ref = "lsp4j" }
 leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version = "2.14" }
 junit = { module = "junit:junit", version = "4.13.2" }
-#gson = { module = "com.google.code.gson:gson", version = "2.13.1" }
 jcodings = { module = "org.jruby.jcodings:jcodings", version = "1.0.63" }
 joni = { module = "org.jruby.joni:joni", version = "2.2.6" }
 snakeyaml-engine = { module = "org.snakeyaml:snakeyaml-engine", version = "2.10" }
@@ -189,19 +119,14 @@ androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profi
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }
 androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-junit4", version.ref = "benchmarkJunit4" }
 
-
-
 [plugins]
-
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin"  }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinParcelize = { id = "org.jetbrains.kotlin.plugin.parcelize",  version.ref = "kotlinPlugin"  }
 
-kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 publish = { id = "com.vanniktech.maven.publish.base", version = "0.34.0" }
-android-test = { id = "com.android.test", version.ref = "agp" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
 benchmark = { id = "androidx.benchmark", version.ref = "benchmark" }
 


### PR DESCRIPTION
## Changes
- Format build scripts (remove e.g. double line breaks)
- Remove unused declarations in `libs.versions.toml`