### PR TITLE
chore(resources): refactor resource names and change OLED desc

### DIFF
--- a/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/editor/SettingsEditorScreen.kt
+++ b/core/main/src/main/java/com/rk/xededitor/ui/screens/settings/editor/SettingsEditorScreen.kt
@@ -53,16 +53,16 @@ fun SettingsEditorScreen(navController: NavController) {
                 )
             }
 
-            EditorSettingsToggle(label = stringResource(id = strings.ww),
-                description = stringResource(id = strings.ww_desc),
+            EditorSettingsToggle(label = stringResource(id = strings.word_wrap),
+                description = stringResource(id = strings.word_wrap_desc),
                 default = Settings.wordwrap,
                 sideEffect = {
                     Settings.wordwrap = it
                 }
             )
 
-            EditorSettingsToggle(label = stringResource(strings.txt_ww),
-                description = stringResource(strings.txt_ww_desc),
+            EditorSettingsToggle(label = stringResource(strings.txt_word_wrap),
+                description = stringResource(strings.txt_word_wrap_desc),
                 default = Settings.word_wrap_for_text,
                 sideEffect = {
                     Settings.word_wrap_for_text = it
@@ -169,7 +169,7 @@ fun SettingsEditorScreen(navController: NavController) {
                 default = Settings.textMateSuggestion,
                 sideEffect = {
                     Settings.textMateSuggestion = it
-                    toast(strings.rr)
+                    toast(strings.restart_required)
                 }
             )
 
@@ -254,9 +254,9 @@ fun SettingsEditorScreen(navController: NavController) {
                     lineSpacingValue = it
                     lineSpacingError = null
                     if (lineSpacingValue.toFloatOrNull() == null) {
-                        lineSpacingError = context.getString(strings.invalid_v)
+                        lineSpacingError = context.getString(strings.value_invalid)
                     } else if (lineSpacingValue.toFloat() < 0) {
-                        lineSpacingError = context.getString(strings.v_small)
+                        lineSpacingError = context.getString(strings.value_small)
                     }
                 },
                 onConfirm = {
@@ -280,11 +280,11 @@ fun SettingsEditorScreen(navController: NavController) {
                     textSizeValue = it
                     textSizeError = null
                     if (it.toIntOrNull() == null) {
-                        textSizeError = context.getString(strings.invalid_v);
+                        textSizeError = context.getString(strings.value_invalid)
                     } else if (it.toInt() > 100) {
-                        textSizeError = context.getString(strings.v_large)
+                        textSizeError = context.getString(strings.value_large)
                     } else if (it.toInt() < 6) {
-                        textSizeError = context.getString(strings.v_small)
+                        textSizeError = context.getString(strings.value_small)
                     }
                 },
                 onConfirm = {
@@ -317,11 +317,11 @@ fun SettingsEditorScreen(navController: NavController) {
                     tabSizeValue = it
                     tabSizeError = null
                     if (tabSizeValue.toIntOrNull() == null) {
-                        tabSizeError = context.getString(strings.invalid_v)
+                        tabSizeError = context.getString(strings.value_invalid)
                     } else if (tabSizeValue.toInt() > 16) {
-                        tabSizeError = context.getString(strings.v_large)
+                        tabSizeError = context.getString(strings.value_large)
                     } else if (tabSizeValue.toInt() < 1) {
-                        tabSizeError = context.getString(strings.v_small)
+                        tabSizeError = context.getString(strings.value_small)
                     }
                 },
                 onConfirm = {

--- a/core/main/src/main/res/menu/menu_main.xml
+++ b/core/main/src/main/res/menu/menu_main.xml
@@ -100,7 +100,7 @@
     <item
         android:id="@+id/toggle_word_wrap"
         android:icon="@drawable/edit"
-        android:title="@string/toggle_ww"
+        android:title="@string/toggle_word_wrap"
         android:visible="false"
         app:showAsAction="never" />
     <item

--- a/core/resources/src/main/res/values-ar/strings.xml
+++ b/core/resources/src/main/res/values-ar/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">إعادة التشغيل مطلوبة</string>
     <string name="saved_all">تم حفظ جميع الملفات</string>
     <string name="save">حفظ</string>
-    <string name="ww_wait">يرجى الانتظار حتى يكتمل ألتفاف النص</string>
+    <string name="word_wrap_wait">يرجى الانتظار حتى يكتمل ألتفاف النص</string>
     <string name="open_file_or_folder">فتح الملف أو المجلد</string>
     <string name="open_directory">فتح مسار</string>
     <string name="new_file">ملف جديد</string>
@@ -48,10 +48,9 @@
     <string name="cancel">إلغاء</string>
     <string name="save_exit">حفظ وخروج</string>
     <string name="exit">خروج</string>
-    <string name="rr">إعادة التشغيل مطلوبة</string>
     <string name="restart_to_apply">يرجى إعادة التشغيل لتطبيق الإعدادات</string>
     <string name="oled">السمة السوداء</string>
-    <string name="ww">التفاف النص</string>
+    <string name="word_wrap">التفاف النص</string>
     <string name="keep_drawer_locked">بقاء الدرج مغلقا</string>
     <string name="restart">إعادة تشغيل</string>
     <string name="refresh">إعادة التحميل</string>
@@ -76,7 +75,6 @@
     <string name="description">وصف</string>
     <string name="download">تحميل</string>
     <string name="dir_exist_not">المجلد غير موجود</string>
-    <string name="file_exist_not">الملف لم يعد موجودا</string>
     <string name="file_saved">تم حفظ الملف</string>
     <string name="apply">تطبيق</string>
     <string name="userdata">بيانات المستخدم</string>
@@ -134,7 +132,7 @@
     <string name="editor">محرر</string>
     <string name="smooth_tabs">علامات تبويب سلسة</string>
     <string name="smooth_tab_desc">التبديل بين علامات التبويب بسلاسة</string>
-    <string name="ww_desc">تفعيل التفاف النص في جميع المحررات</string>
+    <string name="word_wrap_desc">تفعيل التفاف النص في جميع المحررات</string>
     <string name="drawer_lock_desc">بقاء الدرج مغلقًا عند فتح الملف</string>
     <string name="diagonal_scroll">التمرير القطري</string>
     <string name="diagonal_scroll_desc">تمكين التمرير القطري في شجرة الملفات</string>
@@ -147,9 +145,9 @@
     <string name="auto_save">الحفظ التلقائي</string>
     <string name="auto_save_desc">حفظ الملف تلقائيا</string>
     <string name="interval_in_ms">الفاصل الزمني بالمللي ثانية</string>
-    <string name="invalid_v">القيمة غير صالحة</string>
-    <string name="v_small">القيمة صغيرة جدًا</string>
-    <string name="v_large">القيمة كبيرة جدًا</string>
+    <string name="value_invalid">القيمة غير صالحة</string>
+    <string name="value_small">القيمة صغيرة جدًا</string>
+    <string name="value_large">القيمة كبيرة جدًا</string>
     <string name="text_size">حجم النص</string>
     <string name="text_size_desc">ضبط حجم النص</string>
     <string name="tab_size">حجم علامة التبويب</string>
@@ -163,7 +161,7 @@
     <string name="terminal_desc">الإعدادات العامة للمحطة</string>
     <string name="terminal_text_size">حجم النص لموجه الأوامر</string>
     <string name="terminal_text_size_desc">ضبط حجم النص لموجه الأوامر</string>
-    <string name="u_err">خطأ غير معروف</string>
+    <string name="unknown_error">خطأ غير معروف</string>
     <string name="saved">تم الحفظ</string>
     <string name="is_null">InputStream هو لا شيء</string>
     <string name="wait_pkg">الرجاء الانتظار بينما يتم تنزيل الحزم.</string>
@@ -210,8 +208,8 @@
     <string name="file_too_large">الملف كبير جدًا ولا يمكن فتحه</string>
     <string name="toggle_suggestion">تغيير الاقتراح</string>
     <string name="run">تشغيل</string>
-    <string name="txt_ww">لف ملفات TXT</string>
-    <string name="txt_ww_desc">التفاف ملفات TXT تلقائيا</string>
+    <string name="txt_word_wrap">لف ملفات TXT</string>
+    <string name="txt_word_wrap_desc">التفاف ملفات TXT تلقائيا</string>
     <string name="manage_editor_font">إدارة خطوط المحرر</string>
     <string name="default_encoding">الترميز الافتراضي</string>
     <string name="default_encoding_desc">الترميز الافتراضي عند فتح وإنشاء ملفات</string>
@@ -269,8 +267,6 @@
     <string name="add_session">اضف جلسة</string>
     <string name="terminal_runtime_desc">اختيار محطة طرفية</string>
     <string name="terminal_runtime">محطة طرفية</string>
-    <string name="enable_ext">الإضافات</string>
-    <string name="enable_ext_desc">تحميل إضافات طرف ثالث</string>
     <string name="ext">إضافات</string>
     <string name="not_plugin_err">الملف المحدد ليس ملفًا من نوع apk.</string>
     <string name="scroll_to_bottom">التمرير إلى الأسفل</string>
@@ -285,7 +281,7 @@
     <string name="unrestricted_file">فتح الملفات بأي حجم</string>
     <string name="unrestricted_file_desc">السماح بفتح الملفات بأي حجم. قد يؤدي ذلك إلى حدوث أعطال</string>
     <string name="suggest_clear_app_data">يوصى بمسح بيانات التطبيق</string>
-    <string name="toggle_ww">تبديل التفاف الكلمات</string>
+    <string name="toggle_word_wrap">تبديل التفاف الكلمات</string>
     <string name="read_only_file">يتم قراءة الملف فقط</string>
     <string name="temp_file">ملف مؤقت</string>
     <string name="folder">‌مجلد</string>
@@ -304,7 +300,6 @@
     <string name="info">معلومات</string>
     <string name="copied">منسوخ</string>
     <string name="can_read">يمكن القراءة</string>
-    <string name="file_size">حجم الملف</string>
     <string name="file_info">معلومات الملف</string>
     <string name="is_file">هو ملف</string>
     <string name="flavor">نكهة</string>

--- a/core/resources/src/main/res/values-arq/strings.xml
+++ b/core/resources/src/main/res/values-arq/strings.xml
@@ -9,7 +9,7 @@
     <string name="saved">تم حفظ الملف</string>
     <string name="saved_all">تم حفظ كل الملفات</string>
     <string name="save">حفظ</string>
-    <string name="ww_wait">يرجى الانتظار حتى يكتمل التفاف النص</string>
+    <string name="word_wrap_wait">يرجى الانتظار حتى يكتمل التفاف النص</string>
     <string name="open_file_or_folder">فتح ملف أو مجلد</string>
     <string name="open_directory">فتح مجلد</string>
     <string name="new_file">ملف جديد</string>

--- a/core/resources/src/main/res/values-bn-rIN/strings.xml
+++ b/core/resources/src/main/res/values-bn-rIN/strings.xml
@@ -36,13 +36,12 @@
     <string name="unsaved_files">আপনার অসংরক্ষিত ফাইল আছে!</string>
     <string name="cancel">বাতিল করুন</string>
     <string name="exit">বেরিয়ে যান</string>
-    <string name="rr">পুনরারম্ভ করা প্রয়োজনীয়</string>
     <string name="oled">ব্ল্যাক নাইট থিম</string>
-    <string name="ww">শব্দ মোড়ানো</string>
+    <string name="word_wrap">শব্দ মোড়ানো</string>
     <string name="keep_drawer_locked">ড্রয়ার লক রাখুন</string>
     <string name="restart">পুনরারম্ভ করুন</string>
     <string name="saved_all">সমস্ত নথিপত্র সংরক্ষণ করা হয়েছে</string>
-    <string name="ww_wait">শব্দ মোড়ানো সম্পূর্ণ করার জন্য অপেক্ষা করুন</string>
+    <string name="word_wrap_wait">শব্দ মোড়ানো সম্পূর্ণ করার জন্য অপেক্ষা করুন</string>
     <string name="rep">প্রতিস্থাপন</string>
     <string name="null_content">ত্রুটি: শূন্য বিষয়বস্তুসমূহ</string>
     <string name="print">মুদ্রণ</string>

--- a/core/resources/src/main/res/values-bn/strings.xml
+++ b/core/resources/src/main/res/values-bn/strings.xml
@@ -12,7 +12,7 @@
     <string name="restart_required">পুনরায় চালু করা প্রয়োজন</string>
     <string name="saved_all">সব ফাইল সংরক্ষিত হয়েছে</string>
     <string name="save">সংরক্ষন করুন</string>
-    <string name="ww_wait">ওয়ার্ড র‍্যাপ সম্পূর্ণ হওয়া পর্যন্ত অপেক্ষা করুন</string>
+    <string name="word_wrap_wait">ওয়ার্ড র‍্যাপ সম্পূর্ণ হওয়া পর্যন্ত অপেক্ষা করুন</string>
     <string name="open_file_or_folder">ফাইল বা ফোল্ডার খুলুন</string>
     <string name="open_directory">একটি ডিরেক্টরি খুলুন</string>
     <string name="new_file">নতুন ফাইল</string>

--- a/core/resources/src/main/res/values-cs/strings.xml
+++ b/core/resources/src/main/res/values-cs/strings.xml
@@ -7,7 +7,7 @@
     <string name="null_content">Chyba: Obsah je null (prázdný)</string>
     <string name="saved_all">Všechny soubory uloženy</string>
     <string name="save">Uložit</string>
-    <string name="ww_wait">Vičkejte prosím než zalamování slov bude dokončeno</string>
+    <string name="word_wrap_wait">Vičkejte prosím než zalamování slov bude dokončeno</string>
     <string name="open_file_or_folder">Otevřít soubor nebo složku</string>
     <string name="open_directory">Otevřít složku</string>
     <string name="new_file">Nový soubor</string>
@@ -15,7 +15,7 @@
     <string name="not_plugin_err">Vybraný soubor není apk soubor</string>
     <string name="title">Název</string>
     <string name="path">Umístění</string>
-    <string name="ww">Zalamování slov</string>
+    <string name="word_wrap">Zalamování slov</string>
     <string name="check_for_updates">Kontrolovat pro aktualizace</string>
     <string name="check_for_updates_desc">Pravidelné kontrolování aktualizacích</string>
     <string name="unsaved_files">Vy máte neuložené soubory!</string>
@@ -28,7 +28,6 @@
     <string name="tab_text_1">Karta 1</string>
     <string name="tab_text_2">Karta 2</string>
     <string name="dir_exist_not">Složka neexistuje</string>
-    <string name="file_exist_not">Soubor neexistuje</string>
     <string name="apply">Použít</string>
     <string name="open_in_terminal">Otevřít ve Terminálu</string>
     <string name="open_dir_in_terminal">Otevřít složku ve Terminálu</string>
@@ -56,7 +55,7 @@
     <string name="restore">Obnovit</string>
     <string name="monet_desc">Použít téma zařízení</string>
     <string name="terminal_text_size_desc">Nastavit velikost textu v terminálu</string>
-    <string name="u_err">Neznámá chyba</string>
+    <string name="unknown_error">Neznámá chyba</string>
     <string name="saved">Uloženo</string>
     <string name="show_suggestions">Zobrazovat návrhy klávesnice</string>
     <string name="file_too_large">Soubor je příliš velký pro otevření</string>
@@ -115,7 +114,6 @@
     <string name="unsaved">Neuložené soubory</string>
     <string name="cancel">Zrušit</string>
     <string name="save_exit">Uložit a ukončit</string>
-    <string name="rr">Restart aplikace je požadovaný</string>
     <string name="restart_to_apply">Prosím restartněte aplikaci pro použití nových nastavení</string>
     <string name="restart">Restart</string>
     <string name="refresh">Načíst</string>
@@ -200,19 +198,19 @@
     <string name="add_session">Přidat relaci</string>
     <string name="editor_desc">Nastavení editoru</string>
     <string name="extra_keys_desc">Zobrazovat více kláves v editoru</string>
-    <string name="invalid_v">Neplatná hodnota</string>
-    <string name="v_small">Hodnota příliš malá</string>
-    <string name="v_large">Hodnota příliš velká</string>
+    <string name="value_invalid">Neplatná hodnota</string>
+    <string name="value_small">Hodnota příliš malá</string>
+    <string name="value_large">Hodnota příliš velká</string>
     <string name="interval_in_ms">Interval ve milisekundách</string>
     <string name="editor">Editor</string>
     <string name="oled_desc">Černé téma (#000)</string>
     <string name="invalid_file_type">Neplatný typ souboru, ZIP soubor očekáván</string>
-    <string name="ww_desc">Zapnout zalamování slov ve všech editorů</string>
-    <string name="txt_ww">Zalamovat txt soubory</string>
+    <string name="word_wrap_desc">Zapnout zalamování slov ve všech editorů</string>
+    <string name="txt_word_wrap">Zalamovat txt soubory</string>
     <string name="default_encoding_desc">Výchozí kódování v editoru</string>
     <string name="other">Jiný</string>
     <string name="add_font_desc">Vyberte TTF font z uložiště</string>
-    <string name="txt_ww_desc">Automaticky zalamuje txt soubory</string>
+    <string name="txt_word_wrap_desc">Automaticky zalamuje txt soubory</string>
     <string name="unknown_err">Něco se stalo</string>
     <string name="mime">Typ MIME (např. text/plain)</string>
     <string name="click_open">Klepněte tady pro otevření souboru</string>
@@ -230,10 +228,8 @@
     <string name="join">Spojit se</string>
     <string name="ask_unsaved">Opravdu chcete tento neuložený soubor zahodit?</string>
     <string name="keep_editing">Dál upravovat</string>
-    <string name="enable_ext">Doplňky</string>
     <string name="ext_desc">Spravovat doplňky</string>
     <string name="ext">Doplňky</string>
-    <string name="enable_ext_desc">Načíst doplňky ze třetích stran</string>
     <string name="content">Obsah</string>
     <string name="discard">Zahodit</string>
     <string name="telegram">Telegram skupina</string>
@@ -263,7 +259,7 @@
     <string name="show_virtual_keyboard">Zobrazit virtuální klávesnici</string>
     <string name="show_virtual_keyboard_desc">Zobrazit virtuální klávesnici když je připojena fyzická klávesnice</string>
     <string name="encoding_warning">Změna výchozího kódování je velmi nedoporučována, může vést k poškození souborů. Důrazně doporučujeme použít UTF-8, dokud plně nepochopíte důsledky a nevytvoříte správnou zálohu.</string>
-    <string name="toggle_ww">Přepnout zalamování slov</string>
+    <string name="toggle_word_wrap">Přepnout zalamování slov</string>
     <string name="misc">Smíšené</string>
     <string name="misc_desc">Smíšené nastavení</string>
     <string name="smooth_tabs">Hladké animace karet</string>
@@ -274,7 +270,6 @@
     <string name="is_file">Je soubor</string>
     <string name="can_write">Lze zapisovat</string>
     <string name="can_read">Lze číst</string>
-    <string name="file_size">Velikost souboru</string>
     <string name="cant_undo">Táto akce nemůže být vrácena zpět</string>
     <string name="capture_logcat">Zaznamenat logcat</string>
     <string name="capture_logcat_desc">Zaznamenat obsah protokolů na pozadí pro ladění</string>
@@ -324,7 +319,6 @@
     <string name="info_mutators">Mutátory jsou malé skripty, které se používají pro upravování textu v editoru. Vytvořte mutátor a klepněte na ho pro otevření v editoru.</string>
     <string name="flavor">Varianta</string>
     <string name="getting_ready">Všechno se připravuje…</string>
-    <string name="preview_err">Tento soubor nelze zobrazit. Žádná mateřská složka je dostupná. Prosím přesuňte tento soubor někde jinde.</string>
     <string name="tab_memory_warning">Není dostatek prostředků pro otevření této karty. Otevření této karty může způsobit havarii Xed-Editoru. Chcete i tak pokračkovat?</string>
     <string name="read_mode_desc">Výchoze zapnout čtecí režim</string>
     <string name="mutator_desc">Vytvářejte uživatelské skripty</string>

--- a/core/resources/src/main/res/values-de/strings.xml
+++ b/core/resources/src/main/res/values-de/strings.xml
@@ -3,7 +3,7 @@
     <string name="delete">Löschen</string>
     <string name="open_directory">Ein Verzeichnis öffnen</string>
     <string name="saved_all">Alle Dateien gespeichert</string>
-    <string name="ww_wait">Bitte warten, bis der Zeilenumbruch abgeschlossen ist</string>
+    <string name="word_wrap_wait">Bitte warten, bis der Zeilenumbruch abgeschlossen ist</string>
     <string name="open_file_or_folder">Datei oder Ordner öffnen</string>
     <string name="new_file_hint">Name (z. B. test.txt)</string>
     <string name="cs">Groß-/Kleinschreibung</string>
@@ -18,10 +18,9 @@
     <string name="insert_date">Datum einfügen</string>
     <string name="unsaved_files">Es gibt nicht gespeicherte Dateien!</string>
     <string name="cancel">Abbrechen</string>
-    <string name="rr">Neustart erforderlich</string>
     <string name="restart_to_apply">Bitte neu starten, um die Einstellungen anzuwenden</string>
     <string name="oled">Schwarzes Thema</string>
-    <string name="ww">Zeilenumbruch</string>
+    <string name="word_wrap">Zeilenumbruch</string>
     <string name="restart">Neustart</string>
     <string name="refresh">Neu laden</string>
     <string name="dir_example">Name (z. B. Test)</string>
@@ -90,7 +89,6 @@
     <string name="description">Beschreibung</string>
     <string name="download">Herunterladen</string>
     <string name="dir_exist_not">Ordner existiert nicht</string>
-    <string name="file_exist_not">Datei existiert nicht mehr</string>
     <string name="file_open_denied">Das Öffnen dieser Datei mit anderen Apps ist nicht zulässig</string>
     <string name="reload_file_tree">Dateien neu laden</string>
     <string name="close_current_project">Möchtest du das Projekt \'%(project_name)\' wirklich schließen?</string>
@@ -143,19 +141,19 @@
     <string name="diagonal_scroll">Diagonales Scrollen</string>
     <string name="diagonal_scroll_desc">Diagonales Scrollen im Dateibaum aktivieren</string>
     <string name="smooth_tab_desc">Sanftes Wechseln zwischen Tabs</string>
-    <string name="ww_desc">Zeilenumbruch in allen Editoren aktivieren</string>
+    <string name="word_wrap_desc">Zeilenumbruch in allen Editoren aktivieren</string>
     <string name="show_line_number">Zeilennummern anzeigen</string>
     <string name="pin_line_number">Zeilennummern anheften</string>
     <string name="auto_save">Automatisch speichern</string>
     <string name="auto_save_desc">Datei automatisch speichern</string>
-    <string name="invalid_v">Ungültiger Wert</string>
+    <string name="value_invalid">Ungültiger Wert</string>
     <string name="tab_size">Tabgröße</string>
     <string name="tab_size_desc">Tabgröße festlegen</string>
-    <string name="v_small">Wert zu klein</string>
+    <string name="value_small">Wert zu klein</string>
     <string name="text_size">Textgröße</string>
     <string name="interval_in_ms">Intervall in Millisekunden</string>
     <string name="text_size_desc">Textgröße festlegen</string>
-    <string name="v_large">Wert zu groß</string>
+    <string name="value_large">Wert zu groß</string>
     <string name="monet">Dynamische Farben</string>
     <string name="restart_app">Bitte Anwendung neu starten.</string>
     <string name="old_android">Nicht unterstützte Android-Version</string>
@@ -233,8 +231,6 @@
     <string name="add_session">Sitzung hinzufügen</string>
     <string name="terminal_runtime">Terminal-Runtime</string>
     <string name="terminal_runtime_desc">Terminal-Runtime auswählen</string>
-    <string name="enable_ext">Erweiterungen</string>
-    <string name="enable_ext_desc">Drittanbieter-Erweiterungen laden</string>
     <string name="ext">Erweiterungen</string>
     <string name="ext_desc">Erweiterungen verwalten</string>
     <string name="no_mutators">Keine Mutatoren</string>
@@ -244,7 +240,7 @@
     <string name="name_used">Name bereits verwendet</string>
     <string name="script_showing_dialog">Dialog anzeigen</string>
     <string name="installing">Wird installiert …</string>
-    <string name="u_err">Unbekannter Fehler</string>
+    <string name="unknown_error">Unbekannter Fehler</string>
     <string name="not_plugin_err">Ausgewählte Datei ist keine APK-Datei</string>
     <string name="install_from_storage">Aus Speicher installieren</string>
     <string name="no_ext">Keine Erweiterungen installiert.</string>
@@ -271,7 +267,6 @@
     <string name="misc_desc">Sonstige Einstellungen</string>
     <string name="info">Info</string>
     <string name="file_info">Datei-Info</string>
-    <string name="file_size">Dateigröße</string>
     <string name="copied">Kopiert</string>
     <string name="cant_undo">Diese Aktion kann nicht rückgängig gemacht werden</string>
     <string name="auto_complete">Editor-Autovervollständigung</string>
@@ -297,8 +292,8 @@
     <string name="unsupported_aarch">Nicht unterstützte Plattform, Failsafe verwenden</string>
     <string name="theme_mode_desc">App-Farbthema ändern</string>
     <string name="show_suggestions">Tastaturvorschläge anzeigen</string>
-    <string name="txt_ww">TXT-Dateien umbrechen</string>
-    <string name="txt_ww_desc">TXT-Dateien automatisch umbrechen</string>
+    <string name="txt_word_wrap">TXT-Dateien umbrechen</string>
+    <string name="txt_word_wrap_desc">TXT-Dateien automatisch umbrechen</string>
     <string name="ask_unsaved">Bist du sicher, dass du dieses nicht gespeicherte Dokument verwerfen möchtest?</string>
     <string name="encoding_warning">Von einer Änderung der Standardcodierung wird dringend abgeraten, da dies zu einer Beschädigung der Dateien führen kann. Es wird dringend empfohlen, UTF-8 zu verwenden, es sei denn, du bist dir der Auswirkungen voll bewusst und hast entsprechende Sicherungskopien erstellt.</string>
     <string name="info_mutators">Mutatoren sind kleine Skripte, die verwendet werden, um den Text im Editor zu verändern. Erstelle einen Mutator und klicke auf ihn, um ihn im Editor zu öffnen.</string>
@@ -317,7 +312,7 @@
     <string name="unrestricted_file_desc">Öffnen von Dateien beliebiger Größe erlauben. Kann zu Abstürzen führen.</string>
     <string name="suggest_clear_app_data">Löschen der App-Daten wird empfohlen</string>
     <string name="update_files_cleared">App aktualisiert: Daten gelöscht</string>
-    <string name="toggle_ww">Zeilenumbruch umschalten</string>
+    <string name="toggle_word_wrap">Zeilenumbruch umschalten</string>
     <string name="warning_private_dir">Der Inhalt dieses Verzeichnisses wird gelöscht, wenn du die Daten löscht oder Xed-Editor deinstallierst</string>
     <string name="can_read">Kann lesen</string>
     <string name="can_write">Kann schreiben</string>
@@ -328,7 +323,6 @@
     <string name="timeout">Download wegen Zeitüberschreitung abgebrochen. Bitte stelle sicher, dass deine Internetverbindung stabil ist</string>
     <string name="unsupported_feature">Diese Funktion wird auf deinem Gerät nicht unterstützt</string>
     <string name="tab_memory_warning">Zum Öffnen dieses Tabs ist nicht genügend Arbeitsspeicher verfügbar. Das Öffnen kann zum Absturz des Xed-Editors führen. Möchtest du trotzdem fortfahren?</string>
-    <string name="preview_err">Die Vorschau dieser Datei ist nicht möglich. Es ist kein übergeordnetes Verzeichnis verfügbar. Verschiebe die Datei gegebenenfalls an einen anderen Ort.</string>
     <string name="force_normal_desc">Normalmodus auf großen Bildschirmen erzwingen</string>
     <string name="force_char">Zeichen erzwingen</string>
     <string name="force_char_desc">Zeichenbasierte Eingabe im Terminal erzwingen</string>
@@ -415,7 +409,6 @@
     <string name="ask_refresh">Möchtest du dieses Dokument wirklich aktualisieren? Nicht gespeicherte Änderungen gehen verloren.</string>
     <string name="docs">Dokumentation</string>
     <string name="docs_desc">Dokumentationsseite aufrufen.</string>
-    <string name="file_type">Dateityp</string>
     <string name="lsp_settings_desc">Sprachserver-Einstellungen</string>
     <string name="github_stars">GitHub-Sterne</string>
     <string name="api_error">API-Fehler</string>

--- a/core/resources/src/main/res/values-es/strings.xml
+++ b/core/resources/src/main/res/values-es/strings.xml
@@ -13,7 +13,7 @@
     <string name="null_content">Error: el contenido es nulo</string>
     <string name="restart_required">Se requiere un reinicio</string>
     <string name="saved_all">Se guardaron todos los archivos</string>
-    <string name="ww_wait">Por favor espera a que el ajuste de línea esté completo</string>
+    <string name="word_wrap_wait">Por favor espera a que el ajuste de línea esté completo</string>
     <string name="new_file">Nuevo archivo</string>
     <string name="new_file_hint">Nombre (por ejemplo: juanito.txt)</string>
     <string name="mime">Tipo MIME (por ejemplo: text/plain)</string>
@@ -49,10 +49,9 @@
     <string name="cancel">Cancelar</string>
     <string name="save_exit">Guardar y salir</string>
     <string name="exit">Salir</string>
-    <string name="rr">Se requiere un reinicio</string>
     <string name="restart_to_apply">Por favor reinicia para aplicar los ajustes</string>
     <string name="oled">Tema negro puro</string>
-    <string name="ww">Ajuste de línea</string>
+    <string name="word_wrap">Ajuste de línea</string>
     <string name="keep_drawer_locked">Mantener el cajón bloqueado</string>
     <string name="restart">Reiniciar</string>
     <string name="dir_example">Nombre (por ejemplo: pedrito)</string>
@@ -74,7 +73,6 @@
     <string name="description">Descripción</string>
     <string name="download">Descargar</string>
     <string name="dir_exist_not">La carpeta no existe</string>
-    <string name="file_exist_not">El archivo ya no existe</string>
     <string name="userdata">Datos de usuario</string>
     <string name="invalid_userdata">Los datos del usuario no son válidos y deben cambiarse</string>
     <string name="open_in_terminal">Abrir en un terminal</string>
@@ -120,7 +118,7 @@
     <string name="editor">Editor</string>
     <string name="smooth_tabs">Pestañas suaves</string>
     <string name="smooth_tab_desc">Cambiar suavemente entre pestañas</string>
-    <string name="ww_desc">Habilitar ajuste de línea en todos los editores</string>
+    <string name="word_wrap_desc">Habilitar ajuste de línea en todos los editores</string>
     <string name="diagonal_scroll">Desplazamiento en diagonal</string>
     <string name="diagonal_scroll_desc">Habilitar desplazamiento en diagonal dentro del árbol de archivos</string>
     <string name="cursor_anim">Animación de cursor</string>
@@ -130,9 +128,9 @@
     <string name="auto_save">Guardado automático</string>
     <string name="auto_save_desc">Guardar el archivo automáticamente</string>
     <string name="interval_in_ms">Intervalo en milisegundos</string>
-    <string name="invalid_v">Valor inválido</string>
-    <string name="v_large">Valor demasiado alto</string>
-    <string name="v_small">Valor demasiado bajo</string>
+    <string name="value_invalid">Valor inválido</string>
+    <string name="value_large">Valor demasiado alto</string>
+    <string name="value_small">Valor demasiado bajo</string>
     <string name="text_size">Tamaño del texto</string>
     <string name="text_size_desc">Ajustar el tamaño del texto en pantalla</string>
     <string name="tab_size">Tamaño de tabulación</string>
@@ -143,7 +141,7 @@
     <string name="editor_desc">Ajustes generales del editor</string>
     <string name="extra_keys">Teclas adicionales</string>
     <string name="terminal_text_size_desc">Ajustar tamaño del texto en el terminal</string>
-    <string name="u_err">Error desconocido</string>
+    <string name="unknown_error">Error desconocido</string>
     <string name="saved">Guardado</string>
     <string name="is_null">InputStream es null</string>
     <string name="unsupported_aarch">Plataforma sin soporte, utilizar seguro</string>
@@ -183,8 +181,8 @@
     <string name="no">No</string>
     <string name="file_too_large">El archivo es demasiado grande</string>
     <string name="toggle_suggestion">Habilitar/deshabilitar sugerencia</string>
-    <string name="txt_ww">Envolver archivos .txt</string>
-    <string name="txt_ww_desc">Envolver archivos de texto automáticamente</string>
+    <string name="txt_word_wrap">Envolver archivos .txt</string>
+    <string name="txt_word_wrap_desc">Envolver archivos de texto automáticamente</string>
     <string name="manage_editor_font">Administrar fuentes del editor</string>
     <string name="default_encoding">Codificación por defecto</string>
     <string name="default_encoding_desc">Codificación predeterminada del editor</string>
@@ -241,9 +239,7 @@
     <string name="script_show_toast">mostrar mensaje emergente</string>
     <string name="sessions">Sesiones</string>
     <string name="terminal_runtime">Tiempo de ejecución de la terminal</string>
-    <string name="enable_ext_desc">Cargar extensiones de terceros</string>
     <string name="name_empty_err">El nombre no puede estar vacío</string>
-    <string name="enable_ext">Extensiones</string>
     <string name="terminal_runtime_desc">Seleccionar entorno de ejecución de la terminal</string>
     <string name="ext">Extensiones</string>
     <string name="script_showing_dialog">Mostrando un diálogo</string>
@@ -276,7 +272,7 @@
     <string name="highlighting">Resaltado de sintaxis</string>
     <string name="unrestricted_file">Abrir archivos de cualquier tamaño</string>
     <string name="update_files_cleared">Aplicación actualizada: Datos borrados</string>
-    <string name="toggle_ww">Activar o desactivar el ajuste de línea</string>
+    <string name="toggle_word_wrap">Activar o desactivar el ajuste de línea</string>
     <string name="sponsor">Patrocinador</string>
     <string name="sponsor_desc">Desarrollo de Apoyo</string>
     <string name="feature_toggles_desc">Habilitar o deshabilitar funciones específicas</string>

--- a/core/resources/src/main/res/values-fa/strings.xml
+++ b/core/resources/src/main/res/values-fa/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">نیاز به ری استارت</string>
     <string name="saved_all">همه فایل ها ذخیره شدند</string>
     <string name="save">ذخیره</string>
-    <string name="ww_wait">لطفا صبر کنید تا قرارگیری واژه ها تمام شود</string>
+    <string name="word_wrap_wait">لطفا صبر کنید تا قرارگیری واژه ها تمام شود</string>
     <string name="open_file_or_folder">باز کردن فایل یا پوشه</string>
     <string name="open_directory">باز کردن پوشه</string>
     <string name="new_file">فایل جدید</string>

--- a/core/resources/src/main/res/values-fr/strings.xml
+++ b/core/resources/src/main/res/values-fr/strings.xml
@@ -8,7 +8,7 @@
     <string name="null_content">Erreur : le contenu est vide</string>
     <string name="saved_all">tous les fichiers ont été enregistrés</string>
     <string name="save">Enregistrer</string>
-    <string name="ww_wait">Attendez que le retour à la ligne soit terminé</string>
+    <string name="word_wrap_wait">Attendez que le retour à la ligne soit terminé</string>
     <string name="open_file_or_folder">Ouvrir fichier ou dossier</string>
     <string name="rep">Substitution</string>
     <string name="wait">Attendez svp…</string>
@@ -36,11 +36,10 @@
     <string name="unsaved_files">Vous avez des fichiers non-enregistrés !</string>
     <string name="exit">Quitter</string>
     <string name="restart_to_apply">Redémarrez svp pour appliquer les paramètres</string>
-    <string name="ww">Retour à la ligne automatique</string>
+    <string name="word_wrap">Retour à la ligne automatique</string>
     <string name="keep_drawer_locked">Garder le tiroir fermé</string>
     <string name="restart">Redémarrer</string>
     <string name="oled">Apparence noir profond</string>
-    <string name="rr">Redémarrage requis</string>
     <string name="save_exit">Enregistrer et quitter</string>
     <string name="refresh">Mettre à jour</string>
     <string name="dir_example">Nom (par ex. test)</string>
@@ -62,7 +61,6 @@
     <string name="description">Description</string>
     <string name="download">Télécharger</string>
     <string name="dir_exist_not">Le dossier n’existe pas</string>
-    <string name="file_exist_not">Le fichier n’existe plus</string>
     <string name="file_saved">Fichier enregistré</string>
     <string name="apply">Appliquer</string>
     <string name="userdata">Données utilisateur</string>
@@ -118,7 +116,7 @@
     <string name="editor">Éditeur</string>
     <string name="smooth_tabs">Onglets doux</string>
     <string name="smooth_tab_desc">Bascule douce entre les onglets</string>
-    <string name="ww_desc">Activer le retour à la ligne dans tous les éditeurs</string>
+    <string name="word_wrap_desc">Activer le retour à la ligne dans tous les éditeurs</string>
     <string name="drawer_lock_desc">Tiroir verrouillé à l’ouverture</string>
     <string name="diagonal_scroll">Défilement en diagonale</string>
     <string name="diagonal_scroll_desc">Activer le défilement en diagonale dans l’arborescence de fichiers</string>
@@ -130,8 +128,8 @@
     <string name="auto_save_desc">Enregistrer les fichiers automatiquement</string>
     <string name="auto_save">Enregistrement auto</string>
     <string name="interval_in_ms">Intervalle en millisecondes</string>
-    <string name="v_small">Valeur trop faible</string>
-    <string name="v_large">Valeur trop grande</string>
+    <string name="value_small">Valeur trop faible</string>
+    <string name="value_large">Valeur trop grande</string>
     <string name="text_size">Taille du texte</string>
     <string name="text_size_desc">Régler la taille du texte</string>
     <string name="tab_size">Taille d’onglet</string>
@@ -143,7 +141,7 @@
     <string name="terminal_desc">Paramètres généraux du terminal</string>
     <string name="terminal_text_size">Taille du texte du terminal</string>
     <string name="terminal_text_size_desc">Régler la taille du texte du terminal</string>
-    <string name="u_err">Erreur inconnue</string>
+    <string name="unknown_error">Erreur inconnue</string>
     <string name="saved">Enregistré</string>
     <string name="is_null">Flux entrant vide</string>
     <string name="wait_pkg">Attendez que les paquets soient téléchargés.</string>
@@ -177,8 +175,8 @@
     <string name="file_too_large">Le fichier est trop volumineux pour être ouvert</string>
     <string name="toggle_suggestion">(Dés)activer suggestion</string>
     <string name="run">Exécuter</string>
-    <string name="txt_ww">Condenser fichier TXT</string>
-    <string name="txt_ww_desc">Retour à la ligne automatique pour les fichiers TXT</string>
+    <string name="txt_word_wrap">Condenser fichier TXT</string>
+    <string name="txt_word_wrap_desc">Retour à la ligne automatique pour les fichiers TXT</string>
     <string name="default_encoding">Encodage par défaut</string>
     <string name="default_encoding_desc">Encodage par défaut de l’éditeur</string>
     <string name="other">Autres</string>
@@ -209,7 +207,7 @@
     <string name="auto_mode">Auto</string>
     <string name="show_virtual_keyboard">Montrer le clavier virtuel</string>
     <string name="download_sure">Voulez-vous vraiment télécharger \'%(name)\' ?</string>
-    <string name="invalid_v">Valeur invalide</string>
+    <string name="value_invalid">Valeur invalide</string>
     <string name="app_desc">Paramètres généraux de l’application</string>
     <string name="show_suggestions">Montrer les suggestions clavier</string>
     <string name="github">GitHub</string>
@@ -240,7 +238,6 @@
     <string name="sessions">Sessions</string>
     <string name="add_session">Ajouter session</string>
     <string name="terminal_runtime">Moteur du terminal</string>
-    <string name="enable_ext_desc">Charger des extensions tierces</string>
     <string name="ext_desc">Gérer les extensions</string>
     <string name="tab_opened">Onglet ouvert</string>
     <string name="no_mutators">Aucun mutateur</string>
@@ -268,7 +265,6 @@
     <string name="info_ext">Les extensions sont utilisées pour modifier le comportement et les fonctionnalités de Xed-Editor. Pour découvrir comment créer un greffon, cliquer ici.</string>
     <string name="script_network">Réseau</string>
     <string name="launch">Lancer</string>
-    <string name="enable_ext">Extensions</string>
     <string name="script_api_info">Vérifier la classe ImplApi dans le code source de Xed-Editor à PROJECT/core/main/ui/screens/mutators/ImplApi pour plus d’informations</string>
     <string name="install_from_storage">Installer depuis le stockage</string>
     <string name="not_plugin_err">Le fichier sélectionné n’est pas un fichier APK</string>
@@ -285,7 +281,7 @@
     <string name="unrestricted_file">Ouvrir des fichiers de toute taille</string>
     <string name="unrestricted_file_desc">Autoriser l\'ouverture de fichiers de toute taille. Peut provoquer des plantages.</string>
     <string name="suggest_clear_app_data">Il est recommandé de vider le cache</string>
-    <string name="toggle_ww">(Dés)activer le retour automatique à la ligne</string>
+    <string name="toggle_word_wrap">(Dés)activer le retour automatique à la ligne</string>
     <string name="success">Succès</string>
     <string name="failed">Échec</string>
     <string name="new_document">Nouveau document</string>
@@ -309,7 +305,6 @@
     <string name="can_write">Écriture possible</string>
     <string name="can_read">Lecture possible</string>
     <string name="is_file">Est un fichier</string>
-    <string name="file_size">Taille du fichier</string>
     <string name="info">Info</string>
     <string name="file_info">Informations du fichier</string>
     <string name="flavor">Variante</string>
@@ -352,7 +347,6 @@
     <string name="control_panel">Panneau de contrôle</string>
     <string name="tab_memory_warning">Il n\'y a pas assez de mémoire disponible pour ouvrir cet onglet. L\'ouvrir pourrait causer le crash de Xed-Editor. Voulez-vous quand même continuer ?</string>
     <string name="read_mode_desc">Activer par défaut le mode lecture</string>
-    <string name="preview_err">Impossible de pré-afficher ce fichier. Aucun répertoire parent n\'est disponible. Considérez déplacer ce fichier ailleurs.</string>
     <string name="getting_ready">En train de tout préparer…</string>
     <string name="acquire_wakelock">Activer le wakelock</string>
     <string name="release_wakelock">Désactiver le wakelock</string>
@@ -373,7 +367,6 @@
     <string name="sdcard_filetype">Il n\'est pas recommandé d\'exécuter un code à cet endroit. Veuillez déplacer votre fichier dans le répertoire personnel du terminal.</string>
     <string name="rename_file">Renommer le fichier</string>
     <string name="new_name">Nouveau nom</string>
-    <string name="file_type">Type de fichier</string>
     <string name="type">Type</string>
     <string name="name">Nom</string>
     <string name="use_tabs_desc">Utiliser une vraie tabulation (\\t) au lieu des espaces pour l\'indentation</string>

--- a/core/resources/src/main/res/values-hi/strings.xml
+++ b/core/resources/src/main/res/values-hi/strings.xml
@@ -9,7 +9,7 @@
     <string name="restart_required">रिस्टार्ट जरूरी</string>
     <string name="saved_all">सभी फ़ाइलें सेव हुईं</string>
     <string name="save">सेव करें</string>
-    <string name="ww_wait">वर्ड रैप पूरा होने तक प्रतीक्षा करें</string>
+    <string name="word_wrap_wait">वर्ड रैप पूरा होने तक प्रतीक्षा करें</string>
     <string name="open_file_or_folder">फ़ाइल या फ़ोल्डर खोलें</string>
     <string name="open_directory">डायरेक्टरी खोलें</string>
     <string name="new_file">नई फ़ाइल</string>
@@ -49,10 +49,9 @@
     <string name="cancel">कैंसिल</string>
     <string name="save_exit">सेव करके बाहर निकलें</string>
     <string name="exit">बाहर निकलें</string>
-    <string name="rr">रिस्टार्ट जरूरी</string>
     <string name="restart_to_apply">सेटिंग्स लागू करने के लिए रिस्टार्ट करें</string>
     <string name="oled">ब्लैक थीम</string>
-    <string name="ww">वर्ड रैप</string>
+    <string name="word_wrap">वर्ड रैप</string>
     <string name="keep_drawer_locked">ड्रॉअर लॉक रखें</string>
     <string name="restart">रिस्टार्ट करें</string>
     <string name="refresh">रीलोड करें</string>
@@ -77,7 +76,6 @@
     <string name="description">विवरण</string>
     <string name="download">डाउनलोड</string>
     <string name="dir_exist_not">फ़ोल्डर मौजूद नहीं</string>
-    <string name="file_exist_not">फ़ाइल मौजूद नहीं</string>
     <string name="file_saved">फ़ाइल सेव हुई</string>
     <string name="apply">लागू करें</string>
     <string name="userdata">यूज़र डेटा</string>
@@ -135,7 +133,7 @@
     <string name="editor">एडिटर</string>
     <string name="smooth_tabs">स्मूथ टैब्स</string>
     <string name="smooth_tab_desc">टैब्स के बीच सहजता से स्विच करें</string>
-    <string name="ww_desc">सभी एडिटर्स में वर्ड रैप सक्षम करें</string>
+    <string name="word_wrap_desc">सभी एडिटर्स में वर्ड रैप सक्षम करें</string>
     <string name="drawer_lock_desc">फ़ाइल खोलते समय ड्रॉअर लॉक रखें</string>
     <string name="diagonal_scroll">डायगोनल स्क्रॉलिंग</string>
     <string name="diagonal_scroll_desc">फ़ाइल ट्री में डायगोनल स्क्रॉलिंग सक्षम करें</string>
@@ -148,9 +146,9 @@
     <string name="auto_save">ऑटो सेव</string>
     <string name="auto_save_desc">फ़ाइल को स्वचालित रूप से सेव करें</string>
     <string name="interval_in_ms">मिलीसेकंड में अंतराल</string>
-    <string name="invalid_v">अमान्य मान</string>
-    <string name="v_small">मान बहुत छोटा</string>
-    <string name="v_large">मान बहुत बड़ा</string>
+    <string name="value_invalid">अमान्य मान</string>
+    <string name="value_small">मान बहुत छोटा</string>
+    <string name="value_large">मान बहुत बड़ा</string>
     <string name="text_size">टेक्स्ट साइज़</string>
     <string name="text_size_desc">टेक्स्ट साइज़ सेट करें</string>
     <string name="tab_size">टैब साइज़</string>
@@ -164,7 +162,7 @@
     <string name="terminal_desc">सामान्य टर्मिनल सेटिंग्स</string>
     <string name="terminal_text_size">टर्मिनल टेक्स्ट साइज़</string>
     <string name="terminal_text_size_desc">टर्मिनल टेक्स्ट साइज़ सेट करें</string>
-    <string name="u_err">अज्ञात त्रुटि</string>
+    <string name="unknown_error">अज्ञात त्रुटि</string>
     <string name="is_null">इनपुट स्ट्रीम नल है</string>
     <string name="wait_pkg">कृपया प्रतीक्षा करें जब तक पैकेज डाउनलोड हो रहे हैं।</string>
     <string name="unsupported_aarch">असमर्थित प्लेटफ़ॉर्म, फ़ेल सेफ़ उपयोग करें</string>
@@ -210,8 +208,8 @@
     <string name="file_too_large">फ़ाइल बहुत बड़ी है, खोलने के लिए</string>
     <string name="toggle_suggestion">सुझाव टॉगल करें</string>
     <string name="run">रन करें</string>
-    <string name="txt_ww">टेक्स्ट फ़ाइलें रैप करें</string>
-    <string name="txt_ww_desc">टेक्स्ट फ़ाइलों को स्वचालित रूप से रैप करें</string>
+    <string name="txt_word_wrap">टेक्स्ट फ़ाइलें रैप करें</string>
+    <string name="txt_word_wrap_desc">टेक्स्ट फ़ाइलों को स्वचालित रूप से रैप करें</string>
     <string name="manage_editor_font">एडिटर फ़ॉन्ट प्रबंधित करें</string>
     <string name="default_encoding">डिफ़ॉल्ट एन्कोडिंग</string>
     <string name="default_encoding_desc">एडिटर की डिफ़ॉल्ट एन्कोडिंग</string>
@@ -246,8 +244,6 @@
     <string name="add_session">सेशन जोड़ें</string>
     <string name="terminal_runtime">टर्मिनल रनटाइम</string>
     <string name="terminal_runtime_desc">टर्मिनल रनटाइम चुनें</string>
-    <string name="enable_ext">एक्सटेंशन्स</string>
-    <string name="enable_ext_desc">थर्ड-पार्टी एक्सटेंशन्स लोड करें</string>
     <string name="ext">एक्सटेंशन्स</string>
     <string name="ext_desc">एक्सटेंशन्स प्रबंधित करें</string>
     <string name="info_mutators">म्यूटेटर्स छोटी स्क्रिप्ट्स हैं जो एडिटर टेक्स्ट को मॉडिफ़ाई करने के लिए उपयोग की जाती हैं। म्यूटेटर बनाएं और एडिटर में खोलने के लिए उस पर क्लिक करें।</string>
@@ -286,7 +282,7 @@
     <string name="unrestricted_file_desc">किसी भी साइज़ की फ़ाइलें खोलने की अनुमति दें। क्रैश का कारण बन सकता है</string>
     <string name="suggest_clear_app_data">ऐप डेटा क्लियर करने की सिफारिश की गई है</string>
     <string name="update_files_cleared">ऐप अपडेटेड : डेटा क्लियर हो गया</string>
-    <string name="toggle_ww">वर्ड रैप टॉगल करें</string>
+    <string name="toggle_word_wrap">वर्ड रैप टॉगल करें</string>
     <string name="warning_private_dir">यदि आप डेटा क्लियर करते हैं या Xed-Editor डिलीट करते हैं तो इस डायरेक्टरी का कंटेंट डिलीट हो जाएगा</string>
     <string name="read_only_file">फ़ाइल रीड-ओनली है</string>
     <string name="new_document">नया डॉक्यूमेंट</string>
@@ -309,7 +305,6 @@
     <string name="saf_expose_warning">होम डायरेक्टरी एक्सपोज़ करने से संवेदनशील जानकारी (Git टोकन, पासवर्ड, यूज़रनेम आदि) दुर्भावनापूर्ण ऐप्स को दिख सकती है। क्या आप जारी रखना चाहते हैं?</string>
     <string name="info">जानकारी</string>
     <string name="file_info">फ़ाइल जानकारी</string>
-    <string name="file_size">फ़ाइल साइज़</string>
     <string name="can_read">पढ़ सकते हैं</string>
     <string name="can_write">लिख सकते हैं</string>
     <string name="is_file">फ़ाइल है</string>

--- a/core/resources/src/main/res/values-hu/strings.xml
+++ b/core/resources/src/main/res/values-hu/strings.xml
@@ -29,7 +29,6 @@
     <string name="close_drawer">bezárás</string>
     <string name="close_all">Mind bezárása</string>
     <string name="exit">Kilépés</string>
-    <string name="rr">Újraindítás Szükséges</string>
     <string name="dir_example">Név pl.: Teszt</string>
     <string name="already_exists">Már van dokumentum ilyen néven</string>
     <string name="create">Elkészítés</string>
@@ -41,7 +40,7 @@
     <string name="ask_enter_name">Írj be egy nevet</string>
     <string name="unsupported_content">Nem támogatott tartalom</string>
     <string name="null_content">Hiba: A tartalom null</string>
-    <string name="ww_wait">Várj amíg a sortörés befejeződik</string>
+    <string name="word_wrap_wait">Várj amíg a sortörés befejeződik</string>
     <string name="open_file_or_folder">Fájl vagy mappa megnyitása</string>
     <string name="open_directory">Mappa megnyitása</string>
     <string name="new_file">Új Fájl</string>
@@ -77,9 +76,8 @@
     <string name="close_search">Keresés bezárása</string>
     <string name="keyword_regex">kulcsszó (Regex)</string>
     <string name="terminal">Terminál</string>
-    <string name="ww">Sortörés</string>
+    <string name="word_wrap">Sortörés</string>
     <string name="ask_del">Biztosan törlöd?</string>
-    <string name="file_exist_not">A fájl már nem létezik</string>
     <string name="data_clear">Alkalmazásadatok törölve</string>
     <string name="action_done">Kérés végrehajtva</string>
     <string name="clone_repo">Repo klónozása</string>
@@ -108,7 +106,7 @@
     <string name="editor">Szerkesztő</string>
     <string name="smooth_tabs">Sima lapok</string>
     <string name="smooth_tab_desc">Sima váltás a lapok között</string>
-    <string name="ww_desc">Sortörés bekapcsolása minden szerkesztőben</string>
+    <string name="word_wrap_desc">Sortörés bekapcsolása minden szerkesztőben</string>
     <string name="drawer_lock_desc">Eszköztár zárva tartása fájl megnyitása közben</string>
     <string name="diagonal_scroll">Átlós görgetés</string>
     <string name="diagonal_scroll_desc">Átlós görgetés engedélyezése a fájlfában</string>
@@ -121,9 +119,9 @@
     <string name="auto_save">Automentés</string>
     <string name="auto_save_desc">fájlok automatikus elmentése</string>
     <string name="interval_in_ms">Intervallum milliszekundumokban megadva</string>
-    <string name="invalid_v">Invalid érték</string>
-    <string name="v_small">A megadott érték túl alacsony</string>
-    <string name="v_large">A megadott érték túl nagy</string>
+    <string name="value_invalid">Invalid érték</string>
+    <string name="value_small">A megadott érték túl alacsony</string>
+    <string name="value_large">A megadott érték túl nagy</string>
     <string name="text_size">Szöveg mérete</string>
     <string name="text_size_desc">Szöveg méretének beállítása</string>
     <string name="tab_size_desc">Lapok méretének beállítása</string>

--- a/core/resources/src/main/res/values-in/strings.xml
+++ b/core/resources/src/main/res/values-in/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">Muat ulang diperlukan</string>
     <string name="saved_all">Simpan semua berkas</string>
     <string name="save">Simpan</string>
-    <string name="ww_wait">Harap tunggu sampai pembungkusan kata selesai</string>
+    <string name="word_wrap_wait">Harap tunggu sampai pembungkusan kata selesai</string>
     <string name="open_file_or_folder">Buka berkas atau folder</string>
     <string name="open_directory">Buka direktori</string>
     <string name="new_file">Berkas baru</string>
@@ -48,10 +48,9 @@
     <string name="cancel">Batal</string>
     <string name="save_exit">Simpan dan Keluar</string>
     <string name="exit">Keluar</string>
-    <string name="rr">Diperlukan mulai ulang</string>
     <string name="restart_to_apply">Silakan mulai ulang untuk menerapkan pengaturan</string>
     <string name="oled">Tema hitam</string>
-    <string name="ww">Bungkus kata</string>
+    <string name="word_wrap">Bungkus kata</string>
     <string name="keep_drawer_locked">Jaga Laci Tetap Terkunci</string>
     <string name="restart">Mulai Ulang</string>
     <string name="refresh">Muat Ulang</string>
@@ -76,7 +75,6 @@
     <string name="description">Deskripsi</string>
     <string name="download">Unduh</string>
     <string name="dir_exist_not">Folder tidak ada</string>
-    <string name="file_exist_not">Berkas tidak ada lagi</string>
     <string name="file_saved">Berkas disimpan</string>
     <string name="apply">Terapkan</string>
     <string name="userdata">Data pengguna</string>
@@ -128,7 +126,7 @@
     <string name="editor">Penyunting</string>
     <string name="smooth_tabs">Tab halus</string>
     <string name="smooth_tab_desc">Beralih antar tab dengan lembut</string>
-    <string name="ww_desc">Aktifkan pembungkus kata di semua penyunting</string>
+    <string name="word_wrap_desc">Aktifkan pembungkus kata di semua penyunting</string>
     <string name="diagonal_scroll">Pengguliran diagonal</string>
     <string name="diagonal_scroll_desc">Aktifkan pengguliran diagonal di daftar berkas</string>
     <string name="cursor_anim">Animasi kursor</string>
@@ -139,9 +137,9 @@
     <string name="auto_save">Simpan otomatis</string>
     <string name="auto_save_desc">Simpan berkas secara otomatis</string>
     <string name="interval_in_ms">Interval dalam milidetik</string>
-    <string name="invalid_v">Nilai tidak sah</string>
-    <string name="v_small">Nilai terlalu kecil</string>
-    <string name="v_large">Nilai terlalu besar</string>
+    <string name="value_invalid">Nilai tidak sah</string>
+    <string name="value_small">Nilai terlalu kecil</string>
+    <string name="value_large">Nilai terlalu besar</string>
     <string name="text_size">Ukuran teks</string>
     <string name="text_size_desc">Atur ukuran teks</string>
     <string name="tab_size">Ukuran tab</string>
@@ -152,7 +150,7 @@
     <string name="app_desc">Pengaturan umum aplikasi</string>
     <string name="editor_desc">Pengaturan umum penyunting</string>
     <string name="terminal_text_size">Ukuran teks terminal</string>
-    <string name="u_err">Kesalahan tidak diketahui</string>
+    <string name="unknown_error">Kesalahan tidak diketahui</string>
     <string name="saved">Tersimpan</string>
     <string name="is_null">InputStream adalah null</string>
     <string name="wait_pkg">Mohon tunggu sementara paket sedang diunduh.</string>
@@ -194,8 +192,8 @@
     <string name="no">Tidak</string>
     <string name="toggle_suggestion">Tombol saran</string>
     <string name="run">Jalankan</string>
-    <string name="txt_ww">Bungkus berkas TXT</string>
-    <string name="txt_ww_desc">Bungkus berkas TXT secara otomatis</string>
+    <string name="txt_word_wrap">Bungkus berkas TXT</string>
+    <string name="txt_word_wrap_desc">Bungkus berkas TXT secara otomatis</string>
     <string name="manage_editor_font">Kelola penyunting font</string>
     <string name="default_encoding_desc">Pengodean default penyunting</string>
     <string name="other">Lainnya</string>
@@ -247,8 +245,6 @@
     <string name="update_disable">Pemeriksaan pembaruan dinonaktifkan</string>
     <string name="mutator_desc">Buat skrip pengguna</string>
     <string name="launch">Luncurkan</string>
-    <string name="enable_ext">Pengaya</string>
-    <string name="enable_ext_desc">Memuat pengaya pihak ketiga</string>
     <string name="ext">Pengaya</string>
     <string name="ext_desc">Kelola pengaya</string>
     <string name="no_mutators">Tidak ada mutator</string>
@@ -284,7 +280,7 @@
     <string name="unrestricted_file_desc">Izinkan membuka berkas ukuran apapun. Dapat menyebabkan kerusakan.</string>
     <string name="update_files_cleared">Aplikasi diperbarui: data dibersihkan</string>
     <string name="suggest_clear_app_data">Direkomendasikan untuk membersihkan data aplikasi</string>
-    <string name="toggle_ww">Tombol bungkus kata</string>
+    <string name="toggle_word_wrap">Tombol bungkus kata</string>
     <string name="warning_private_dir">Konten direktori ini akan terhapus jika Anda menghapus data atau menghapus Xed-Editor</string>
     <string name="read_only_file">Berkas hanya dapat dibaca</string>
     <string name="folder">Folder</string>
@@ -304,7 +300,6 @@
     <string name="misc_desc">Pengaturan lainnya</string>
     <string name="expose_saf_desc">Jadikan direktori beranda dapat diakses oleh aplikasi eksternal melalui pemilih berkas sistem (SAF)</string>
     <string name="expose_saf">Perlihatkan direktori beranda</string>
-    <string name="file_size">Ukuran berkas</string>
     <string name="is_file">Merupakan Berkas</string>
     <string name="can_write">Dapat menulis</string>
     <string name="can_read">Dapat membaca</string>
@@ -352,7 +347,6 @@
     <string name="control_panel">Panel Kontrol</string>
     <string name="tab_memory_warning">Memori yang tersedia tidak cukup untuk membuka tab ini. Membuka tab ini dapat menyebabkan Xed-Editor macet. Apakah Anda tetap ingin melanjutkan?</string>
     <string name="read_mode_desc">Mengaktifkan mode baca secara default</string>
-    <string name="preview_err">Tidak dapat melihat pratinjau berkas ini. Tidak ada direktori induk yang tersedia. Pertimbangkan untuk memindahkan file ini ke tempat lain.</string>
     <string name="acquire_wakelock">Ambil wakelock</string>
     <string name="release_wakelock">Bebaskan wakelock</string>
     <string name="getting_ready">Menyiapkan segala sesuatunya…</string>
@@ -373,7 +367,6 @@
     <string name="sdcard_filetype">Menjalankan kode tidak disarankan di lokasi ini. Pertimbangkan untuk memindahkan file Anda ke direktori home terminal.</string>
     <string name="rename_file">Ubah nama berkas</string>
     <string name="new_name">Nama baru</string>
-    <string name="file_type">JenisBerkas</string>
     <string name="type">Jenis</string>
     <string name="name">Nama</string>
     <string name="discord">Komunitas Discord</string>

--- a/core/resources/src/main/res/values-it/strings.xml
+++ b/core/resources/src/main/res/values-it/strings.xml
@@ -24,7 +24,6 @@
     <string name="save_exit">Salva e Esci</string>
     <string name="already_exists">Un documento con questo nome è già presente</string>
     <string name="open_drawer">Apri</string>
-    <string name="rr">Riavvio richiesto</string>
     <string name="create_new_file_desc">Crea un nuovo file nella cartella selezionata</string>
     <string name="apply">Applica</string>
     <string name="restart">Riavvia</string>
@@ -32,7 +31,7 @@
     <string name="not_implemented">Questa funzionalità non è implementata</string>
     <string name="unsupported_content">Contenuto non supportato</string>
     <string name="saved_all">tutti i file sono stati salvati</string>
-    <string name="ww_wait">Per favore attendi che il testo sia mandato a capo automaticamente</string>
+    <string name="word_wrap_wait">Per favore attendi che il testo sia mandato a capo automaticamente</string>
     <string name="open_file_or_folder">Apri file o cartella</string>
     <string name="new_file">Nuovo file</string>
     <string name="new_file_hint">Nome (es. test.txt)</string>
@@ -67,7 +66,7 @@
     <string name="exit">Esci</string>
     <string name="restart_to_apply">Per favore riavvia per applicare le impostazioni</string>
     <string name="oled">Tema nero</string>
-    <string name="ww">A capo automatico</string>
+    <string name="word_wrap">A capo automatico</string>
     <string name="keep_drawer_locked">Mantieni il Menù Chiuso</string>
     <string name="refresh">Ricarica</string>
     <string name="dir_example">Nome (es. Test)</string>
@@ -126,8 +125,7 @@
     <string name="oled_desc">Tema nero (#000)</string>
     <string name="change_theme">Cambia tema</string>
     <string name="editor">Editor</string>
-    <string name="ww_desc">Abilita a capo automatico in tutti gli editor</string>
-    <string name="file_exist_not">Il file non esiste più</string>
+    <string name="word_wrap_desc">Abilita a capo automatico in tutti gli editor</string>
     <string name="available">Disponibile</string>
     <string name="fetch_failed">La richiesta ha restituito una risposta vuota</string>
     <string name="reload_file_tree">Ricarica file</string>
@@ -143,8 +141,8 @@
     <string name="auto_save">Salvataggio automatico</string>
     <string name="auto_save_desc">Salva automaticamente il file</string>
     <string name="interval_in_ms">Intervallo in millisecondi</string>
-    <string name="invalid_v">Valore non valido</string>
-    <string name="v_small">Valore troppo piccolo</string>
+    <string name="value_invalid">Valore non valido</string>
+    <string name="value_small">Valore troppo piccolo</string>
     <string name="tab_size">Dimensione della tabulazione</string>
     <string name="tab_size_desc">Imposta la dimensione del tabulatore</string>
     <string name="monet">Colori dinamici</string>
@@ -160,10 +158,10 @@
     <string name="app_desc">Impostazioni generali dell\'applicazione</string>
     <string name="text_size_desc">Imposta la dimensione del testo</string>
     <string name="terminal_text_size_desc">Imposta la dimensione del testo del terminale</string>
-    <string name="v_large">Valore troppo grande</string>
+    <string name="value_large">Valore troppo grande</string>
     <string name="text_size">Dimensione del testo</string>
     <string name="terminal_text_size">Dimensione testo del terminale</string>
-    <string name="u_err">Errore sconosciuto</string>
+    <string name="unknown_error">Errore sconosciuto</string>
     <string name="saved">Salvato</string>
     <string name="is_null">InputStream è nullo</string>
     <string name="wait_pkg">Attendere mentre i pacchetti vengono scaricati.</string>
@@ -214,8 +212,8 @@
     <string name="other">Altro</string>
     <string name="delete_font">Elimina font</string>
     <string name="fonts">Font</string>
-    <string name="txt_ww">Avvolgi file TXT</string>
-    <string name="txt_ww_desc">Avvolgi automaticamente i file TXT</string>
+    <string name="txt_word_wrap">Avvolgi file TXT</string>
+    <string name="txt_word_wrap_desc">Avvolgi automaticamente i file TXT</string>
     <string name="file_not_saved">Alcuni file non sono salvati</string>
     <string name="file_unsaved">File non salvato</string>
     <string name="ask_unsaved">Sei sicuro di voler eliminare questo documento non salvato?</string>
@@ -243,7 +241,6 @@
     <string name="script_api_info">Consulta la classe ImplApi nel codice sorgente di Xed-Editor in PROJECT/core/main/ui/screens/mutators/ImplApi per maggiori informazioni</string>
     <string name="install_from_storage">Installa dalla memoria interna</string>
     <string name="add_session">Aggiungi sessione</string>
-    <string name="enable_ext">Estensioni</string>
     <string name="script_get_text">Ottieni il testo</string>
     <string name="terminal_runtime">Tempo di esecuzione del terminale</string>
     <string name="ext">Estensioni</string>
@@ -261,7 +258,6 @@
     <string name="terminal_home_desc">Cartella home predefinita del terminale</string>
     <string name="script_set_text">Imposta testo</string>
     <string name="tab_opened">Schede aperte</string>
-    <string name="enable_ext_desc">Carica estensioni di terze parti</string>
     <string name="ext_desc">Gestisci estensioni</string>
     <string name="mutator_desc">Crea script utente</string>
     <string name="restore_sessions">Ripristina sessioni</string>
@@ -284,7 +280,7 @@
     <string name="update_files_cleared">App aggiornata: dati cancellati</string>
     <string name="unrestricted_file_desc">Consenti l\'apertura di file di qualsiasi dimensione. Può causare crash.</string>
     <string name="unrestricted_file">Apri file di qualsiasi dimensione</string>
-    <string name="toggle_ww">Attiva/Disattiva a capo automatico</string>
+    <string name="toggle_word_wrap">Attiva/Disattiva a capo automatico</string>
     <string name="warning_private_dir">Il contenuto di questa directory verrà eliminato se si cancellano i dati o si elimina Xed-Editor</string>
     <string name="read_only_file">File in sola lettura</string>
     <string name="new_document">Nuovo documento</string>
@@ -310,7 +306,6 @@
     <string name="copied">Copiato</string>
     <string name="expose_saf_desc">Rendi accessibile la directory home alle app esterne tramite il selettore file di sistema (SAF)</string>
     <string name="info">Info</string>
-    <string name="file_size">Dimensione file</string>
     <string name="file_info">Informazioni file</string>
     <string name="flavor">Variante</string>
     <string name="cant_undo">Questa azione non può essere annullata</string>
@@ -366,7 +361,6 @@
     <string name="sdcard_filetype">L’esecuzione del codice non è consigliata in questa posizione. Sposta il file nella directory home del terminale.</string>
     <string name="rename_file">Rinomina file</string>
     <string name="new_name">Nuovo nome</string>
-    <string name="file_type">Tipo di file</string>
     <string name="type">Tipo</string>
     <string name="name">Nome</string>
     <string name="view_github_profile">Visualizza profilo GitHub</string>

--- a/core/resources/src/main/res/values-iw/strings.xml
+++ b/core/resources/src/main/res/values-iw/strings.xml
@@ -11,7 +11,7 @@
     <string name="null_content">שגיאה: התוכן ריק</string>
     <string name="saved_all">כל הקבצים נשמרו</string>
     <string name="save">שמירה</string>
-    <string name="ww_wait">אנא המתן עד להשלמת גלישת המילים</string>
+    <string name="word_wrap_wait">אנא המתן עד להשלמת גלישת המילים</string>
     <string name="open_file_or_folder">פתח קובץ או תיקיה</string>
     <string name="open_directory">פתח תיקיה</string>
     <string name="new_file">קובץ חדש</string>
@@ -44,10 +44,9 @@
     <string name="cancel">ביטול</string>
     <string name="save_exit">שמור וצא</string>
     <string name="exit">יציאה</string>
-    <string name="rr">נדרש הפעלה מחדש</string>
     <string name="restart_to_apply">אנא הפעל מחדש כדי להחיל את ההגדרות</string>
     <string name="oled">עיצוב שחור</string>
-    <string name="ww">גלישת טקסט</string>
+    <string name="word_wrap">גלישת טקסט</string>
     <string name="close_this">סגור את זה</string>
     <string name="mime">סוג תוכן (MimeType), לדוגמה: text/plain</string>
     <string name="restart">הפעלה מחדש</string>
@@ -59,7 +58,6 @@
     <string name="replace_all">החלף הכל</string>
     <string name="title">כותרת</string>
     <string name="download">הורדה</string>
-    <string name="file_exist_not">הקובץ כבר לא קיים</string>
     <string name="file_saved">קובץ נשמר</string>
     <string name="userdata">נתוני משתמש</string>
     <string name="reload_file_tree">טען קבצים מחדש</string>
@@ -110,10 +108,10 @@
     <string name="oled_desc">שימוש בעיצוב שחור לגמרי עבור מכשירי AMOLED</string>
     <string name="editor">עורך</string>
     <string name="smooth_tab_desc">מעבר חלק בין כרטיסיות</string>
-    <string name="ww_desc">הפעלת גלישת מילים בכל העורכים</string>
-    <string name="invalid_v">ערך לא חוקי</string>
-    <string name="v_small">ערך קטן מידי</string>
-    <string name="v_large">ערך גדול מידי</string>
+    <string name="word_wrap_desc">הפעלת גלישת מילים בכל העורכים</string>
+    <string name="value_invalid">ערך לא חוקי</string>
+    <string name="value_small">ערך קטן מידי</string>
+    <string name="value_large">ערך גדול מידי</string>
     <string name="text_size">גודל טקסט</string>
     <string name="tab_size">גודל טאב</string>
     <string name="tab_size_desc">הגדר גודל טאב</string>
@@ -125,7 +123,7 @@
     <string name="terminal_desc">הגדרות מסוף כלליות</string>
     <string name="cursor_anim">אנימציית עכבר</string>
     <string name="diagonal_scroll">גלילה אלכסונית</string>
-    <string name="u_err">שגיאה לא ידועה ץ</string>
+    <string name="unknown_error">שגיאה לא ידועה ץ</string>
     <string name="copy_failed">העתקת קובץ נכשלה</string>
     <string name="install_done">הותקן בהצלחה</string>
     <string name="choose_file">בחר קובץ</string>
@@ -216,10 +214,10 @@
     <string name="default_encoding">קידוד ברירת מחדל</string>
     <string name="default_encoding_desc">קידוד ברירת מחדל של העורך</string>
     <string name="invalid_file_type">סוג קובץ לא חוקי, נדרש קובץ zip</string>
-    <string name="txt_ww">גלישת קבצי txt</string>
+    <string name="txt_word_wrap">גלישת קבצי txt</string>
     <string name="use_ctrl_workaround">השתמש בפתרון עוקף של Ctrl</string>
     <string name="use_ctrl_workaround_desc">השתמש בפתרון עוקף של Ctrl רווח</string>
-    <string name="txt_ww_desc">גלישת טקסט אוטומטית בקבצים</string>
+    <string name="txt_word_wrap_desc">גלישת טקסט אוטומטית בקבצים</string>
     <string name="file_not_saved">חלק מהקבצים לא נשמרו</string>
     <string name="ask_unsaved">האם אתה בטוח שברצונך למחוק את המסמך שלא נשמר?</string>
     <string name="keep_editing">המשך לערוך</string>
@@ -229,7 +227,6 @@
     <string name="update">עידכון</string>
     <string name="ignore">התעלם</string>
     <string name="update_disable">בדיקת עדכונים כבוי</string>
-    <string name="enable_ext">תוספים</string>
     <string name="ext">תוספים</string>
     <string name="no_mutators">אין ממירים</string>
     <string name="tab_opened">טאב נפתח</string>
@@ -246,7 +243,6 @@
     <string name="sessions">הפעלות</string>
     <string name="add_session">הוסף הפעלה</string>
     <string name="terminal_runtime">הרצת מסוף</string>
-    <string name="enable_ext_desc">טען תוספי צד שלישי</string>
     <string name="script_get_text">קבל טקסט</string>
     <string name="script_show_toast">הצג התראה קופצת</string>
     <string name="script_network">רשת</string>
@@ -294,7 +290,6 @@
     <string name="saf_expose_warning">חשיפת ספריית הבית עלולה לחשוף מידע רגיש לאפליקציות זדוניות, כולל אסימוני Git, סיסמאות, שמות משתמש וקבצים אחרים המאוחסנים בספריית הבית של המסוף שלך. האם ברצונך להמשיך?</string>
     <string name="info">מידע</string>
     <string name="file_info">מידע על הקובץ</string>
-    <string name="file_size">גודל הקובץ</string>
     <string name="can_read">ניתן לקריאה</string>
     <string name="can_write">ניתן לכתיבה</string>
     <string name="is_file">זה קובץ</string>
@@ -307,7 +302,7 @@
     <string name="unrestricted_file_desc">איפשור פתיחת קבצים בכל גודל. עלול לגרום לקריסות</string>
     <string name="suggest_clear_app_data">מומלץ לנקות נתוני אפליקציה</string>
     <string name="update_files_cleared">האפליקציה עודכנה: נתונים נוקו</string>
-    <string name="toggle_ww">החלף גלישת מילים</string>
+    <string name="toggle_word_wrap">החלף גלישת מילים</string>
     <string name="warning_private_dir">תוכן התיקייה הזו יימחק אם תנקה נתונים או תמחק את Xed-Editor</string>
     <string name="read_only_file">הקובץ לקריאה בלבד</string>
     <string name="new_document">מסמך חדש</string>

--- a/core/resources/src/main/res/values-ja/strings.xml
+++ b/core/resources/src/main/res/values-ja/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="already_exists">この名前のドキュメントが既に存在します</string>
-    <string name="file_exist_not">ファイルは既に存在しません</string>
     <string name="open_drawer">開く</string>
     <string name="unsupported_content">非対応の内容です</string>
     <string name="open_with">他で開く</string>
@@ -42,8 +41,7 @@
     <string name="cancel">キャンセル</string>
     <string name="save_exit">保存して終了</string>
     <string name="exit">終了</string>
-    <string name="rr">再起動が必要です</string>
-    <string name="ww">ワードラップ</string>
+    <string name="word_wrap">ワードラップ</string>
     <string name="keep_drawer_locked">引き出しをロックしたままにする</string>
     <string name="refresh">再読み込み</string>
     <string name="dir_example">名前 (例: Test)</string>
@@ -94,7 +92,7 @@
     <string name="change_theme">テーマを変更</string>
     <string name="editor">エディター</string>
     <string name="smooth_tabs">滑らかなタブ</string>
-    <string name="ww_desc">全てのエディターでワードラップを有効にする</string>
+    <string name="word_wrap_desc">全てのエディターでワードラップを有効にする</string>
     <string name="drawer_lock_desc">ファイルを開いている間は引き出しをロックする</string>
     <string name="diagonal_scroll">斜めスクロール</string>
     <string name="diagonal_scroll_desc">ファイルツリーで斜めスクロールを有効にする</string>
@@ -104,16 +102,16 @@
     <string name="extra_keys_desc">エディターに追加キーを表示する</string>
     <string name="auto_save">自動保存</string>
     <string name="interval_in_ms">間隔(ミリ秒)</string>
-    <string name="invalid_v">無効な値です</string>
-    <string name="v_small">値が小さすぎます</string>
-    <string name="v_large">値が大きすぎます</string>
+    <string name="value_invalid">無効な値です</string>
+    <string name="value_small">値が小さすぎます</string>
+    <string name="value_large">値が大きすぎます</string>
     <string name="text_size">文字サイズ</string>
     <string name="tab_size">タブサイズ</string>
     <string name="editor_desc">エディターの一般設定</string>
     <string name="terminal_desc">ターミナルの一般設定</string>
     <string name="terminal_text_size">ターミナルの文字サイズ</string>
     <string name="terminal_text_size_desc">ターミナルの文字の大きさを設定</string>
-    <string name="u_err">不明なエラー</string>
+    <string name="unknown_error">不明なエラー</string>
     <string name="saved">保存しました</string>
     <string name="pkg_download_failed">パッケージのダウンロードに失敗しました</string>
     <string name="install_done">インストールに成功しました</string>
@@ -139,7 +137,7 @@
     <string name="manage_storage_reason">Xed-Editorはストレージ内のファイルを編集するためのアクセスを必要とします。次に表示されるシステム設定でアクセスを許可してください。</string>
     <string name="cs">大文字/小文字を区別</string>
     <string name="close">閉じる</string>
-    <string name="ww_wait">ワードラップが完了するまでお待ちください</string>
+    <string name="word_wrap_wait">ワードラップが完了するまでお待ちください</string>
     <string name="invalid_file_type">無効なファイルの種類です。ZIPである必要があります</string>
     <string name="close_this">このファイルを閉じる</string>
     <string name="wait">お待ちください…</string>
@@ -224,8 +222,6 @@
     <string name="sessions">セッション</string>
     <string name="terminal_runtime_desc">ターミナルのランタイムを選択</string>
     <string name="terminal_runtime">ターミナルのランタイム</string>
-    <string name="enable_ext">拡張機能</string>
-    <string name="enable_ext_desc">サードパーティーの拡張機能を読み込む</string>
     <string name="ext">拡張機能</string>
     <string name="ext_desc">拡張機能の管理</string>
     <string name="no_mutators">ミューテーターはありません</string>
@@ -256,8 +252,8 @@
     <string name="version">バージョン</string>
     <string name="click_open">ファイルを開くにはここをクリック</string>
     <string name="add_font_desc">ストレージからTTFフォントを選択する</string>
-    <string name="txt_ww">テキストファイルのワードラップ</string>
-    <string name="txt_ww_desc">テキストファイルを自動的にワードラップする</string>
+    <string name="txt_word_wrap">テキストファイルのワードラップ</string>
+    <string name="txt_word_wrap_desc">テキストファイルを自動的にワードラップする</string>
     <string name="info_ext">拡張機能を使用することで、Xed-Editorの動作や機能を変更することができます。プラグインの作り方については、ここをクリックしてください。</string>
     <string name="dark_mode">ダーク</string>
     <string name="theme_mode">テーマモード</string>
@@ -284,7 +280,7 @@
     <string name="unrestricted_file">サイズによらずファイルを開く</string>
     <string name="suggest_clear_app_data">アプリのデータをクリアすることを推奨します</string>
     <string name="unrestricted_file_desc">どのようなサイズのファイルでも開くようにする(クラッシュの可能性あり)</string>
-    <string name="toggle_ww">ワードラップを切り替え</string>
+    <string name="toggle_word_wrap">ワードラップを切り替え</string>
     <string name="warning_private_dir">アプリデータを消去したり、Xed-Editorを削除すると、このディレクトリの中身は削除されます</string>
     <string name="read_only_file">ファイルは読み取り専用です</string>
     <string name="folder">フォルダ</string>
@@ -308,7 +304,6 @@
     <string name="copied">コピーしました</string>
     <string name="flavor">種類</string>
     <string name="unknown_err">不明なエラが発生しました</string>
-    <string name="file_size">ファイルサイズ</string>
     <string name="info">情報</string>
     <string name="file_info">ファイル情報</string>
     <string name="misc">その他</string>
@@ -351,7 +346,6 @@
     <string name="control_panel">コントロールパネル</string>
     <string name="tab_memory_warning">このタブを開くのに十分なメモリがありません。このタブを開くとXed-Editorがクラッシュする可能性があります。とにかく続けますか？</string>
     <string name="read_mode_desc">デフォルトで読み取りモードを有効にする</string>
-    <string name="preview_err">このファイルをプレビューできません。親ディレクトリがありません。このファイルを他の場所に移動することを検討してください。</string>
     <string name="acquire_wakelock">ウェークロックを取得</string>
     <string name="release_wakelock">ウェークロックを開放</string>
     <string name="getting_ready">準備中…</string>
@@ -373,7 +367,6 @@
     <string name="sdcard_filetype">この場所でのコードの実行は推奨されません。ファイルをターミナルのホームディレクトリに移動することを検討してください。</string>
     <string name="rename_file">ファイル名を変更</string>
     <string name="new_name">新しい名前</string>
-    <string name="file_type">ファイルの種類</string>
     <string name="type">種類</string>
     <string name="name">名前</string>
     <string name="delete_desc">ドキュメントを完全に削除</string>

--- a/core/resources/src/main/res/values-pl/strings.xml
+++ b/core/resources/src/main/res/values-pl/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">Wymagane ponowne uruchomienie</string>
     <string name="saved_all">Wszystkie pliki zapisane</string>
     <string name="save">Zapisz</string>
-    <string name="ww_wait">Proszę czekać na ukończenie zawijania tekstu</string>
+    <string name="word_wrap_wait">Proszę czekać na ukończenie zawijania tekstu</string>
     <string name="open_file_or_folder">Otwórz plik lub katalog</string>
     <string name="open_directory">Otwórz katalog</string>
     <string name="new_file">Nowy plik</string>
@@ -48,10 +48,9 @@
     <string name="cancel">Anuluj</string>
     <string name="save_exit">Zapisz i wyjdź</string>
     <string name="exit">Wyjdź</string>
-    <string name="rr">Wymagane ponowne uruchomienie</string>
     <string name="restart_to_apply">Proszę, uruchom ponownie, aby zastosować zmiany</string>
     <string name="oled">Czarny motyw</string>
-    <string name="ww">Zawijanie tekstu</string>
+    <string name="word_wrap">Zawijanie tekstu</string>
     <string name="keep_drawer_locked">Utrzymuj szufladę w pozycji zablokowanej</string>
     <string name="restart">Uruchom ponownie</string>
     <string name="refresh">Przeładuj</string>
@@ -86,9 +85,9 @@
     <string name="auto_save">Automatyczny zapis</string>
     <string name="auto_save_desc">Automatyczne zapisywanie pliku</string>
     <string name="interval_in_ms">Interwał w milisekundach</string>
-    <string name="invalid_v">Nieprawidłowa wartość</string>
-    <string name="v_small">Wartość zbyt niska</string>
-    <string name="v_large">Wartość zbyt wysoka</string>
+    <string name="value_invalid">Nieprawidłowa wartość</string>
+    <string name="value_small">Wartość zbyt niska</string>
+    <string name="value_large">Wartość zbyt wysoka</string>
     <string name="text_size">Rozmiar tekstu</string>
     <string name="text_size_desc">Ustaw rozmiar tekstu</string>
     <string name="tab_size">Rozmiar kart</string>
@@ -102,7 +101,7 @@
     <string name="terminal_desc">Ogólne ustawienia terminalu</string>
     <string name="terminal_text_size">Rozmiar tekstu terminalu</string>
     <string name="terminal_text_size_desc">Ustaw rozmiar tekstu w terminalu</string>
-    <string name="u_err">Nieznany bład</string>
+    <string name="unknown_error">Nieznany bład</string>
     <string name="is_null">Strumień wejściowy wykazuje pustą wartość</string>
     <string name="wait_pkg">Proszę czekać na ukończenie pobierania paczek.</string>
     <string name="unsupported_aarch">Nieobsługiwana platforma, użyj trybu bezpiecznego</string>
@@ -162,7 +161,7 @@
     <string name="unrestricted_file_desc">Pozwala otwierać pliki każdego rozmiaru. Może powodować awarię.</string>
     <string name="suggest_clear_app_data">Zalecane czyszczenie danych aplikacji</string>
     <string name="update_files_cleared">Aplikacja zaktualizowana: dane wyczyszczone</string>
-    <string name="toggle_ww">Włącz zawijanie słów</string>
+    <string name="toggle_word_wrap">Włącz zawijanie słów</string>
     <string name="warning_private_dir">Zawartość tego katalogu zostanie usunięta jeśli wyczyścisz dane lub odinstalujesz aplikację</string>
     <string name="read_only_file">Plik tylko do odczytu</string>
     <string name="new_document">Nowy dokument</string>
@@ -183,7 +182,6 @@
     <string name="expose_saf">Udostępnij katalog główny</string>
     <string name="saved">Plik zapisany</string>
     <string name="dir_exist_not">Katalog nie istnieje</string>
-    <string name="file_exist_not">Plik nie istnieje</string>
     <string name="file_saved">Plik zapisany</string>
     <string name="apply">Zastosuj</string>
     <string name="userdata">Dane użytkownika</string>
@@ -223,8 +221,8 @@
     <string name="file_too_large">Plik jest za duży, aby go otworzyć</string>
     <string name="toggle_suggestion">Włącz sugestie</string>
     <string name="run">Uruchom</string>
-    <string name="txt_ww">Zawijanie w plikach TXT</string>
-    <string name="txt_ww_desc">Automatycznie zawijaj pliki TXT</string>
+    <string name="txt_word_wrap">Zawijanie w plikach TXT</string>
+    <string name="txt_word_wrap_desc">Automatycznie zawijaj pliki TXT</string>
     <string name="manage_editor_font">Zarządzaj czcionkami edytora</string>
     <string name="default_encoding">Domyślne kodowanie</string>
     <string name="default_encoding_desc">Domyślne kodowanie w edytorze</string>
@@ -259,8 +257,6 @@
     <string name="add_session">Dodaj sesje</string>
     <string name="terminal_runtime">Czas działania terminalu</string>
     <string name="terminal_runtime_desc">Wybierz czas działania terminalu</string>
-    <string name="enable_ext">Rozszerzenia</string>
-    <string name="enable_ext_desc">Wczytaj rozszerzenia innych twórców</string>
     <string name="ext">Rozszerzenia</string>
     <string name="ext_desc">Zarządzaj rozszerzeniami</string>
     <string name="info_mutators">Mutatory to niewielkie skrypty używane do modyfikowania tekstu w edytorze. Stwórz mutator i kliknij, aby otworzyć go w edytorze.</string>
@@ -296,7 +292,7 @@
     <string name="editor">Edytor</string>
     <string name="smooth_tabs">Płynne karty</string>
     <string name="smooth_tab_desc">Płynnie przełączaj pomiędzy kartami</string>
-    <string name="ww_desc">Włącz zawijanie tekstu we wszystkich edytorach</string>
+    <string name="word_wrap_desc">Włącz zawijanie tekstu we wszystkich edytorach</string>
     <string name="drawer_lock_desc">Utrzymuj szufladę w pozycji zablokowanej podczas otwierania pliku</string>
     <string name="downloading">Pobieranie…</string>
     <string name="memory_usage">Użycie pamięci</string>
@@ -332,7 +328,6 @@
     <string name="edit_runner">Edytuj program uruchamiający</string>
     <string name="info">Informacje</string>
     <string name="file_info">Informacje o pliku</string>
-    <string name="file_size">Rozmiar pliku</string>
     <string name="can_read">Odczyt</string>
     <string name="can_write">Zapis</string>
     <string name="is_file">Jest plikiem</string>
@@ -365,7 +360,6 @@
     <string name="debug_options">Opcje debug</string>
     <string name="debug_options_desc">Opcje debug dla %(app_name)</string>
     <string name="force_crash">Wymuś awarie</string>
-    <string name="file_type">Typ pliku</string>
     <string name="type">Typ</string>
     <string name="name">Nazwa</string>
     <string name="force_crash_desc">Wywołaj wyjątek czasu wykonywania</string>
@@ -419,7 +413,6 @@
     <string name="github_stars">Gwiazdki na GitHub\'ie</string>
     <string name="api_error">Błąd API</string>
     <string name="unknown">Nieznany</string>
-    <string name="cant_read">Nie można odczytać pliku (brak uprawnienia odczytu)</string>
     <string name="cant_write">Nie można zapisać pliku (brak uprawnienia zapisu)</string>
     <string name="content_update">Dokument został zmodyfikowany przez inną aplikacje. Czy napewno chcesz odświeżyć? Wszystkie niezapisane zmiany zostaną utracone.</string>
     <string name="info_lsp">Serwery językowe dodają inteligentne funkcje, takie jak wypełnianie kodu, podkreślanie błędów oraz dokumentację osadzoną w kodzie.</string>

--- a/core/resources/src/main/res/values-pt-rBR/strings.xml
+++ b/core/resources/src/main/res/values-pt-rBR/strings.xml
@@ -7,7 +7,7 @@
     <string name="null_content">Erro: conteúdo é nulo</string>
     <string name="restart_required">Reinicialização necessária</string>
     <string name="saved_all">Todos os arquivos foram salvos</string>
-    <string name="ww_wait">Aguarde a conclusão da quebra de linha</string>
+    <string name="word_wrap_wait">Aguarde a conclusão da quebra de linha</string>
     <string name="open_file_or_folder">Abrir arquivo ou pasta</string>
     <string name="open_directory">Abrir um diretório</string>
     <string name="new_file">Novo arquivo</string>
@@ -47,10 +47,9 @@
     <string name="cancel">Cancelar</string>
     <string name="save_exit">Salvar e sair</string>
     <string name="exit">Sair</string>
-    <string name="rr">Reinicialização necessária</string>
     <string name="restart_to_apply">Reinicie para aplicar as configurações</string>
     <string name="oled">Tema Preto</string>
-    <string name="ww">Quebra de linha</string>
+    <string name="word_wrap">Quebra de linha</string>
     <string name="keep_drawer_locked">Manter gaveta travada</string>
     <string name="restart">Reiniciar</string>
     <string name="refresh">Recarregar</string>
@@ -75,7 +74,6 @@
     <string name="description">Descrição</string>
     <string name="download">Baixar</string>
     <string name="dir_exist_not">Pasta não existe</string>
-    <string name="file_exist_not">O arquivo não existe mais</string>
     <string name="file_saved">Arquivo salvo</string>
     <string name="apply">Aplicar</string>
     <string name="userdata">Dados do usuário</string>
@@ -133,7 +131,7 @@
     <string name="editor">Editor</string>
     <string name="smooth_tabs">Abas suaves</string>
     <string name="smooth_tab_desc">Alternar suavemente entre as abas</string>
-    <string name="ww_desc">Ativar Quebra de Linha em todos os editores</string>
+    <string name="word_wrap_desc">Ativar Quebra de Linha em todos os editores</string>
     <string name="drawer_lock_desc">Manter gaveta bloqueada ao abrir um arquivo</string>
     <string name="diagonal_scroll">Rolagem Diagonal</string>
     <string name="diagonal_scroll_desc">Ativar Rolagem Diagonal na Árvore de Arquivos</string>
@@ -146,9 +144,9 @@
     <string name="auto_save">Salvar automaticamente</string>
     <string name="auto_save_desc">Salvar arquivos automaticamente</string>
     <string name="interval_in_ms">Intervalo em milissegundos</string>
-    <string name="invalid_v">Valor inválido</string>
-    <string name="v_small">Valor muito pequeno</string>
-    <string name="v_large">Valor muito grande</string>
+    <string name="value_invalid">Valor inválido</string>
+    <string name="value_small">Valor muito pequeno</string>
+    <string name="value_large">Valor muito grande</string>
     <string name="text_size">Tamanho do texto</string>
     <string name="text_size_desc">Defina o tamanho do texto</string>
     <string name="tab_size">Tamanho da tabulação</string>
@@ -162,7 +160,7 @@
     <string name="terminal_desc">Configurações gerais do terminal</string>
     <string name="terminal_text_size">Tamanho do texto do terminal</string>
     <string name="terminal_text_size_desc">Definir tamanho do texto do terminal</string>
-    <string name="u_err">Erro Desconhecido</string>
+    <string name="unknown_error">Erro Desconhecido</string>
     <string name="saved">Salvo</string>
     <string name="is_null">InputStream é nulo</string>
     <string name="wait_pkg">Aguarde enquanto os pacotes estão sendo baixados.</string>
@@ -204,14 +202,14 @@
     <string name="git_commit">Hash do Commit Git</string>
     <string name="check_for_updates">Checar por Atualizações</string>
     <string name="check_for_updates_desc">Verificar periodicamente se há atualizações</string>
-    <string name="txt_ww">Quebrar arquivos txt</string>
+    <string name="txt_word_wrap">Quebrar arquivos txt</string>
     <string name="no">Não</string>
     <string name="save">Salvar</string>
     <string name="click_open">Clique aqui para abrir o arquivo</string>
     <string name="file_too_large">Arquivo é muito grande para abrir</string>
     <string name="toggle_suggestion">Alternar sugestão</string>
     <string name="run">Executar</string>
-    <string name="txt_ww_desc">Quebrar linhas em arquivos de texto automaticamente</string>
+    <string name="txt_word_wrap_desc">Quebrar linhas em arquivos de texto automaticamente</string>
     <string name="manage_editor_font">Gerenciar fontes do editor</string>
     <string name="default_encoding">Codificação padrão</string>
     <string name="default_encoding_desc">Codificação padrão do editor</string>
@@ -241,7 +239,6 @@
     <string name="sessions">Sessões</string>
     <string name="add_session">Adicionar Sessão</string>
     <string name="terminal_runtime">Tempo de Execução do Terminal</string>
-    <string name="enable_ext">Extensões</string>
     <string name="ext">Extensões</string>
     <string name="ext_desc">Gerenciar Extensões</string>
     <string name="no_mutators">Sem mutadores</string>
@@ -265,7 +262,6 @@
     <string name="restore_sessions">Restaurar sessões</string>
     <string name="terminal_home">Caminho Inicial do Terminal</string>
     <string name="terminal_runtime_desc">Selecione o Tempo de Execução do Terminal</string>
-    <string name="enable_ext_desc">Carregar extensões de terceiros</string>
     <string name="info_mutators">Mutadores são pequenos scripts usados para modificar o texto do editor. Crie um mutador e clique nele para abri-lo no editor.</string>
     <string name="mutator_name">Nome do Mutador</string>
     <string name="script_api_info">verifique a classe ImplApi no código-fonte do xed-editors em PROJECT/core/main/ui/screens/mutators/ImplApi para obter mais informações</string>
@@ -298,12 +294,11 @@
     <string name="suggest_clear_app_data">Limpar dados do app é recomendado</string>
     <string name="feature_toggles_desc">Habilite ou desabilite recursos específicos</string>
     <string name="read_only_file">Arquivo é apenas leitura</string>
-    <string name="toggle_ww">Alternar quebra de linha</string>
+    <string name="toggle_word_wrap">Alternar quebra de linha</string>
     <string name="unknown_err">Algo deu errado</string>
     <string name="misc">Diversos</string>
     <string name="misc_desc">Configurações Variadas</string>
     <string name="file_info">Detalhes do Arquivo</string>
-    <string name="file_size">Tamanho do Arquivo</string>
     <string name="can_read">Pode Ler</string>
     <string name="can_write">Pode Gravar</string>
     <string name="flavor">Variante</string>
@@ -352,7 +347,6 @@
     <string name="control_panel">Painel de Controle</string>
     <string name="tab_memory_warning">Sem memória suficiente para abrir essa aba, Abri-la pode causar o travamento do Xed-Editor. Você quer continuar mesmo assim?</string>
     <string name="read_mode_desc">Ativar modo de leitira por padrão</string>
-    <string name="preview_err">Não é possível visualizar este arquivo. Nenhum diretório pai está disponível. Considere mover este arquivo para outro lugar.</string>
     <string name="acquire_wakelock">Obter wakelock</string>
     <string name="release_wakelock">Liberar wakelock</string>
     <string name="getting_ready">Deixando tudo pronto…</string>
@@ -373,7 +367,6 @@
     <string name="sdcard_filetype">Não é recomendável executar código neste local. Considere mover seu arquivo para o diretório inicial do terminal.</string>
     <string name="rename_file">Renomear Arquivo</string>
     <string name="new_name">Novo nome</string>
-    <string name="file_type">Tipo de Arquivo</string>
     <string name="type">Tipo</string>
     <string name="name">Nome</string>
     <string name="discord">Comunidade Discord</string>

--- a/core/resources/src/main/res/values-pt/strings.xml
+++ b/core/resources/src/main/res/values-pt/strings.xml
@@ -5,7 +5,7 @@
     <string name="saved">Ficheiro gravado</string>
     <string name="saved_all">Todos os ficheiros foram gravados</string>
     <string name="save">Gravar</string>
-    <string name="ww_wait">Aguarde a conclusão da quebra de linha</string>
+    <string name="word_wrap_wait">Aguarde a conclusão da quebra de linha</string>
     <string name="rep">Substituição</string>
     <string name="wait">Por favor, aguarde…</string>
     <string name="copy">Copiar</string>
@@ -93,9 +93,9 @@
     <string name="drawer_lock_desc">Manter gaveta bloqueada ao abrir um ficheiro</string>
     <string name="extra_keys_desc">Exibir teclas extras no editor</string>
     <string name="interval_in_ms">Intervalo em milissegundos</string>
-    <string name="invalid_v">Valor inválido</string>
-    <string name="v_small">Valor muito pequeno</string>
-    <string name="v_large">Valor muito grande</string>
+    <string name="value_invalid">Valor inválido</string>
+    <string name="value_small">Valor muito pequeno</string>
+    <string name="value_large">Valor muito grande</string>
     <string name="text_size_desc">Defina o tamanho do texto</string>
     <string name="tab_size_desc">Defina o tamanho da tabulação</string>
     <string name="monet_desc">Usar o tema do sistema</string>

--- a/core/resources/src/main/res/values-ru/strings.xml
+++ b/core/resources/src/main/res/values-ru/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">Требуется перезапуск</string>
     <string name="saved_all">Все файлы сохранены</string>
     <string name="save">Сохранить</string>
-    <string name="ww_wait">Пожалуйста, дождитесь завершения переноса слов</string>
+    <string name="word_wrap_wait">Пожалуйста, дождитесь завершения переноса слов</string>
     <string name="open_file_or_folder">Открыть файл или папку</string>
     <string name="open_directory">Открыть каталог</string>
     <string name="new_file">Новый файл</string>
@@ -48,10 +48,9 @@
     <string name="cancel">Отмена</string>
     <string name="save_exit">Сохранить и выйти</string>
     <string name="exit">Выйти</string>
-    <string name="rr">Требуется перезапуск</string>
     <string name="restart_to_apply">Перезапустите, чтобы применить настройки</string>
     <string name="oled">Тёмная тема</string>
-    <string name="ww">Перенос слов</string>
+    <string name="word_wrap">Перенос слов</string>
     <string name="keep_drawer_locked">Оставить панель закрытой</string>
     <string name="restart">Перезапуск</string>
     <string name="refresh">Перезагрузить</string>
@@ -76,7 +75,6 @@
     <string name="description">Описание</string>
     <string name="download">Скачать</string>
     <string name="dir_exist_not">Папка не существует</string>
-    <string name="file_exist_not">Файл больше не существует</string>
     <string name="file_saved">Файл сохранен</string>
     <string name="apply">Применить</string>
     <string name="userdata">Данные пользователя</string>
@@ -134,7 +132,7 @@
     <string name="editor">Редактор</string>
     <string name="smooth_tabs">Плавный переход</string>
     <string name="smooth_tab_desc">Плавный переход между вкладками</string>
-    <string name="ww_desc">Включить перенос слов во всех редакторах</string>
+    <string name="word_wrap_desc">Включить перенос слов во всех редакторах</string>
     <string name="drawer_lock_desc">При открытии файла держать панель открытой</string>
     <string name="diagonal_scroll">Диагональная прокрутка</string>
     <string name="diagonal_scroll_desc">Включить диагональную прокрутку в дереве файлов</string>
@@ -147,9 +145,9 @@
     <string name="auto_save">Автоматическое сохранение</string>
     <string name="auto_save_desc">Сохранять файл автоматически</string>
     <string name="interval_in_ms">Интервал в миллисекундах</string>
-    <string name="invalid_v">Недопустимое значение</string>
-    <string name="v_small">Слишком маленькое значение</string>
-    <string name="v_large">Слишком большое значение</string>
+    <string name="value_invalid">Недопустимое значение</string>
+    <string name="value_small">Слишком маленькое значение</string>
+    <string name="value_large">Слишком большое значение</string>
     <string name="text_size">Размер текста</string>
     <string name="text_size_desc">Установить размер текста</string>
     <string name="tab_size">Размер табуляции</string>
@@ -163,7 +161,7 @@
     <string name="terminal_desc">Общие настройки терминала</string>
     <string name="terminal_text_size">Размер текста терминала</string>
     <string name="terminal_text_size_desc">Установить размер текста терминала</string>
-    <string name="u_err">Неизвестная ошибка</string>
+    <string name="unknown_error">Неизвестная ошибка</string>
     <string name="saved">Сохранено</string>
     <string name="is_null">InputStream пустой</string>
     <string name="wait_pkg">Пожалуйста, подождите, пока пакеты будут загружены.</string>
@@ -210,8 +208,8 @@
     <string name="file_too_large">Файл слишком велик, чтобы его открывать</string>
     <string name="toggle_suggestion">Включить предложения</string>
     <string name="run">Запустить</string>
-    <string name="txt_ww">Перенос TXT файлов</string>
-    <string name="txt_ww_desc">Автоматически переносить строки в TXT файлах</string>
+    <string name="txt_word_wrap">Перенос TXT файлов</string>
+    <string name="txt_word_wrap_desc">Автоматически переносить строки в TXT файлах</string>
     <string name="content">Контент</string>
     <string name="default_encoding_desc">Кодировка редактора по умолчанию</string>
     <string name="other">Другое</string>
@@ -244,7 +242,6 @@
     <string name="loading">Загрузка…</string>
     <string name="terminal_home">Домашняя папка терминала</string>
     <string name="terminal_home_desc">Домашняя папка терминала по умолчанию</string>
-    <string name="enable_ext_desc">Загружать сторонние расширения</string>
     <string name="ext">Расширения</string>
     <string name="ext_desc">Управление расширениями</string>
     <string name="tab_opened">Вкладка открыта</string>
@@ -262,7 +259,6 @@
     <string name="restore_sessions">Восстанавливать сессии</string>
     <string name="terminal_runtime">Среда выполнения терминала</string>
     <string name="restore_sessions_desc">Восстанавливать открытые вкладки</string>
-    <string name="enable_ext">Расширения</string>
     <string name="name_empty_err">Имя не должно быть пустым</string>
     <string name="sessions">Сессии</string>
     <string name="add_session">Добавить сессию</string>
@@ -289,7 +285,7 @@
     <string name="file">Файл</string>
     <string name="folder">Папка</string>
     <string name="read_only_file">Файл доступен только для чтения</string>
-    <string name="toggle_ww">Переключить перенос слов</string>
+    <string name="toggle_word_wrap">Переключить перенос слов</string>
     <string name="warning_private_dir">Содержимое этого каталога будет удалено, если вы очистите данные или удалите Xed-Editor</string>
     <string name="sponsor">Поддержать</string>
     <string name="sponsor_desc">Поддержать разработку</string>
@@ -308,7 +304,6 @@
     <string name="saf_expose_warning">Разрешение доступа к домашней директории может раскрыть конфиденциальную информацию к вредоносным приложениям, например: Git токены, пароли, имена пользователей и другие файлы хранящиеся в домашней директории. Вы уверены что хотите продолжить?</string>
     <string name="info">Информация</string>
     <string name="file_info">Информация о файле</string>
-    <string name="file_size">Размер файла</string>
     <string name="copied">Скопировано</string>
     <string name="cant_undo">Это действие необратимо</string>
     <string name="temp_file">Временный файл</string>

--- a/core/resources/src/main/res/values-sv/strings.xml
+++ b/core/resources/src/main/res/values-sv/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">Omstart krävs</string>
     <string name="saved_all">alla filer sparade</string>
     <string name="save">Spara</string>
-    <string name="ww_wait">Vänta tills radbryt är klar</string>
+    <string name="word_wrap_wait">Vänta tills radbryt är klar</string>
     <string name="open_file_or_folder">Öppna fil eller katalog</string>
     <string name="open_directory">Öppna katalog</string>
     <string name="new_file">Ny fil</string>
@@ -48,10 +48,9 @@
     <string name="cancel">Avbryt</string>
     <string name="save_exit">Spara och stäng</string>
     <string name="exit">Avsluta</string>
-    <string name="rr">Omstart krävs</string>
     <string name="restart_to_apply">Vänligen starta om för att applicera ändringar</string>
     <string name="oled">Mörkt tema</string>
-    <string name="ww">Radbryt</string>
+    <string name="word_wrap">Radbryt</string>
     <string name="keep_drawer_locked">Håll sidomeny stängd</string>
     <string name="restart">Omstart</string>
     <string name="refresh">Ladda om</string>
@@ -76,7 +75,6 @@
     <string name="description">Beskrivning</string>
     <string name="download">Nerladdning</string>
     <string name="dir_exist_not">Katalogen finns inte</string>
-    <string name="file_exist_not">Filen finns inte längre</string>
     <string name="file_saved">Fil sparad</string>
     <string name="apply">Tillämpa</string>
     <string name="userdata">Användardata</string>
@@ -134,7 +132,7 @@
     <string name="editor">Editor</string>
     <string name="smooth_tabs">Mjuka flikar</string>
     <string name="smooth_tab_desc">Byt mjukt mellan flikar</string>
-    <string name="ww_desc">Slå på radbryt i alla editorer</string>
+    <string name="word_wrap_desc">Slå på radbryt i alla editorer</string>
     <string name="drawer_lock_desc">Håll kvar sidomeny vid öppning av fil</string>
     <string name="diagonal_scroll">Diagonal skrollning</string>
     <string name="diagonal_scroll_desc">Slå på diagonal skrollning i filträdet</string>
@@ -147,9 +145,9 @@
     <string name="auto_save">Autospara</string>
     <string name="auto_save_desc">spara fil automatiskt</string>
     <string name="interval_in_ms">Intervall i millisekunder</string>
-    <string name="invalid_v">Ogiltigt värde</string>
-    <string name="v_small">Värde för litet</string>
-    <string name="v_large">Värde för stort</string>
+    <string name="value_invalid">Ogiltigt värde</string>
+    <string name="value_small">Värde för litet</string>
+    <string name="value_large">Värde för stort</string>
     <string name="text_size">Textstorlek</string>
     <string name="text_size_desc">Sätt textstorlek</string>
     <string name="tab_size">Tabstorlek</string>
@@ -163,7 +161,7 @@
     <string name="terminal_desc">Generella terminalinställningar</string>
     <string name="terminal_text_size">Textstorlek för terminal</string>
     <string name="terminal_text_size_desc">Sätt textstorlek för terminal</string>
-    <string name="u_err">Okänt fel</string>
+    <string name="unknown_error">Okänt fel</string>
     <string name="is_null">InputStream är null</string>
     <string name="wait_pkg">Vänligen vänta medan paket laddas ner.</string>
     <string name="unsupported_aarch">Plattform stöds ej, använd felsäkert läge</string>
@@ -208,8 +206,8 @@
     <string name="file_too_large">Filen är för stor för att öppna</string>
     <string name="toggle_suggestion">Slå på/av förslag</string>
     <string name="run">Kör</string>
-    <string name="txt_ww">Radbryt textfiler</string>
-    <string name="txt_ww_desc">Radbryt automatiskt textfiler</string>
+    <string name="txt_word_wrap">Radbryt textfiler</string>
+    <string name="txt_word_wrap_desc">Radbryt automatiskt textfiler</string>
     <string name="manage_editor_font">Hantera teckensnitt för editor</string>
     <string name="default_encoding">Default encoding</string>
     <string name="default_encoding_desc">Editor default encoding</string>

--- a/core/resources/src/main/res/values-ta/strings.xml
+++ b/core/resources/src/main/res/values-ta/strings.xml
@@ -34,7 +34,7 @@
     <string name="null_content">பிழை: உள்ளடக்கம் பூச்யமானது</string>
     <string name="saved_all">எல்லா கோப்புகளையும் சேமித்தது</string>
     <string name="save">சேமி</string>
-    <string name="ww_wait">சொல் மடக்கு முடிவடையும் வரை காத்திருங்கள்</string>
+    <string name="word_wrap_wait">சொல் மடக்கு முடிவடையும் வரை காத்திருங்கள்</string>
     <string name="open_file_or_folder">கோப்பு அல்லது கோப்புறையைத் திறக்கவும்</string>
     <string name="new_file">புதிய கோப்பு</string>
     <string name="new_file_hint">பெயர் எ.கா. Test.txt</string>
@@ -67,10 +67,9 @@
     <string name="cancel">ரத்துசெய்</string>
     <string name="save_exit">சேமித்து வெளியேறவும்</string>
     <string name="exit">வெளியேறு</string>
-    <string name="rr">மறுதொடக்கம் தேவை</string>
     <string name="restart_to_apply">அமைப்புகளைப் பயன்படுத்த மறுதொடக்கம் செய்யுங்கள்</string>
     <string name="oled">கருப்பு கருப்பொருள்</string>
-    <string name="ww">சொல் மடக்கு</string>
+    <string name="word_wrap">சொல் மடக்கு</string>
     <string name="keep_drawer_locked">டிராயரை பூட்டிக் கொள்ளுங்கள்</string>
     <string name="restart">மறுதொடக்கம்</string>
     <string name="refresh">மறுஏற்றம்</string>
@@ -93,7 +92,6 @@
     <string name="description">விவரம்</string>
     <string name="download">பதிவிறக்கம்</string>
     <string name="dir_exist_not">கோப்புறை இல்லை</string>
-    <string name="file_exist_not">கோப்பு இனி இல்லை</string>
     <string name="close_current_project">தற்போதைய திட்டத்தை மூடு</string>
     <string name="file_saved">கோப்பு சேமிக்கப்பட்டது</string>
     <string name="open_in_terminal">முனையத்தில் திறந்திருக்கும்</string>
@@ -147,7 +145,7 @@
     <string name="editor">திருத்தி</string>
     <string name="smooth_tabs">மென்மையான தாவல்கள்</string>
     <string name="smooth_tab_desc">தாவல்களுக்கு இடையில் சீராக மாறவும்</string>
-    <string name="ww_desc">அனைத்து ஆசிரியர்களிடமும் சொல் மடக்கை இயக்கவும்</string>
+    <string name="word_wrap_desc">அனைத்து ஆசிரியர்களிடமும் சொல் மடக்கை இயக்கவும்</string>
     <string name="drawer_lock_desc">கோப்பைத் திறக்கும்போது டிராயரை பூட்டிக் கொள்ளுங்கள்</string>
     <string name="diagonal_scroll">மூலைவிட்ட ச்க்ரோலிங்</string>
     <string name="diagonal_scroll_desc">கோப்பு மரத்தில் மூலைவிட்ட ச்க்ரோலிங் இயக்கவும்</string>
@@ -158,9 +156,9 @@
     <string name="auto_save">தானியங்கு சேமிப்பு</string>
     <string name="auto_save_desc">கோப்பை தானாக சேமிக்கவும்</string>
     <string name="interval_in_ms">மில்லி விநாடிகளில் இடைவெளி</string>
-    <string name="invalid_v">தவறான மதிப்பு</string>
-    <string name="v_small">மதிப்பு மிகவும் சிறியது</string>
-    <string name="v_large">மதிப்பு மிகப் பெரியது</string>
+    <string name="value_invalid">தவறான மதிப்பு</string>
+    <string name="value_small">மதிப்பு மிகவும் சிறியது</string>
+    <string name="value_large">மதிப்பு மிகப் பெரியது</string>
     <string name="text_size">உரை அளவு</string>
     <string name="text_size_desc">உரை அளவை அமைக்கவும்</string>
     <string name="tab_size">தாவல் அளவு</string>
@@ -174,7 +172,7 @@
     <string name="terminal_desc">பொது முனைய அமைப்புகள்</string>
     <string name="terminal_text_size_desc">முனைய உரை அளவை அமைக்கவும்</string>
     <string name="terminal_text_size">முனைய உரை அளவு</string>
-    <string name="u_err">தெரியாத பிழை</string>
+    <string name="unknown_error">தெரியாத பிழை</string>
     <string name="saved">சேமிக்கப்பட்டது</string>
     <string name="is_null">உள்ளீட்டு நீரோடை பூச்யமாகும்</string>
     <string name="wait_pkg">தொகுப்புகள் பதிவிறக்கம் செய்யப்படும்போது தயவுசெய்து காத்திருங்கள்.</string>
@@ -217,8 +215,8 @@
     <string name="file_too_large">கோப்பு திறக்க முடியாத அளவுக்கு பெரியது</string>
     <string name="toggle_suggestion">ஆலோசனையை மாற்றவும்</string>
     <string name="run">ஓடு</string>
-    <string name="txt_ww">உரை கோப்புகளை மடிக்கவும்</string>
-    <string name="txt_ww_desc">உரை கோப்புகளை தானாக மடிக்கவும்</string>
+    <string name="txt_word_wrap">உரை கோப்புகளை மடிக்கவும்</string>
+    <string name="txt_word_wrap_desc">உரை கோப்புகளை தானாக மடிக்கவும்</string>
     <string name="manage_editor_font">ஆசிரியர் எழுத்துருக்களை நிர்வகிக்கவும்</string>
     <string name="default_encoding">இயல்புநிலை குறியாக்கம்</string>
     <string name="other">மற்றொன்று</string>
@@ -251,8 +249,6 @@
     <string name="add_session">அமர்வு சேர்க்கவும்</string>
     <string name="terminal_runtime">முனைய இயக்க நேரம்</string>
     <string name="terminal_runtime_desc">முனைய இயக்க நேரத்தைத் தேர்ந்தெடுக்கவும்</string>
-    <string name="enable_ext">நீட்டிப்புகள்</string>
-    <string name="enable_ext_desc">மூன்றாம் தரப்பு நீட்டிப்புகளை ஏற்றவும்</string>
     <string name="ext">நீட்டிப்புகள்</string>
     <string name="ext_desc">நீட்டிப்புகளை நிர்வகிக்கவும்</string>
     <string name="info_mutators">பிறழ்வுகள் சிறிய ச்கிரிப்ட்கள் ஆகும், அவை எடிட்டர் உரையை மாற்ற பயன்படுகின்றன. ஒரு பிறழ்வை உருவாக்கி, அதை எடிட்டரில் திறக்க அதைக் சொடுக்கு செய்க.</string>
@@ -288,7 +284,7 @@
     <string name="unrestricted_file_desc">எந்த அளவிலான கோப்புகளையும் திறக்க அனுமதிக்கவும். விபத்துக்களுக்கு வழிவகுக்கும்.</string>
     <string name="suggest_clear_app_data">பயன்பாட்டு தரவை அழிக்க பரிந்துரைக்கப்படுகிறது</string>
     <string name="update_files_cleared">பயன்பாடு புதுப்பிக்கப்பட்டது: தரவு அழிக்கப்பட்டது</string>
-    <string name="toggle_ww">சொல் மடக்கு மாற்று</string>
+    <string name="toggle_word_wrap">சொல் மடக்கு மாற்று</string>
     <string name="warning_private_dir">நீங்கள் தரவை அழித்தால் அல்லது xed-editer ஐ நீக்கினால் இந்த கோப்பகத்தின் உள்ளடக்கம் நீக்கப்படும்</string>
     <string name="read_only_file">கோப்பு மட்டுமே படிக்கப்படுகிறது</string>
     <string name="new_document">புதிய ஆவணம்</string>
@@ -309,7 +305,6 @@
     <string name="saf_expose_warning">வீட்டு கோப்பகத்தை அம்பலப்படுத்துவது, அறிவிலி டோக்கன்கள், கடவுச்சொற்கள், பயனர்பெயர்கள் மற்றும் உங்கள் டெர்மினல் ஓம் டைரக்டரியில் சேமிக்கப்பட்ட பிற கோப்புகள் உள்ளிட்ட தீங்கிழைக்கும் பயன்பாடுகளுக்கு முக்கியமான தகவல்களை வெளிப்படுத்தக்கூடும். நீங்கள் தொடர விரும்புகிறீர்களா?</string>
     <string name="info">தகவல்</string>
     <string name="file_info">கோப்பு செய்தி</string>
-    <string name="file_size">கோப்பு அளவு</string>
     <string name="can_read">படிக்க முடியும்</string>
     <string name="can_write">எழுத முடியும்</string>
     <string name="is_file">கோப்பு</string>
@@ -352,7 +347,6 @@
     <string name="control_panel">Controlpanel</string>
     <string name="tab_memory_warning">இந்த தாவலைத் திறக்க போதுமான நினைவகம் கிடைக்கவில்லை. அதைத் திறப்பது xed-editor விபத்துக்குள்ளாக்கக்கூடும். எப்படியும் தொடர விரும்புகிறீர்களா?</string>
     <string name="read_mode_desc">இயல்புநிலையாக வாசிப்பு பயன்முறையை இயக்கவும்</string>
-    <string name="preview_err">இந்த கோப்பை முன்னோட்டமிட முடியவில்லை. பெற்றோர் அடைவு எதுவும் கிடைக்கவில்லை. இந்த கோப்பை வேறு எங்காவது நகர்த்துவதைக் கவனியுங்கள்.</string>
     <string name="acquire_wakelock">வேக்கலாக் பெறுங்கள்</string>
     <string name="release_wakelock">வேக்க்லாக் வெளியீடு</string>
     <string name="getting_ready">எல்லாவற்றையும் ஆயத்தம் செய்வது…</string>

--- a/core/resources/src/main/res/values-tr/strings.xml
+++ b/core/resources/src/main/res/values-tr/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">Yeniden başlatmanız gerekiyor</string>
     <string name="saved_all">Tüm dosyalar kaydedildi</string>
     <string name="save">Kaydet</string>
-    <string name="ww_wait">Lütfen sözcük kaydırmanın tamamlanmasını bekleyin</string>
+    <string name="word_wrap_wait">Lütfen sözcük kaydırmanın tamamlanmasını bekleyin</string>
     <string name="open_file_or_folder">Dosya veya klasör aç</string>
     <string name="open_directory">Bir klasör aç</string>
     <string name="new_file">Yeni dosya</string>
@@ -48,10 +48,9 @@
     <string name="cancel">İptal et</string>
     <string name="save_exit">Kaydet ve çık</string>
     <string name="exit">Çıkış</string>
-    <string name="rr">Yeniden başlatma gerekli</string>
     <string name="restart_to_apply">Ayarları uygulamak için lütfen yeniden başlatın</string>
     <string name="oled">Koyu tema</string>
-    <string name="ww">Satır kaydırma</string>
+    <string name="word_wrap">Satır kaydırma</string>
     <string name="keep_drawer_locked">Paneli sabitle</string>
     <string name="restart">Tekrar başlat</string>
     <string name="refresh">Yenile</string>
@@ -76,7 +75,6 @@
     <string name="description">Açıklama</string>
     <string name="download">İndir</string>
     <string name="dir_exist_not">Dizin mevcut değil</string>
-    <string name="file_exist_not">Dosya artık mevcut değil</string>
     <string name="file_saved">Dosya kaydedildi</string>
     <string name="apply">Uygula</string>
     <string name="userdata">Kullanıcı Verileri</string>
@@ -134,7 +132,7 @@
     <string name="editor">Editör</string>
     <string name="smooth_tabs">Akıcı sekmeler</string>
     <string name="smooth_tab_desc">Sekmeler arasında sorunsuz geçiş yapın</string>
-    <string name="ww_desc">Tüm düzenleyicilerde satır kaydırmayı etkinleştir</string>
+    <string name="word_wrap_desc">Tüm düzenleyicilerde satır kaydırmayı etkinleştir</string>
     <string name="drawer_lock_desc">Dosyayı açarken çekmeceyi kapalı tutun</string>
     <string name="diagonal_scroll">Çapraz kaydırma</string>
     <string name="diagonal_scroll_desc">Dosya ağacında çapraz kaydırmayı etkinleştir</string>
@@ -147,9 +145,9 @@
     <string name="auto_save">Otomatik kaydetme</string>
     <string name="auto_save_desc">Dosyayı otomatik kaydet</string>
     <string name="interval_in_ms">Milisaniye cinsinden aralık</string>
-    <string name="invalid_v">Geçersiz değer</string>
-    <string name="v_small">Değer çok küçük</string>
-    <string name="v_large">Değer çok büyük</string>
+    <string name="value_invalid">Geçersiz değer</string>
+    <string name="value_small">Değer çok küçük</string>
+    <string name="value_large">Değer çok büyük</string>
     <string name="text_size">Metin boyutu</string>
     <string name="text_size_desc">Metin boyutunu ayarla</string>
     <string name="tab_size">Sekme boyutu</string>
@@ -163,7 +161,7 @@
     <string name="terminal_desc">Genel terminal ayarları</string>
     <string name="terminal_text_size">Terminal metin boyutu</string>
     <string name="terminal_text_size_desc">Terminal metin boyutunu ayarla</string>
-    <string name="u_err">Bilinmeyen hata</string>
+    <string name="unknown_error">Bilinmeyen hata</string>
     <string name="saved">Dosya kaydedildi</string>
     <string name="is_null">Giriş Akışı sıfırdır</string>
     <string name="wait_pkg">Paketler indirilirken lütfen bekleyin.</string>
@@ -210,8 +208,8 @@
     <string name="file_too_large">Dosya açılamayacak kadar büyük</string>
     <string name="toggle_suggestion">Öneriyi Aç/Kapat</string>
     <string name="run">Çalıştır</string>
-    <string name="txt_ww">TXT dosyalarını sarın</string>
-    <string name="txt_ww_desc">TXT dosyalarında satırları otomatik kaydır</string>
+    <string name="txt_word_wrap">TXT dosyalarını sarın</string>
+    <string name="txt_word_wrap_desc">TXT dosyalarında satırları otomatik kaydır</string>
     <string name="manage_editor_font">Editörün yazı tiplerini yönet</string>
     <string name="default_encoding">Varsayılan kodlama</string>
     <string name="default_encoding_desc">Varsayılan editör metin kodlaması</string>
@@ -233,7 +231,6 @@
     <string name="line_spacing_multiplier">Satır aralığı çarpanı</string>
     <string name="mutator_desc">Kullanıcı komut dosyaları oluştur</string>
     <string name="restore_sessions">Oturumu yeniden yükle</string>
-    <string name="enable_ext">Eklentiler</string>
     <string name="ext">Eklentiler</string>
     <string name="script_get_text">Metni al</string>
     <string name="installing">Indiriliyor…</string>
@@ -291,7 +288,6 @@
     <string name="launch">Başlat</string>
     <string name="terminal_home">Terminal ana sayfası</string>
     <string name="sessions">Oturumlar</string>
-    <string name="enable_ext_desc">Üçüncü parti eklentileri yükle</string>
     <string name="script_show_toast">Bilgi mesajı göster</string>
     <string name="script_network">Ağ</string>
     <string name="experimental_feature">Deneysel özellik</string>
@@ -301,12 +297,11 @@
     <string name="misc">Çeşitli</string>
     <string name="misc_desc">Çeşitli ayarlar</string>
     <string name="unrestricted_file">Herhangi boyutta dosya açmaya izin ver</string>
-    <string name="toggle_ww">Satır kaydırmayı aç/kapa</string>
+    <string name="toggle_word_wrap">Satır kaydırmayı aç/kapa</string>
     <string name="native_runner">Bu çalıştırıcı yalnızca yerel dosyalar üzerinde çalışır, terminal ana dizinine taşımayı düşünün</string>
     <string name="getting_ready">Her şey hazırlanıyor…</string>
     <string name="release_wakelock">Wakelock\'u serbest bırakın</string>
     <string name="acquire_wakelock">Wakelock\'u al</string>
-    <string name="preview_err">Bu dosyanın önizlemesi yapılamıyor. Hiçbir üst dizin mevcut değil. Bu dosyayı başka bir yere taşımayı düşünün.</string>
     <string name="edit_mode">Edit modu</string>
     <string name="no_folder_opened">Klasör açılmadı</string>
     <string name="cut">Kes</string>
@@ -327,7 +322,6 @@
     <string name="saf_expose_warning">Giriş dizinini açığa çıkarmak, Git belirteçleri, parolalar, kullanıcı adları ve terminal giriş dizininizde depolanan diğer dosyalar dahil olmak üzere hassas bilgileri kötü amaçlı uygulamalara ifşa edebilir. Devam etmek istiyor musunuz?</string>
     <string name="info">Bilgi</string>
     <string name="file_info">Dosya bilgileri</string>
-    <string name="file_size">Dosya boyutu</string>
     <string name="cant_undo">Bu eylem geri alınamaz</string>
     <string name="auto_complete">Editör otomatik tamamlama</string>
     <string name="capture_logcat">Logcat\'i yakala</string>
@@ -373,7 +367,6 @@
     <string name="sdcard_filetype">Bu konumda kod çalıştırmanız tavsiye edilmez. Dosyanızı terminalin ana dizinine taşımanız önerilir.</string>
     <string name="rename_file">Dosyayı yeniden adlandır</string>
     <string name="new_name">Yeni İsim</string>
-    <string name="file_type">DosyaTürü</string>
     <string name="type">Tür</string>
     <string name="name">İsim</string>
     <string name="view_github_profile">GitHub profilini görüntüle</string>

--- a/core/resources/src/main/res/values-uk/strings.xml
+++ b/core/resources/src/main/res/values-uk/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">Потрібен перезапуск</string>
     <string name="saved_all">зберіг усі файли</string>
     <string name="save">Зберегти</string>
-    <string name="ww_wait">Зачекайте, доки завершиться перенесення слів</string>
+    <string name="word_wrap_wait">Зачекайте, доки завершиться перенесення слів</string>
     <string name="open_file_or_folder">Відкрити файл або теку</string>
     <string name="open_directory">Відкрити каталог</string>
     <string name="new_file">Новий файл</string>
@@ -17,7 +17,7 @@
     <string name="rep">Заміна</string>
     <string name="search_keyword">Ключове слово для пошуку</string>
     <string name="cs">Враховувати регістр</string>
-    <string name="wait">Будь ласка, зачекайте...</string>
+    <string name="wait">Будь ласка, зачекайте…</string>
     <string name="report_issue">Повідомити про проблему</string>
     <string name="copy">Копія</string>
     <string name="save_all">Зберегти все</string>
@@ -34,7 +34,7 @@
     <string name="open_file">Відкрити файл</string>
     <string name="new_folder">Нова тека</string>
     <string name="rename">Перейменувати</string>
-    <string name="open_with">Відкрити за допомогою...</string>
+    <string name="open_with">Відкрити за допомогою…</string>
     <string name="save_as">Зберегти як</string>
     <string name="paste">Вставити</string>
     <string name="delete">Видалити</string>
@@ -48,10 +48,9 @@
     <string name="cancel">Скасувати</string>
     <string name="save_exit">Зберегти та вийти</string>
     <string name="exit">Вийти</string>
-    <string name="rr">Потрібен перезапуск</string>
     <string name="restart_to_apply">Перезапустіть, щоб застосувати налаштування</string>
     <string name="oled">Тема «Чорна ніч»</string>
-    <string name="ww">Перенесення слова</string>
+    <string name="word_wrap">Перенесення слова</string>
     <string name="keep_drawer_locked">Тримати вкладку заблокованою</string>
     <string name="restart">Перезапустити</string>
     <string name="refresh">Оновити</string>
@@ -76,7 +75,6 @@
     <string name="description">Опис</string>
     <string name="download">Завантажити</string>
     <string name="dir_exist_not">Каталог не існує</string>
-    <string name="file_exist_not">Файл більше не існує</string>
     <string name="file_saved">Файл збережено</string>
     <string name="apply">Застосувати</string>
     <string name="userdata">Дані користувача</string>
@@ -134,7 +132,7 @@
     <string name="editor">Редактор</string>
     <string name="smooth_tabs">Плавні вкладки</string>
     <string name="smooth_tab_desc">Плавне перемикання між вкладками</string>
-    <string name="ww_desc">Увімкніть перенесення слів у всіх редакторах</string>
+    <string name="word_wrap_desc">Увімкніть перенесення слів у всіх редакторах</string>
     <string name="drawer_lock_desc">Тримати вкладку відкритою, відкривши файл</string>
     <string name="diagonal_scroll">Діагональна прокрутка</string>
     <string name="diagonal_scroll_desc">Увімкнути діагональне прокручування в дереві файлів</string>
@@ -147,9 +145,9 @@
     <string name="auto_save">Автоматичне збереження</string>
     <string name="auto_save_desc">Автоматично зберігати файл</string>
     <string name="interval_in_ms">Інтервал у мілісекундах</string>
-    <string name="invalid_v">Недійсне значення</string>
-    <string name="v_small">Замале значення</string>
-    <string name="v_large">Завелике значення</string>
+    <string name="value_invalid">Недійсне значення</string>
+    <string name="value_small">Замале значення</string>
+    <string name="value_large">Завелике значення</string>
     <string name="text_size">Розмір тексту</string>
     <string name="text_size_desc">Встановити розмір тексту</string>
     <string name="tab_size">Розмір вкладки</string>
@@ -163,7 +161,7 @@
     <string name="terminal_desc">Загальні налаштування терміналів</string>
     <string name="terminal_text_size">Розмір тексту терміналу</string>
     <string name="terminal_text_size_desc">Встановити розмір тексту терміналу</string>
-    <string name="u_err">Невідома помилка</string>
+    <string name="unknown_error">Невідома помилка</string>
     <string name="saved">Збережено</string>
     <string name="is_null">InputStream порожній</string>
     <string name="wait_pkg">Зачекайте, поки пакети завантажаться.</string>
@@ -210,8 +208,8 @@
     <string name="file_too_large">Файл завеликий для відкриття</string>
     <string name="toggle_suggestion">Змінити пропозицію</string>
     <string name="run">Запустити</string>
-    <string name="txt_ww">Перенесення txt файлів</string>
-    <string name="txt_ww_desc">Автоматично переносити текстові файли</string>
+    <string name="txt_word_wrap">Перенесення txt файлів</string>
+    <string name="txt_word_wrap_desc">Автоматично переносити текстові файли</string>
     <string name="mutators">Мутатори</string>
     <string name="manage_editor_font">Керування шрифтами редактора</string>
     <string name="default_encoding">Типове кодування</string>

--- a/core/resources/src/main/res/values-vi/strings.xml
+++ b/core/resources/src/main/res/values-vi/strings.xml
@@ -5,7 +5,7 @@
     <string name="unsupported_content">Nội dung không được hỗ trợ</string>
     <string name="saved_all">đã lưu tất cả các tệp</string>
     <string name="save">Lưu</string>
-    <string name="ww_wait">Vui lòng đợi quá trình ngắt từ hoàn tất</string>
+    <string name="word_wrap_wait">Vui lòng đợi quá trình ngắt từ hoàn tất</string>
     <string name="open_file_or_folder">Mở tệp hoặc thư mục</string>
     <string name="open_directory">Mở thư mục</string>
     <string name="new_file">Tệp mới</string>
@@ -43,9 +43,8 @@
     <string name="cancel">Hủy</string>
     <string name="save_exit">Lưu và thoát</string>
     <string name="exit">Thoát</string>
-    <string name="rr">Yêu cầu khởi động lại</string>
     <string name="oled">Chủ đề Tối</string>
-    <string name="ww">Word wrap</string>
+    <string name="word_wrap">Word wrap</string>
     <string name="restart">Khởi động lại</string>
     <string name="refresh">Tải lại</string>
     <string name="dir_example">Tên thư mục, vd: Test</string>
@@ -62,7 +61,7 @@
     <string name="download">Tải xuống</string>
     <string name="experimental_session_restore_warning">Tính năng này đang trong giai đoạn thử nghiệm và có thể gây mất dữ liệu</string>
     <string name="warning_private_dir">Nội dung của thư mục này sẽ bị xóa nếu bạn xóa dữ liệu hoặc xóa Xed-Editor</string>
-    <string name="toggle_ww">Đóng/mở Word wrap</string>
+    <string name="toggle_word_wrap">Đóng/mở Word wrap</string>
     <string name="unrestricted_file">Mở tập tin kích thước bất kỳ</string>
     <string name="unrestricted_file_desc">Cho phép mở tệp kích thước tùy ý (có thể dẫn đến sự cố)</string>
     <string name="suggest_clear_app_data">Nên xóa dữ liệu ứng dụng</string>
@@ -80,7 +79,6 @@
     <string name="telegram_desc">Tham gia cộng đồng Telegram</string>
     <string name="terminal">Terminal</string>
     <string name="tab_text_1">Thẻ 1</string>
-    <string name="file_exist_not">Tệp không tồn tại</string>
     <string name="apply">Áp dụng</string>
     <string name="invalid_userdata">Dữ liệu người dùng không hợp lệ. Thay đổi nó trong cài đặt</string>
     <string name="open_in_terminal">Mở Trong Terminal</string>
@@ -141,7 +139,7 @@
     <string name="editor">Trình chỉnh sửa</string>
     <string name="smooth_tabs">Thẻ Mượt</string>
     <string name="smooth_tab_desc">Chuyển đổi thẻ một cách mượt mà</string>
-    <string name="ww_desc">Cho phép Gói Từ trong mọi trình chỉnh sửa</string>
+    <string name="word_wrap_desc">Cho phép Gói Từ trong mọi trình chỉnh sửa</string>
     <string name="drawer_lock_desc">Giữ ngăn kéo bị khoá khi đang mở tệp</string>
     <string name="diagonal_scroll">Cuộn chéo</string>
     <string name="diagonal_scroll_desc">Cho phép Cuộn Chéo trong Cây Tệp</string>

--- a/core/resources/src/main/res/values-zh-rTW/strings.xml
+++ b/core/resources/src/main/res/values-zh-rTW/strings.xml
@@ -8,7 +8,7 @@
     <string name="restart_required">需要重新啟動</string>
     <string name="saved_all">已儲存所有檔案</string>
     <string name="save">儲存</string>
-    <string name="ww_wait">請等待換行完成</string>
+    <string name="word_wrap_wait">請等待換行完成</string>
     <string name="open_file_or_folder">開啟檔案或資料夾</string>
     <string name="open_directory">開啟資料夾</string>
     <string name="new_file">新增檔案</string>
@@ -48,10 +48,9 @@
     <string name="cancel">取消</string>
     <string name="save_exit">儲存並退出</string>
     <string name="exit">退出</string>
-    <string name="rr">需要重新啟動以生效</string>
     <string name="restart_to_apply">請重新啟動以套用設定</string>
     <string name="oled">純黑主題</string>
-    <string name="ww">自動換行</string>
+    <string name="word_wrap">自動換行</string>
     <string name="keep_drawer_locked">保持側滑欄狀態</string>
     <string name="restart">重新啟動</string>
     <string name="refresh">重新載入</string>
@@ -76,7 +75,6 @@
     <string name="description">描述</string>
     <string name="download">下載</string>
     <string name="dir_exist_not">資料夾不存在</string>
-    <string name="file_exist_not">檔案已不存在</string>
     <string name="file_saved">檔案已儲存</string>
     <string name="apply">套用</string>
     <string name="userdata">使用者資料</string>
@@ -134,7 +132,7 @@
     <string name="editor">編輯器</string>
     <string name="smooth_tabs">平滑分頁</string>
     <string name="smooth_tab_desc">在分頁之間平滑切換</string>
-    <string name="ww_desc">在所有編輯器中啟用自動換行</string>
+    <string name="word_wrap_desc">在所有編輯器中啟用自動換行</string>
     <string name="drawer_lock_desc">開啟檔案時保持側邊欄鎖定</string>
     <string name="diagonal_scroll">斜向捲動</string>
     <string name="diagonal_scroll_desc">在檔案樹中啟用斜向捲動</string>
@@ -147,9 +145,9 @@
     <string name="auto_save">自動儲存</string>
     <string name="auto_save_desc">自動儲存檔案</string>
     <string name="interval_in_ms">間隔（毫秒）</string>
-    <string name="invalid_v">無效值</string>
-    <string name="v_small">數值太小</string>
-    <string name="v_large">數值太大</string>
+    <string name="value_invalid">無效值</string>
+    <string name="value_small">數值太小</string>
+    <string name="value_large">數值太大</string>
     <string name="text_size">文字大小</string>
     <string name="text_size_desc">設定文字大小</string>
     <string name="tab_size">標簽大小</string>
@@ -163,7 +161,7 @@
     <string name="terminal_desc">終端機一般設定</string>
     <string name="terminal_text_size">終端機文字大小</string>
     <string name="terminal_text_size_desc">設定終端機文字大小</string>
-    <string name="u_err">未知錯誤</string>
+    <string name="unknown_error">未知錯誤</string>
     <string name="is_null">InputStream 為 null</string>
     <string name="wait_pkg">請等待套件下載完成。</string>
     <string name="unsupported_aarch">不支援的平台，已啟動安全模式</string>
@@ -209,8 +207,8 @@
     <string name="file_too_large">開啓的檔案過大</string>
     <string name="toggle_suggestion">鍵盤選詞建議</string>
     <string name="run">運行</string>
-    <string name="txt_ww">自動換行 TXT 檔</string>
-    <string name="txt_ww_desc">自動換行文字檔</string>
+    <string name="txt_word_wrap">自動換行 TXT 檔</string>
+    <string name="txt_word_wrap_desc">自動換行文字檔</string>
     <string name="manage_editor_font">管理編輯器字型</string>
     <string name="default_encoding">預設編碼</string>
     <string name="default_encoding_desc">編輯器預設編碼</string>
@@ -245,8 +243,6 @@
     <string name="add_session">新增工作階段</string>
     <string name="terminal_runtime">終端機執行環境</string>
     <string name="terminal_runtime_desc">選取終端機執行環境</string>
-    <string name="enable_ext">擴充功能</string>
-    <string name="enable_ext_desc">載入第三方擴充功能</string>
     <string name="ext">擴充功能</string>
     <string name="ext_desc">管理擴充功能</string>
     <string name="info_mutators">Mutator 是用來修改編輯器文字的小型腳本。建立一個 Mutator 並點擊它即可在編輯器中開啟。</string>
@@ -285,7 +281,7 @@
     <string name="unrestricted_file_desc">允許開啟任意大小的檔案 （可能會導致程式當機）。</string>
     <string name="suggest_clear_app_data">建議清除應用程式資料</string>
     <string name="update_files_cleared">應用程式已更新：已清除資料</string>
-    <string name="toggle_ww">切換自動換行</string>
+    <string name="toggle_word_wrap">切換自動換行</string>
     <string name="warning_private_dir">若你清除資料或刪除 Xed-Editor時，此資料夾的內容將被刪除</string>
     <string name="new_document">新增檔案</string>
     <string name="read_only_file">檔案為唯讀</string>
@@ -306,7 +302,6 @@
     <string name="expose_saf">顯示主目錄</string>
     <string name="expose_saf_desc">透過系統檔案選擇器 (SAF) 讓外部應用程式可以存取主目錄</string>
     <string name="saf_expose_warning">公開主目錄可能會讓惡意應用程式取得敏感資訊，包括 Git 權杖、密碼、使用者名稱，以及儲存在你終端機主目錄中的其他檔案。你要繼續嗎？</string>
-    <string name="file_size">檔案大小</string>
     <string name="info">資訊</string>
     <string name="file_info">檔案資訊</string>
     <string name="can_read">可讀取</string>
@@ -351,7 +346,6 @@
     <string name="control_panel">控制面板</string>
     <string name="read_mode_desc">預設開啟只讀模式</string>
     <string name="tab_memory_warning">可用記憶體不足，無法開啟此分頁。開啟可能導致 Xed-Editor 當機。你仍要繼續嗎？</string>
-    <string name="preview_err">無法預覽此檔案。沒有可用的上層目錄。請考慮將此檔案移動到其他位置。</string>
     <string name="acquire_wakelock">保持螢幕常亮</string>
     <string name="release_wakelock">停用螢幕常亮</string>
     <string name="getting_ready">正在初始化…</string>
@@ -374,7 +368,6 @@
     <string name="delete_desc">永久刪除檔案</string>
     <string name="rename_file">重新命名檔案</string>
     <string name="new_name">新名稱</string>
-    <string name="file_type">檔案類型</string>
     <string name="type">類型</string>
     <string name="name">名稱</string>
     <string name="view_github_profile">檢視 GitHub 個人資料</string>

--- a/core/resources/src/main/res/values-zh/strings.xml
+++ b/core/resources/src/main/res/values-zh/strings.xml
@@ -21,10 +21,9 @@
     <string name="insert_date">插入日期</string>
     <string name="save_exit">保存并退出</string>
     <string name="exit">退出</string>
-    <string name="rr">需要重启以生效</string>
     <string name="restart_to_apply">请重启以应用设置</string>
     <string name="oled">纯黑主题</string>
-    <string name="ww">自动换行</string>
+    <string name="word_wrap">自动换行</string>
     <string name="restart">重新启动</string>
     <string name="refresh">重载</string>
     <string name="dir_example">名称（例如：测试）</string>
@@ -71,7 +70,7 @@
     <string name="null_content">错误：内容为空</string>
     <string name="restart_required">需要重启</string>
     <string name="save">保存</string>
-    <string name="ww_wait">请等待换行完成</string>
+    <string name="word_wrap_wait">请等待换行完成</string>
     <string name="open_file_or_folder">打开文件或文件夹</string>
     <string name="open_directory">打开目录</string>
     <string name="new_file">新建文件</string>
@@ -93,7 +92,6 @@
     <string name="remove_a_search_batch">移除一组批量搜索</string>
     <string name="tab_text_1">标签页 1</string>
     <string name="tab_text_2">标签页 2</string>
-    <string name="file_exist_not">文件已不存在</string>
     <string name="apply">应用</string>
     <string name="invalid_userdata">用户数据无效。请在设置中更改</string>
     <string name="reload_file_tree">重新加载文件</string>
@@ -128,7 +126,7 @@
     <string name="editor">编辑器</string>
     <string name="smooth_tabs">平滑标签页</string>
     <string name="smooth_tab_desc">在标签页之间平滑切换</string>
-    <string name="ww_desc">在所有编辑器中启用自动换行</string>
+    <string name="word_wrap_desc">在所有编辑器中启用自动换行</string>
     <string name="drawer_lock_desc">在打开文件时保持侧滑栏锁定</string>
     <string name="diagonal_scroll">对角线滚动</string>
     <string name="diagonal_scroll_desc">在文件树中启用对角线滚动</string>
@@ -138,9 +136,9 @@
     <string name="extra_keys">额外关键字</string>
     <string name="extra_keys_desc">在编辑器中显示额外关键字</string>
     <string name="interval_in_ms">间隔（毫秒）</string>
-    <string name="invalid_v">无效值</string>
-    <string name="v_small">数值太小</string>
-    <string name="v_large">数值太大</string>
+    <string name="value_invalid">无效值</string>
+    <string name="value_small">数值太小</string>
+    <string name="value_large">数值太大</string>
     <string name="monet">动态颜色</string>
     <string name="app_desc">应用通用设置</string>
     <string name="editor_desc">编辑器通用设置</string>
@@ -161,7 +159,7 @@
     <string name="text_size">字体大小</string>
     <string name="monet_desc">跟随系统主题</string>
     <string name="add_new_replacement_batch">添加新的批量替换</string>
-    <string name="u_err">未知错误</string>
+    <string name="unknown_error">未知错误</string>
     <string name="choose_file">选择文件</string>
     <string name="terminal_text_size_desc">设置终端字体大小</string>
     <string name="saved">已保存</string>
@@ -228,8 +226,8 @@
     <string name="file_too_large">打开的文件过大</string>
     <string name="toggle_suggestion">键盘选词建议</string>
     <string name="run">运行</string>
-    <string name="txt_ww">换行 TXT 文件</string>
-    <string name="txt_ww_desc">自动换行 TXT 文件</string>
+    <string name="txt_word_wrap">换行 TXT 文件</string>
+    <string name="txt_word_wrap_desc">自动换行 TXT 文件</string>
     <string name="telegram">Telegram 群</string>
     <string name="mutators">Mutator</string>
     <string name="update_av">有新版本可用</string>
@@ -264,7 +262,6 @@
     <string name="script_get_text">获取编辑器文本</string>
     <string name="script_show_toast">显示 Toast 提示消息</string>
     <string name="script_network">网络</string>
-    <string name="enable_ext">扩展</string>
     <string name="file_err">无法保存文件，请尝试关闭并重新打开文件</string>
     <string name="file_not_loaded">文件尚未加载。</string>
     <string name="experimental_feature">实验性功能</string>
@@ -272,7 +269,6 @@
     <string name="unrestricted_file">打开任意大小的文件</string>
     <string name="new_document">新建文件</string>
     <string name="new_document_desc">新建文件或文件夹</string>
-    <string name="enable_ext_desc">加载第三方扩展</string>
     <string name="ext_desc">管理扩展</string>
     <string name="script_text">此文本将被写入到编辑器</string>
     <string name="script_set_text">设置编辑器文本</string>
@@ -298,13 +294,12 @@
     <string name="file">文件</string>
     <string name="warning_private_dir">当你清除数据或删除 Xed-Editor 时，此目录的内容将被删除</string>
     <string name="read_only_file">文件处于只读状态</string>
-    <string name="toggle_ww">切换自动换行</string>
+    <string name="toggle_word_wrap">切换自动换行</string>
     <string name="unknown_err">出了点问题</string>
     <string name="misc">其他设置</string>
     <string name="misc_desc">其他的设置选项</string>
     <string name="expose_saf">显示主目录</string>
     <string name="file_info">文件属性</string>
-    <string name="file_size">文件大小</string>
     <string name="can_read">可读</string>
     <string name="can_write">可写</string>
     <string name="is_file">是文件</string>
@@ -352,7 +347,6 @@
     <string name="control_panel">控制面板</string>
     <string name="tab_memory_warning">当前没有足够的内存。打开此标签页可能导致 Xed-Editor 崩溃。你要继续吗？</string>
     <string name="read_mode_desc">默认开启只读模式</string>
-    <string name="preview_err">无法预览此文件，因为找不到父目录。建议将文件移动到其他位置后再试。</string>
     <string name="acquire_wakelock">保持屏幕常亮</string>
     <string name="release_wakelock">关闭屏幕常亮</string>
     <string name="getting_ready">正在初始化…</string>
@@ -374,7 +368,6 @@
     <string name="delete_desc">永久删除文件</string>
     <string name="rename_file">重命名文件</string>
     <string name="new_name">新名称</string>
-    <string name="file_type">文件类型</string>
     <string name="type">类型</string>
     <string name="name">名称</string>
     <string name="view_github_profile">查看 GitHub 个人资料</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="saved">File saved</string>
     <string name="saved_all">Saved all files</string>
     <string name="save">Save</string>
-    <string name="ww_wait">Please wait for word wrap to complete</string>
+    <string name="word_wrap_wait">Please wait for word wrap to complete</string>
     <string name="open_file_or_folder">Open file or folder</string>
     <string name="open_directory">Open a directory</string>
     <string name="new_file">New file</string>
@@ -50,10 +50,9 @@
     <string name="cancel">Cancel</string>
     <string name="save_exit">Save and exit</string>
     <string name="exit">Exit</string>
-    <string name="rr">Restart required</string>
     <string name="restart_to_apply">Please restart to apply settings</string>
     <string name="oled">Black theme</string>
-    <string name="ww">Word wrap</string>
+    <string name="word_wrap">Word wrap</string>
     <string name="keep_drawer_locked">Keep drawer locked</string>
     <string name="restart">Restart</string>
     <string name="refresh">Reload</string>
@@ -130,13 +129,13 @@
     <string name="yes">Yes</string>
     <string name="fetch_failed">Fetch request returned null</string>
     <string name="app">Application</string>
-    <string name="oled_desc">Black theme (#000)</string>
+    <string name="oled_desc">Applies a pure black theme</string>
     <string name="themes">Themes</string>
     <string name="change_theme">Change theme</string>
     <string name="editor">Editor</string>
     <string name="smooth_tabs">Smooth tabs</string>
     <string name="smooth_tab_desc">Smoothly switch between tabs</string>
-    <string name="ww_desc">Enable word wrap in all editors</string>
+    <string name="word_wrap_desc">Enable word wrap in all editors</string>
     <string name="drawer_lock_desc">Keep drawer locked when opening file</string>
     <string name="diagonal_scroll">Diagonal scrolling</string>
     <string name="diagonal_scroll_desc">Enable diagonal scrolling in file tree</string>
@@ -149,9 +148,9 @@
     <string name="auto_save">Auto save</string>
     <string name="auto_save_desc">Automatically save file</string>
     <string name="interval_in_ms">Interval in milliseconds</string>
-    <string name="invalid_v">Invalid value</string>
-    <string name="v_small">Value too small</string>
-    <string name="v_large">Value too large</string>
+    <string name="value_invalid">Invalid value</string>
+    <string name="value_small">Value too small</string>
+    <string name="value_large">Value too large</string>
     <string name="text_size">Text size</string>
     <string name="text_size_desc">Set text size</string>
     <string name="tab_size">Tab size</string>
@@ -165,7 +164,7 @@
     <string name="terminal_desc">General terminal settings</string>
     <string name="terminal_text_size">Terminal text size</string>
     <string name="terminal_text_size_desc">Set terminal text size</string>
-    <string name="u_err">Unknown error</string>
+    <string name="unknown_error">Unknown error</string>
     <string name="is_null">InputStream is null</string>
     <string name="wait_pkg">Please wait while the packages are being downloaded.</string>
     <string name="unsupported_aarch">Unsupported platform, use fail safe</string>
@@ -211,8 +210,8 @@
     <string name="file_too_large">File is too big to open</string>
     <string name="toggle_suggestion">Toggle suggestion</string>
     <string name="run">Run</string>
-    <string name="txt_ww">Wrap TXT files</string>
-    <string name="txt_ww_desc">Automatically wrap TXT files</string>
+    <string name="txt_word_wrap">Wrap TXT files</string>
+    <string name="txt_word_wrap_desc">Automatically wrap TXT files</string>
     <string name="manage_editor_font">Manage editor fonts</string>
     <string name="default_encoding">Default encoding</string>
     <string name="default_encoding_desc">Editor default encoding</string>
@@ -247,8 +246,6 @@
     <string name="add_session">Add session</string>
     <string name="terminal_runtime">Terminal runtime</string>
     <string name="terminal_runtime_desc">Select terminal runtime</string>
-    <string name="enable_ext">Extensions</string>
-    <string name="enable_ext_desc">Load third party extensions</string>
     <string name="ext">Extensions</string>
     <string name="ext_desc">Manage extensions</string>
     <string name="info_mutators">Mutators are small scripts that are used to modify the editor text. Create a mutator and click on it to open it in the editor.</string>
@@ -287,7 +284,7 @@
     <string name="unrestricted_file_desc">Allow opening files of any size. May lead to crashes.</string>
     <string name="suggest_clear_app_data">Clearing app data is recommended</string>
     <string name="update_files_cleared">App updated: data cleared</string>
-    <string name="toggle_ww">Toggle word wrap</string>
+    <string name="toggle_word_wrap">Toggle word wrap</string>
     <string name="warning_private_dir">Content of this directory will get deleted if you clear data or delete Xed-Editor</string>
     <string name="read_only_file">File is read only</string>
     <string name="new_document">New document</string>


### PR DESCRIPTION
This PR consists of the most important changes proposed in #860.

## Changes
- Change OLED theme description
- Change undescriptive resource names (e.g. `ww` to `word_wrap`)
- Remove duplicate strings
- Remove a few unused translations