### PR TITLE
fix(topbar): clamp selected tab index to prevent OOB

### DIFF
--- a/core/main/src/main/java/com/rk/xededitor/ui/activities/main/TopBar.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/activities/main/TopBar.kt
@@ -34,11 +34,14 @@ fun XedTopBar(modifier: Modifier = Modifier,drawerState: DrawerState, viewModel:
         actions = {
             this.GlobalActions(viewModel)
 
-            if (viewModel.tabs.isNotEmpty()){
-                viewModel.tabs[viewModel.currentTabIndex].apply {
-                    Actions()
-                }
-            }
+            val tabs = viewModel.tabs
+            if (tabs.isNotEmpty()) {
+                val lastIndex = (tabs.size - 1).coerceAtLeast(0)
+                val safeIndex = viewModel.currentTabIndex.coerceIn(0, lastIndex)
+                tabs.getOrNull(safeIndex)?.apply {
+                    Actions()
+                }
+            }
 
 
         }


### PR DESCRIPTION
Also read via getOrNull() during recomposition to avoid crashes when the tab list shrinks. #832.