### PR TITLE
chore(kotlin): Remove .kotlin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .gradle
 .idea
+.kotlin
 /local.properties
 /.idea/caches
 /.idea/libraries


### PR DESCRIPTION
This PR removes the `.kotlin` folder and adds it to the `.gitignore` list.

These files are probably auto-generated by the Kotlin compiler, are machine-specific, and should not be tracked in version control.