### PR TITLE
feat(bottom-sheet): use ModalBottomSheet instead of dialog

### DIFF
--- a/core/main/src/main/java/com/rk/compose/filetree/Drawer.kt
+++ b/core/main/src/main/java/com/rk/compose/filetree/Drawer.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
@@ -349,6 +350,7 @@ fun DrawerContent(modifier: Modifier = Modifier,onFileSelected:(FileObject)-> Un
 }
 
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AddProjectDialog(
     onDismiss: () -> Unit,
@@ -360,8 +362,10 @@ private fun AddProjectDialog(
     val activity = context as? MainActivity
     val lifecycleScope = remember { activity?.lifecycleScope ?: DefaultScope }
 
-    XedDialog(onDismissRequest = onDismiss) {
-        DividerColumn {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 0.dp)
+        ) {
             AddDialogItem(
                 icon = drawables.file_symlink,
                 title = stringResource(strings.open_directory),

--- a/core/main/src/main/java/com/rk/xededitor/ui/components/AddDialogItem.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/components/AddDialogItem.kt
@@ -71,7 +71,7 @@ fun AddDialogItem(
     Row(
         modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
             .clickable(onClick = onClick)
-            .padding(16.dp),
+            .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
 

--- a/core/main/src/main/java/com/rk/xededitor/ui/components/FileActionDialog.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/components/FileActionDialog.kt
@@ -17,7 +17,9 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
@@ -51,6 +53,7 @@ import kotlinx.coroutines.withContext
 import org.apache.commons.net.io.Util.copyStream
 import java.util.Locale
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FileActionDialog(
     modifier: Modifier = Modifier,
@@ -78,11 +81,12 @@ fun FileActionDialog(
     var showNewDialog by remember { mutableStateOf(false) }
 
     if (showXedDialog){
-        XedDialog(onDismissRequest = onDismissRequest) {
-            DividerColumn(modifier = Modifier
-                .padding(0.dp)
-                .verticalScroll(rememberScrollState())) {
-
+        ModalBottomSheet(onDismissRequest = onDismissRequest) {
+            Column(
+                modifier = Modifier
+                    .padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 0.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
                 if (file.isDirectory()) {
                     AddDialogItem(
                         icon = Icons.Outlined.Refresh,
@@ -96,15 +100,15 @@ fun FileActionDialog(
                     )
                 }
 
-                if (file is FileWrapper && file.isDirectory()){
+                if (file is FileWrapper && file.isDirectory()) {
                     AddDialogItem(
                         icon = drawables.terminal,
                         title = stringResource(strings.open_in_terminal),
                         //description = stringResource(strings.open_in_terminal),
                         onClick = {
-                            showTerminalNotice(activity = MainActivity.instance!!){
-                                val intent = Intent(context,Terminal::class.java)
-                                intent.putExtra("cwd",file.getAbsolutePath())
+                            showTerminalNotice(activity = MainActivity.instance!!) {
+                                val intent = Intent(context, Terminal::class.java)
+                                intent.putExtra("cwd", file.getAbsolutePath())
                                 context.startActivity(intent)
                                 onDismissRequest()
                             }
@@ -112,7 +116,7 @@ fun FileActionDialog(
                     )
                 }
 
-                if (file.isDirectory()){
+                if (file.isDirectory()) {
                     AddDialogItem(
                         icon = XedIcons.CreateNewFile,
                         title = stringResource(strings.new_file),
@@ -176,14 +180,14 @@ fun FileActionDialog(
                     //description = stringResource(strings.cut_desc),
                     onClick = {
                         scope.launch {
-                            FileOperations.copyToClipboard(file,isCut = true)
+                            FileOperations.copyToClipboard(file, isCut = true)
                             showXedDialog = true
                             onDismissRequest()
                         }
                     }
                 )
 
-                if (fileTreeContext && FileOperations.clipboard != null && file.isDirectory()){
+                if (fileTreeContext && FileOperations.clipboard != null && file.isDirectory()) {
                     AddDialogItem(
                         icon = drawables.round_content_paste_20,
                         title = stringResource(strings.paste),
@@ -191,7 +195,12 @@ fun FileActionDialog(
                         onClick = {
                             scope.launch {
                                 val parentFile = FileOperations.clipboard!!.getParentFile()
-                                pasteFile(context,FileOperations.clipboard!!,file,isCut = FileOperations.isCut)
+                                pasteFile(
+                                    context,
+                                    FileOperations.clipboard!!,
+                                    file,
+                                    isCut = FileOperations.isCut
+                                )
                                 fileTreeViewModel?.updateCache(file)
                                 fileTreeViewModel?.updateCache(parentFile!!)
                                 //showXedDialog = true
@@ -199,7 +208,7 @@ fun FileActionDialog(
                             }
                         }
                     )
-                    
+
                 }
 
                 AddDialogItem(
@@ -225,7 +234,7 @@ fun FileActionDialog(
                     }
                 )
 
-                if (fileTreeContext && file.isDirectory()){
+                if (fileTreeContext && file.isDirectory()) {
                     AddDialogItem(
                         icon = drawables.arrow_downward,
                         title = stringResource(strings.add_file),
@@ -237,7 +246,7 @@ fun FileActionDialog(
                             onDismissRequest()
                         }
                     )
-                    
+
                 }
 
                 AddDialogItem(
@@ -252,18 +261,16 @@ fun FileActionDialog(
                 )
 
                 Hooks.FileAction.actions.values.forEach { action ->
-                    if (action.shouldAttach(root,file)){
+                    if (action.shouldAttach(root, file)) {
                         AddDialogItem(
                             icon = action.icon,
                             title = action.title,
                             onClick = {
-                                action.onClick(root,file)
+                                action.onClick(root, file)
                             }
                         )
                     }
-
                 }
-                
             }
         }
     }

--- a/core/main/src/main/java/com/rk/xededitor/ui/components/GlobalActions.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/components/GlobalActions.kt
@@ -2,19 +2,25 @@ package com.rk.xededitor.ui.components
 
 import android.content.Intent
 import android.content.pm.PackageManager
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.rk.DefaultScope
 import com.rk.components.compose.preferences.base.DividerColumn
@@ -38,6 +44,7 @@ import kotlinx.coroutines.launch
 
 var addDialog by mutableStateOf(false)
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RowScope.GlobalActions(viewModel: MainViewModel) {
     val context = LocalContext.current
@@ -65,11 +72,13 @@ fun RowScope.GlobalActions(viewModel: MainViewModel) {
         }
     }
 
-    if (addDialog){
-        XedDialog(onDismissRequest = {
+    if (addDialog) {
+        ModalBottomSheet(onDismissRequest = {
             addDialog = false
         }) {
-            DividerColumn {
+            Column(
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 0.dp)
+            ) {
                 AddDialogItem(icon = drawables.file, title = stringResource(strings.temp_file)) {
                     DefaultScope.launch{
                         viewModel.newTab(FileWrapper(sandboxHomeDir().child("temp").createFileIfNot()),checkDuplicate = true,switchToTab = true)


### PR DESCRIPTION
This PR replaces the `XedDialog` for certain actions with the `ModalBottomSheet`.

Why this is better:
- It's easier to reach with the thumb (and better for one-handed use)
- The bottom sheet only covers the bottom part of the screen, letting users still see the content beneath it
- Swipe gestures can be used to dismiss the sheet quickly

This is also used in [AndroidIDE](https://github.com/AndroidIDEOfficial/AndroidIDE).

## Screenshots
<img width="573" height="1251" alt="grafik" src="https://github.com/user-attachments/assets/3dc93c69-1437-4d3a-93bc-3b2d114fe35a" />
