### PR TITLE
fix(main): improve LSP URI conversion

### DIFF
--- a/core/main/src/main/java/com/rk/lsp/LspActions.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspActions.kt
@@ -19,6 +19,8 @@ import com.rk.tabs.CodeEditorState
 import com.rk.tabs.EditorTab
 import com.rk.activities.main.MainViewModel
 import com.rk.components.CodeItem
+import com.rk.file.child
+import com.rk.file.sandboxDir
 import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.lsp.events.EventType
 import io.github.rosemoe.sora.lsp.events.document.applyEdits
@@ -37,10 +39,19 @@ import kotlin.text.substring
  * Example: The LSP may return `file:///home/...` but Xed-Editor has to resolve the path to `file:///data/user/0/com.rk.xededitor/local/sandbox/home/...`
  * */
 fun fixHomeLocation(context: Context, uri: String): String {
-    if (uri.toUri().path!!.startsWith("/home")) {
-        return Uri.fromFile(File(sandboxHomeDir(context), uri.toUri().path!!.removePrefix("/home/"))).toString()
+    val path = uri.toUri().path ?: return uri
+
+    val fixedPath  = when {
+        path.startsWith("/home") -> {
+            File(sandboxHomeDir(context), uri.toUri().path!!.removePrefix("/home/"))
+        }
+        path.startsWith("/usr") -> {
+            File(sandboxDir(context).child("usr"), uri.toUri().path!!.removePrefix("/usr/"))
+        }
+        else -> null
     }
-    return uri
+
+    return fixedPath?.let { Uri.fromFile(it).toString() } ?: uri
 }
 
 /**


### PR DESCRIPTION
This PR improves URI conversion to transform paths from the LSP in the terminal sandbox into actual paths.

It adds support for `/usr` paths, which are used, for example, in the built-in Python LSP.