### PR TITLE
feat(lsp): add language servers and improve ui

### DIFF
--- a/core/main/src/main/assets/terminal/universal_runner.sh
+++ b/core/main/src/main/assets/terminal/universal_runner.sh
@@ -43,15 +43,21 @@ install_package() {
   apt install -y "$packages"
 }
 
-
 install_nodejs() {
   echo "Installing Node.js LTS..."
+  install_package "curl"
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
+  mkdir -p /home/.npm-global
+  npm config set prefix '/home/.npm-global'
+  grep -qxF "export PATH=\"/home/.npm-global/bin:$PATH\"" ~/.bashrc || \
+      echo "export PATH=\"/home/.npm-global/bin:$PATH\"" >> ~/.bashrc
+  export PATH="/home/.npm-global/bin:$PATH"
 }
 
 install_rust() {
   echo "Installing Rust..."
+  install_package "curl"
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
   source "$HOME/.cargo/env"
   # Add to PATH for current session
@@ -68,6 +74,7 @@ install_dotnet() {
 }
 
 install_kotlin() {
+    install_package "unzip curl"
     echo "Fetching latest Kotlin compiler..."
     url=$(curl -s https://api.github.com/repos/JetBrains/kotlin/releases/latest \
         | grep "browser_download_url" \
@@ -135,7 +142,6 @@ case "$file" in
     fi
     if ! command_exists kotlinc; then
       echo "Installing Kotlin..."
-      install_package "curl unzip"
       install_kotlin
     fi
     kotlinc "$file" -include-runtime -d temp.jar && java -jar temp.jar

--- a/core/main/src/main/java/com/rk/libcommons/editor/BaseLspServer.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/BaseLspServer.kt
@@ -8,4 +8,5 @@ abstract class BaseLspServer {
     abstract fun command(): Array<String>
     abstract val id: String
     abstract val languageName: String
+    abstract val supportedExtensions: List<String>
 }

--- a/core/main/src/main/java/com/rk/libcommons/editor/ScopeRegistry.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/ScopeRegistry.kt
@@ -1,6 +1,10 @@
 package com.rk.libcommons.editor
 
+import com.rk.libcommons.editor.lspServers.CSS
+import com.rk.libcommons.editor.lspServers.HTML
+import com.rk.libcommons.editor.lspServers.JSON
 import com.rk.libcommons.editor.lspServers.Python
+import com.rk.libcommons.editor.lspServers.TypeScript
 
 val textmateSources = mapOf(
     "pro" to "source.shell",
@@ -70,6 +74,10 @@ val textmateSources = mapOf(
     "zig" to "source.zig"
 )
 
-val lspRegistry = mapOf<String, BaseLspServer>(
-    "py" to Python()
+val lspRegistry = listOf(
+    Python(),
+    HTML(),
+    CSS(),
+    TypeScript(),
+    JSON()
 )

--- a/core/main/src/main/java/com/rk/libcommons/editor/lspServers/Bash.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/lspServers/Bash.kt
@@ -1,11 +1,14 @@
 package com.rk.libcommons.editor.lspServers
 
 import android.content.Context
-import com.rk.libcommons.editor.BaseLspConnector
 import com.rk.libcommons.editor.BaseLspServer
 import com.rk.terminal.isTerminalInstalled
 
 class Bash() : BaseLspServer() {
+    override val id: String = "bash-lsp"
+    override val languageName: String = "Bash"
+    override val supportedExtensions: List<String> = listOf()
+
     override fun isInstalled(context: Context): Boolean {
         if (isTerminalInstalled().not()){
             return false
@@ -21,8 +24,4 @@ class Bash() : BaseLspServer() {
     override fun command(): Array<String> {
         TODO("Not yet implemented")
     }
-
-    override val id: String = "bash-lsp"
-    override val languageName: String = "Bash"
-
 }

--- a/core/main/src/main/java/com/rk/libcommons/editor/lspServers/CSS.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/lspServers/CSS.kt
@@ -1,0 +1,58 @@
+package com.rk.libcommons.editor.lspServers
+
+import android.content.Context
+import com.rk.file.child
+import com.rk.file.getPrivateDir
+import com.rk.file.sandboxDir
+import com.rk.file.sandboxHomeDir
+import com.rk.libcommons.TerminalCommand
+import com.rk.libcommons.editor.BaseLspServer
+import com.rk.terminal.isTerminalInstalled
+import com.rk.terminal.launchInternalTerminal
+import java.io.File
+
+class CSS() : BaseLspServer() {
+    override val id: String = "css-lsp"
+    override val languageName: String = "CSS"
+    override val supportedExtensions: List<String> = listOf("css")
+
+    override fun isInstalled(context: Context): Boolean {
+        if (!isTerminalInstalled()){
+            return false
+        }
+
+        return sandboxHomeDir().child("/.npm-global/bin/vscode-css-language-server").exists()
+    }
+
+    override fun install(context: Context) {
+        val installCommand = """
+            apt update && \
+            apt upgrade -y && \
+            apt install curl -y && \
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+            apt install -y nodejs && \
+            mkdir -p /home/.npm-global && \
+            npm config set prefix '/home/.npm-global' && \
+            grep -qxF 'export PATH="/home/.npm-global/bin:${"$"}PATH"' ~/.bashrc || \
+                echo 'export PATH="/home/.npm-global/bin:${"$"}PATH"' >> ~/.bashrc && \
+            export PATH="/home/.npm-global/bin:${"$"}PATH" && \
+            npm install -g vscode-langservers-extracted && \
+            clear && \
+            echo 'CSS language server installed successfully. Please reopen all tabs or restart the app.'
+        """.trimIndent()
+
+        launchInternalTerminal(
+            context = context,
+            terminalCommand = TerminalCommand(
+                exe = "/bin/bash",
+                args = arrayOf("-c", "\"${installCommand}\""),
+                id = "css-lsp-installer",
+                env = arrayOf("DEBIAN_FRONTEND=noninteractive"),
+            )
+        )
+    }
+
+    override fun command(): Array<String> {
+        return arrayOf("/usr/bin/node", "/home/.npm-global/bin/vscode-css-language-server",  "--stdio")
+    }
+}

--- a/core/main/src/main/java/com/rk/libcommons/editor/lspServers/ESLint.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/lspServers/ESLint.kt
@@ -1,0 +1,55 @@
+package com.rk.libcommons.editor.lspServers
+
+import android.content.Context
+import com.rk.file.child
+import com.rk.file.sandboxHomeDir
+import com.rk.libcommons.TerminalCommand
+import com.rk.libcommons.editor.BaseLspServer
+import com.rk.terminal.isTerminalInstalled
+import com.rk.terminal.launchInternalTerminal
+
+class ESLint() : BaseLspServer() {
+    override val id: String = "eslint-lsp"
+    override val languageName: String = "ESLint"
+    override val supportedExtensions: List<String> = listOf("js", "jsx", "ts", "tsx")
+
+    override fun isInstalled(context: Context): Boolean {
+        if (!isTerminalInstalled()){
+            return false
+        }
+
+        return sandboxHomeDir().child("/.npm-global/bin/vscode-eslint-language-server").exists()
+    }
+
+    override fun install(context: Context) {
+        val installCommand = """
+            apt update && \
+            apt upgrade -y && \
+            apt install curl -y && \
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+            apt install -y nodejs && \
+            mkdir -p /home/.npm-global && \
+            npm config set prefix '/home/.npm-global' && \
+            grep -qxF 'export PATH="/home/.npm-global/bin:${"$"}PATH"' ~/.bashrc || \
+                echo 'export PATH="/home/.npm-global/bin:${"$"}PATH"' >> ~/.bashrc && \
+            export PATH="/home/.npm-global/bin:${"$"}PATH" && \
+            npm install -g vscode-langservers-extracted && \
+            clear && \
+            echo 'ESLint language server installed successfully. Please reopen all tabs or restart the app.'
+        """.trimIndent()
+
+        launchInternalTerminal(
+            context = context,
+            terminalCommand = TerminalCommand(
+                exe = "/bin/bash",
+                args = arrayOf("-c", "\"${installCommand}\""),
+                id = "css-eslint-installer",
+                env = arrayOf("DEBIAN_FRONTEND=noninteractive"),
+            )
+        )
+    }
+
+    override fun command(): Array<String> {
+        return arrayOf("/usr/bin/node", "/home/.npm-global/bin/vscode-eslint-language-server",  "--stdio")
+    }
+}

--- a/core/main/src/main/java/com/rk/libcommons/editor/lspServers/HTML.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/lspServers/HTML.kt
@@ -1,0 +1,55 @@
+package com.rk.libcommons.editor.lspServers
+
+import android.content.Context
+import com.rk.file.child
+import com.rk.file.sandboxHomeDir
+import com.rk.libcommons.TerminalCommand
+import com.rk.libcommons.editor.BaseLspServer
+import com.rk.terminal.isTerminalInstalled
+import com.rk.terminal.launchInternalTerminal
+
+class HTML() : BaseLspServer() {
+    override val id: String = "html-lsp"
+    override val languageName: String = "HTML"
+    override val supportedExtensions: List<String> = listOf("html", "htm", "xht", "xhtml")
+
+    override fun isInstalled(context: Context): Boolean {
+        if (!isTerminalInstalled()){
+            return false
+        }
+
+        return sandboxHomeDir().child("/.npm-global/bin/vscode-html-language-server").exists()
+    }
+
+    override fun install(context: Context) {
+        val installCommand = """
+            apt update && \
+            apt upgrade -y && \
+            apt install curl -y && \
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+            apt install -y nodejs && \
+            mkdir -p /home/.npm-global && \
+            npm config set prefix '/home/.npm-global' && \
+            grep -qxF 'export PATH="/home/.npm-global/bin:${"$"}PATH"' ~/.bashrc || \
+                echo 'export PATH="/home/.npm-global/bin:${"$"}PATH"' >> ~/.bashrc && \
+            export PATH="/home/.npm-global/bin:${"$"}PATH" && \
+            npm install -g vscode-langservers-extracted && \
+            clear && \
+            echo 'HTML language server installed successfully. Please reopen all tabs or restart the app.'
+        """.trimIndent()
+
+        launchInternalTerminal(
+            context = context,
+            terminalCommand = TerminalCommand(
+                exe = "/bin/bash",
+                args = arrayOf("-c", "\"${installCommand}\""),
+                id = "html-lsp-installer",
+                env = arrayOf("DEBIAN_FRONTEND=noninteractive"),
+            )
+        )
+    }
+
+    override fun command(): Array<String> {
+        return arrayOf("/usr/bin/node", "/home/.npm-global/bin/vscode-html-language-server",  "--stdio")
+    }
+}

--- a/core/main/src/main/java/com/rk/libcommons/editor/lspServers/JSON.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/lspServers/JSON.kt
@@ -1,0 +1,55 @@
+package com.rk.libcommons.editor.lspServers
+
+import android.content.Context
+import com.rk.file.child
+import com.rk.file.sandboxHomeDir
+import com.rk.libcommons.TerminalCommand
+import com.rk.libcommons.editor.BaseLspServer
+import com.rk.terminal.isTerminalInstalled
+import com.rk.terminal.launchInternalTerminal
+
+class JSON() : BaseLspServer() {
+    override val id: String = "json-lsp"
+    override val languageName: String = "JSON"
+    override val supportedExtensions: List<String> = listOf("json")
+
+    override fun isInstalled(context: Context): Boolean {
+        if (!isTerminalInstalled()){
+            return false
+        }
+
+        return sandboxHomeDir().child("/.npm-global/bin/vscode-json-language-server").exists()
+    }
+
+    override fun install(context: Context) {
+        val installCommand = """
+            apt update && \
+            apt upgrade -y && \
+            apt install curl -y && \
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+            apt install -y nodejs && \
+            mkdir -p /home/.npm-global && \
+            npm config set prefix '/home/.npm-global' && \
+            grep -qxF 'export PATH="/home/.npm-global/bin:${"$"}PATH"' ~/.bashrc || \
+                echo 'export PATH="/home/.npm-global/bin:${"$"}PATH"' >> ~/.bashrc && \
+            export PATH="/home/.npm-global/bin:${"$"}PATH" && \
+            npm install -g vscode-langservers-extracted && \
+            clear && \
+            echo 'JSON language server installed successfully. Please reopen all tabs or restart the app.'
+        """.trimIndent()
+
+        launchInternalTerminal(
+            context = context,
+            terminalCommand = TerminalCommand(
+                exe = "/bin/bash",
+                args = arrayOf("-c", "\"${installCommand}\""),
+                id = "json-lsp-installer",
+                env = arrayOf("DEBIAN_FRONTEND=noninteractive"),
+            )
+        )
+    }
+
+    override fun command(): Array<String> {
+        return arrayOf("/usr/bin/node", "/home/.npm-global/bin/vscode-json-language-server",  "--stdio")
+    }
+}

--- a/core/main/src/main/java/com/rk/libcommons/editor/lspServers/Markdown.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/lspServers/Markdown.kt
@@ -1,0 +1,55 @@
+package com.rk.libcommons.editor.lspServers
+
+import android.content.Context
+import com.rk.file.child
+import com.rk.file.sandboxHomeDir
+import com.rk.libcommons.TerminalCommand
+import com.rk.libcommons.editor.BaseLspServer
+import com.rk.terminal.isTerminalInstalled
+import com.rk.terminal.launchInternalTerminal
+
+class Markdown() : BaseLspServer() {
+    override val id: String = "markdown-lsp"
+    override val languageName: String = "Markdown"
+    override val supportedExtensions: List<String> = listOf("md")
+
+    override fun isInstalled(context: Context): Boolean {
+        if (!isTerminalInstalled()){
+            return false
+        }
+
+        return sandboxHomeDir().child("/.npm-global/bin/vscode-markdown-language-server").exists()
+    }
+
+    override fun install(context: Context) {
+        val installCommand = """
+            apt update && \
+            apt upgrade -y && \
+            apt install curl -y && \
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+            apt install -y nodejs && \
+            mkdir -p /home/.npm-global && \
+            npm config set prefix '/home/.npm-global' && \
+            grep -qxF 'export PATH="/home/.npm-global/bin:${"$"}PATH"' ~/.bashrc || \
+                echo 'export PATH="/home/.npm-global/bin:${"$"}PATH"' >> ~/.bashrc && \
+            export PATH="/home/.npm-global/bin:${"$"}PATH" && \
+            npm install -g vscode-langservers-extracted && \
+            clear && \
+            echo 'Markdown language server installed successfully. Please reopen all tabs or restart the app.'
+        """.trimIndent()
+
+        launchInternalTerminal(
+            context = context,
+            terminalCommand = TerminalCommand(
+                exe = "/bin/bash",
+                args = arrayOf("-c", "\"${installCommand}\""),
+                id = "markdown-lsp-installer",
+                env = arrayOf("DEBIAN_FRONTEND=noninteractive"),
+            )
+        )
+    }
+
+    override fun command(): Array<String> {
+        return arrayOf("/usr/bin/node", "/home/.npm-global/bin/vscode-markdown-language-server",  "--stdio")
+    }
+}

--- a/core/main/src/main/java/com/rk/libcommons/editor/lspServers/Python.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/lspServers/Python.kt
@@ -2,7 +2,6 @@ package com.rk.libcommons.editor.lspServers
 
 import android.content.Context
 import com.rk.file.child
-import com.rk.file.sandboxDir
 import com.rk.file.sandboxHomeDir
 import com.rk.libcommons.TerminalCommand
 import com.rk.libcommons.editor.BaseLspServer
@@ -12,10 +11,10 @@ import com.rk.terminal.launchInternalTerminal
 class Python() : BaseLspServer() {
     override val id: String = "python-lsp"
     override val languageName: String = "Python"
-
+    override val supportedExtensions: List<String> = listOf("py")
 
     override fun isInstalled(context: Context): Boolean {
-        if (isTerminalInstalled().not()){
+        if (!isTerminalInstalled()) {
             return false
         }
 
@@ -23,12 +22,21 @@ class Python() : BaseLspServer() {
     }
 
     override fun install(context: Context) {
+        val installCommand = """
+            apt update && \
+            apt upgrade -y && \
+            apt install -y pipx && \
+            pipx ensurepath && \
+            pipx install 'python-lsp-server[all]' && \
+            clear && \
+            echo 'Python language server installed successfully. Please reopen all tabs or restart the app.'
+        """.trimIndent()
+
         launchInternalTerminal(
             context = context,
-            terminalCommand = TerminalCommand(exe = "/bin/bash",
-                args = arrayOf("-c",
-                    "\"apt update && apt upgrade -y && apt install -y pipx && pipx install 'python-lsp-server[all]' && clear && echo 'Successfully installed close all tabs and reopen.' \""
-                ),
+            terminalCommand = TerminalCommand(
+                exe = "/bin/bash",
+                args = arrayOf("-c", "\"${installCommand}\""),
                 id = "python-lsp-installer",
                 env = arrayOf("DEBIAN_FRONTEND=noninteractive"),
             )

--- a/core/main/src/main/java/com/rk/libcommons/editor/lspServers/TypeScript.kt
+++ b/core/main/src/main/java/com/rk/libcommons/editor/lspServers/TypeScript.kt
@@ -1,0 +1,55 @@
+package com.rk.libcommons.editor.lspServers
+
+import android.content.Context
+import com.rk.file.child
+import com.rk.file.sandboxHomeDir
+import com.rk.libcommons.TerminalCommand
+import com.rk.libcommons.editor.BaseLspServer
+import com.rk.terminal.isTerminalInstalled
+import com.rk.terminal.launchInternalTerminal
+
+class TypeScript() : BaseLspServer() {
+    override val id: String = "typescript-lsp"
+    override val languageName: String = "TypeScript"
+    override val supportedExtensions: List<String> = listOf("js", "jsx", "ts", "tsx")
+
+    override fun isInstalled(context: Context): Boolean {
+        if (!isTerminalInstalled()){
+            return false
+        }
+
+        return sandboxHomeDir().child("/.npm-global/bin/typescript-language-server").exists()
+    }
+
+    override fun install(context: Context) {
+        val installCommand = """
+            apt update && \
+            apt upgrade -y && \
+            apt install curl -y && \
+            curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+            apt install -y nodejs && \
+            mkdir -p /home/.npm-global && \
+            npm config set prefix '/home/.npm-global' && \
+            grep -qxF 'export PATH="/home/.npm-global/bin:${"$"}PATH"' ~/.bashrc || \
+                echo 'export PATH="/home/.npm-global/bin:${"$"}PATH"' >> ~/.bashrc && \
+            export PATH="/home/.npm-global/bin:${"$"}PATH" && \
+            npm install -g typescript typescript-language-server && \
+            clear && \
+            echo 'TypeScript language server installed successfully. Please reopen all tabs or restart the app.'
+        """.trimIndent()
+
+        launchInternalTerminal(
+            context = context,
+            terminalCommand = TerminalCommand(
+                exe = "/bin/bash",
+                args = arrayOf("-c", "\"${installCommand}\""),
+                id = "typescript-lsp-installer",
+                env = arrayOf("DEBIAN_FRONTEND=noninteractive"),
+            )
+        )
+    }
+
+    override fun command(): Array<String> {
+        return arrayOf("/usr/bin/node", "/home/.npm-global/bin/typescript-language-server",  "--stdio")
+    }
+}

--- a/core/main/src/main/java/com/rk/xededitor/ui/components/InfoBlock.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/components/InfoBlock.kt
@@ -1,7 +1,7 @@
 package com.rk.xededitor.ui.components
 
 
-
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,27 +9,34 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import com.rk.components.compose.preferences.base.PreferenceGroup
+import com.rk.xededitor.ui.theme.onWarningSurface
+import com.rk.xededitor.ui.theme.warningSurface
 
 
+@SuppressLint("RestrictedApi")
 @Composable
 fun InfoBlock(
     modifier: Modifier = Modifier,
     text: String,
     icon: @Composable (() -> Unit)? = null,
     shape: Shape = RoundedCornerShape(12.dp),
+    warning: Boolean = false
 ) {
     PreferenceGroup(modifier = modifier) {
         Card(
             modifier = modifier,
             shape = shape,
+            colors = if (warning) CardDefaults.cardColors(MaterialTheme.colorScheme.warningSurface) else CardDefaults.cardColors()
         ) {
             Row(
                 modifier = Modifier
@@ -49,6 +56,7 @@ fun InfoBlock(
                 Text(
                     text = text,
                     style = MaterialTheme.typography.bodySmall,
+                    color = if (warning) MaterialTheme.colorScheme.onWarningSurface else Color.Unspecified,
                     modifier = Modifier.padding(start = 8.dp)
                 )
             }

--- a/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/editor/LspSettings.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/editor/LspSettings.kt
@@ -2,6 +2,10 @@ package com.rk.xededitor.ui.screens.settings.editor
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Warning
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -12,25 +16,48 @@ import com.rk.components.compose.preferences.base.PreferenceLayout
 import com.rk.libcommons.editor.lspRegistry
 import com.rk.resources.strings
 import com.rk.settings.Preference
+import com.rk.xededitor.ui.components.InfoBlock
 import com.rk.xededitor.ui.components.SettingsToggle
 
 @Composable
 fun LspSettings(modifier: Modifier = Modifier) {
     PreferenceLayout(label = stringResource(strings.lsp_settings)) {
-        if (lspRegistry.isNotEmpty()){
+        InfoBlock(
+            icon = {
+                Icon(
+                    imageVector = Icons.Outlined.Info, contentDescription = null
+                )
+            },
+            text = stringResource(strings.info_lsp),
+        )
+
+        InfoBlock(
+            icon = {
+                Icon(
+                    imageVector = Icons.Outlined.Warning, contentDescription = null
+                )
+            },
+            text = stringResource(strings.experimental_lsp),
+            warning = true
+        )
+
+        if (lspRegistry.isNotEmpty()) {
             PreferenceGroup {
-                lspRegistry.values.forEach { server ->
-                    SettingsToggle(label = server.languageName, default = Preference.getBoolean("lsp_${server.id}",false), showSwitch = true, sideEffect = {
-                        Preference.setBoolean("lsp_${server.id}",it)
-                    })
+                lspRegistry.forEach { server ->
+                    SettingsToggle(
+                        label = server.languageName,
+                        default = Preference.getBoolean("lsp_${server.id}", false),
+                        description = server.supportedExtensions.joinToString(", ") {".$it"},
+                        showSwitch = true,
+                        sideEffect = {
+                            Preference.setBoolean("lsp_${server.id}", it)
+                        })
                 }
             }
-        }else{
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center){
+        } else {
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 Text(stringResource(strings.no_language_server))
             }
         }
-
-
     }
 }

--- a/core/main/src/main/java/com/rk/xededitor/ui/theme/Theme.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/theme/Theme.kt
@@ -3,6 +3,7 @@ package com.rk.xededitor.ui.theme
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -83,3 +84,10 @@ fun KarbonTheme(
 
 @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.S)
 fun supportsDynamicTheming() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+// Custom warning colors
+val ColorScheme.warningSurface: Color
+    @Composable get() = if (isSystemInDarkTheme()) Color(0xFF633F00) else Color(0xFFFFDDB4)
+
+val ColorScheme.onWarningSurface: Color
+    @Composable get() = if (isSystemInDarkTheme()) Color(0xFFFFDDB4) else Color(0xFF633F00)

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -421,4 +421,6 @@
     <string name="unknown">Unknown</string>
     <string name="cant_write">Cannot write to the file (no write permissions)</string>
     <string name="content_update">This file was modified by another app. Do you want to refresh? Unsaved changes will be lost.</string>
+    <string name="info_lsp">Language servers are separate processes that provide intelligent features, such as code completion, error highlighting and inline documentation.</string>
+    <string name="experimental_lsp">Language servers are experimental and may not work properly.</string>
 </resources>


### PR DESCRIPTION
## Description
This PR improves the LSP settings UI, refactors the code and adds more language servers.

## Changes
- Improve LSP settings UI
  - Add info box with explanation
  - Add experimental box (Generated warning colors with Material Theme Builder)
  - Add file extensions that the LSP handles (could be changed in the future to e.g. language server size)
- Add more language servers
   - HTML language server _(uses [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted))_
   - CSS language server _(uses [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted))_
   - JavaScript/TypeScript language server _(uses [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server))_
   - JSON language server _(uses [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted))_
- Fix python LSP install script (`pipx ensurepath`)
- Allow LSPs to handle multiple file extensions (extensions property is now in `BaseLspServer.kt`)
- Add cURL installation to `universal_runner.sh` to fix e.g. NodeJS installation

## Notes
> [!NOTE]
> I wrote this part in all of Xed-Editor's automatic NodeJS installation scripts:
> ```sh
> mkdir -p /home/.npm-global
> npm config set prefix '/home/.npm-global'
> grep -qxF "export PATH=\"/home/.npm-global/bin:$PATH\"" ~/.bashrc || \
>     echo "export PATH=\"/home/.npm-global/bin:$PATH\"" >> ~/.bashrc
> export PATH="/home/.npm-global/bin:$PATH"
> ```
> This makes sure that all global packages (such as the `typescript-language-server`) are installed in that .npm-global directory. This is a workaround because NodeJS would otherwise install them **outside** of the sandbox. (This is probably unintended, I'm going to write an issue)

> [!NOTE]
> I also had to manually type the location of the node binary `arrayOf("/usr/bin/node", "/home/.npm-global/bin/vscode-html-language-server",  "--stdio")` because otherwise, even though the binary is in the PATH, Xed-Editor wouldn't find the binary. The PATH seems to be different when such commands are executed.

## Screenshots
<div>
<img src="https://github.com/user-attachments/assets/6b131952-62c3-4b33-85d3-a6c72c294592" width="45%"> <img src="https://github.com/user-attachments/assets/3f56166e-1603-4c8f-8fd8-78069f2f4a5a" width="45%">
</div>

## Current limitations and issues
> [!NOTE]
> I added the Markdown and ESLint language servers because they're also included in the [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted) package but I didn't add them to the registry because for me they didn't work.

- vscode-html-language-server:
   - Error toast when trying to auto complete the closing pair of an HTML tag
    ```kotlin
    java.lang.StringIndexOutOfBoundsException: start > end
	    at io.github.rosemoe.sora.text.Content.subSequence(Content.java:216)
	    at io.github.rosemoe.sora.lsp.editor.completion.LspCompletionItem.performCompletion(LspCompletionItem.kt:130)
	    at io.github.rosemoe.sora.widget.component.EditorAutoCompletion.select(EditorAutoCompletion.java:487)
	    at io.github.rosemoe.sora.widget.component.DefaultCompletionLayout.lambda$inflate$0(DefaultCompletionLayout.java:127)
	    at io.github.rosemoe.sora.widget.component.DefaultCompletionLayout.$r8$lambda$E6-zPRaPfv9BZs_7eHihY72lIOs(Unknown Source:0)
	    at io.github.rosemoe.sora.widget.component.DefaultCompletionLayout$$ExternalSyntheticLambda1.onItemClick(D8$$SyntheticClass:0)
	    // ...
    ```
   - Still shows all tags like `area` even though `met` is already written, it should only show `meta` and `meter` as suggestions (General issue of all language servers)
   - Some errors (red underline) don't disappear even after fixing them (also general issue of all LSPs of [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted))
   - No JS autocompletion in `script` tag (but has CSS autocompletion in `style` tag)
- vscode-css-language-server:
   - Still shows all suggestions after starting to type something like in vscode-html-language-server (General issue of all language servers)
   - Some errors (red underline) don't disappear even after fixing them (General issue of [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted))
- typescript-language-server:
    - Still shows all suggestions after starting to type something (General issue of all language servers)
    - Some tiny issues like still showing suggestions while typing strings
- vscode-json-language-server:
   - Same issues: still shows all suggestions after starting to type something (General issue of all language servers)
   - Some errors (red underline) don't disappear even after fixing them (General issue of [vscode-langservers-extracted](https://github.com/hrsh7th/vscode-langservers-extracted))