### PR TITLE
fix: dotnet GC heap initialization failed

### DIFF
--- a/core/main/src/main/assets/terminal/universal_runner.sh
+++ b/core/main/src/main/assets/terminal/universal_runner.sh
@@ -193,6 +193,7 @@ case "$file" in
     # Create a temporary project
     mkdir -p temp_cs_project
     cd temp_cs_project
+    export DOTNET_GCHeapHardLimit=1C0000000
     dotnet new console --force
     cp "../$file" Program.cs
     dotnet run


### PR DESCRIPTION
Fixed by adding export DOTNET_GCHeapHardLimit=1C0000000 to .cs runner in universal_runner.sh