### PR TITLE
fix(main): fix missing `ca-certificates` and remove `clear`

### DIFF
--- a/core/main/src/main/assets/terminal/init.sh
+++ b/core/main/src/main/assets/terminal/init.sh
@@ -24,7 +24,7 @@ if [ -d "$ALPINE_DIR" ]; then
     :
   else
     info "Detected existing Alpine installation"
-    printf "\nxed-editor has now migrated from Alpine to Ubuntu for better compatibility and support.\n\n"
+    printf "\nXed-editor has now migrated from Alpine to Ubuntu for better compatibility and support.\n\n"
 
     if confirm "Do you want to migrate your home data from Alpine to Ubuntu?"; then
       info "Migrating data..."
@@ -55,24 +55,19 @@ if [[ -f ~/.bashrc ]]; then
 fi
 
 
-export PATH=/home/.npm-global:/bin:/sbin:/usr/bin:/usr/sbin:/usr/games:/usr/local/bin:/usr/local/sbin:$LOCAL/bin:$PATH
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/games:/usr/local/bin:/usr/local/sbin:$LOCAL/bin:$PATH
 export SHELL="bash"
 export PS1="\[\e[1;32m\]\u@\h\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\] \\$ "
 
 ensure_packages_once() {
     local marker_file="/.cache/.packages_ensured"
-    local PACKAGES=("command-not-found" "sudo" "xkb-data" "curl")
+    local PACKAGES=("command-not-found" "sudo" "xkb-data")
 
     # Exit early if already done
     [[ -f "$marker_file" ]] && return 0
 
     echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/99norecommends
     echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/99norecommends
-
-    #setup node lts
-    curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
-    #npm config set prefix '/home/.npm-global'
-
 
     # Create cache dir
     mkdir -p "/.cache"

--- a/core/main/src/main/assets/terminal/lsp/bash.sh
+++ b/core/main/src/main/assets/terminal/lsp/bash.sh
@@ -7,7 +7,7 @@ apt update && apt upgrade -y
 
 install_nodejs() {
   info "Installing Node.js LTS..."
-  apt install -y curl
+  apt install -y curl ca-certificates
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
   mkdir -p /home/.npm-global
@@ -27,5 +27,4 @@ npm i -g bash-language-server
 info 'Installing ShellCheck...'
 apt install -y shellcheck
 
-clear
 info 'Bash language server installed successfully. Please reopen all tabs or restart the app.'

--- a/core/main/src/main/assets/terminal/lsp/css.sh
+++ b/core/main/src/main/assets/terminal/lsp/css.sh
@@ -7,7 +7,7 @@ apt update && apt upgrade -y
 
 install_nodejs() {
   info "Installing Node.js LTS..."
-  apt install -y curl
+  apt install -y curl ca-certificates
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
   mkdir -p /home/.npm-global
@@ -24,5 +24,4 @@ fi
 info 'Installing extracted VSCode language servers...'
 npm install -g vscode-langservers-extracted
 
-clear
 info 'CSS language server installed successfully. Please reopen all tabs or restart the app.'

--- a/core/main/src/main/assets/terminal/lsp/eslint.sh
+++ b/core/main/src/main/assets/terminal/lsp/eslint.sh
@@ -7,7 +7,7 @@ apt update && apt upgrade -y
 
 install_nodejs() {
   info "Installing Node.js LTS..."
-  apt install -y curl
+  apt install -y curl ca-certificates
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
   mkdir -p /home/.npm-global
@@ -24,5 +24,4 @@ fi
 info 'Installing extracted VSCode language servers...'
 npm install -g vscode-langservers-extracted
 
-clear
 info 'ESLint language server installed successfully. Please reopen all tabs or restart the app.'

--- a/core/main/src/main/assets/terminal/lsp/html.sh
+++ b/core/main/src/main/assets/terminal/lsp/html.sh
@@ -7,7 +7,7 @@ apt update && apt upgrade -y
 
 install_nodejs() {
   info "Installing Node.js LTS..."
-  apt install -y curl
+  apt install -y curl ca-certificates
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
   mkdir -p /home/.npm-global
@@ -24,5 +24,4 @@ fi
 info 'Installing extracted VSCode language servers...'
 npm install -g vscode-langservers-extracted
 
-clear
 info 'HTML language server installed successfully. Please reopen all tabs or restart the app.'

--- a/core/main/src/main/assets/terminal/lsp/json.sh
+++ b/core/main/src/main/assets/terminal/lsp/json.sh
@@ -7,7 +7,7 @@ apt update && apt upgrade -y
 
 install_nodejs() {
   info "Installing Node.js LTS..."
-  apt install -y curl
+  apt install -y curl ca-certificates
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
   mkdir -p /home/.npm-global
@@ -24,5 +24,4 @@ fi
 info 'Installing extracted VSCode language servers...'
 npm install -g vscode-langservers-extracted
 
-clear
 info 'JSON language server installed successfully. Please reopen all tabs or restart the app.'

--- a/core/main/src/main/assets/terminal/lsp/markdown.sh
+++ b/core/main/src/main/assets/terminal/lsp/markdown.sh
@@ -7,7 +7,7 @@ apt update && apt upgrade -y
 
 install_nodejs() {
   info "Installing Node.js LTS..."
-  apt install -y curl
+  apt install -y curl ca-certificates
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
   mkdir -p /home/.npm-global
@@ -24,5 +24,4 @@ fi
 info 'Installing extracted VSCode language servers...'
 npm install -g vscode-langservers-extracted
 
-clear
 info 'Markdown language server installed successfully. Please reopen all tabs or restart the app.'

--- a/core/main/src/main/assets/terminal/lsp/python.sh
+++ b/core/main/src/main/assets/terminal/lsp/python.sh
@@ -12,5 +12,4 @@ pipx ensurepath
 info 'Installing python language server...'
 pipx install 'python-lsp-server[all]'
 
-clear
 info 'Python language server installed successfully. Please reopen all tabs or restart the app.'

--- a/core/main/src/main/assets/terminal/lsp/typescript.sh
+++ b/core/main/src/main/assets/terminal/lsp/typescript.sh
@@ -7,7 +7,7 @@ apt update && apt upgrade -y
 
 install_nodejs() {
   info "Installing Node.js LTS..."
-  apt install -y curl
+  apt install -y curl ca-certificates
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
   mkdir -p /home/.npm-global
@@ -24,5 +24,4 @@ fi
 info 'Installing typescript language server...'
 npm install -g typescript typescript-language-server
 
-clear
 info 'TypeScript language server installed successfully. Please reopen all tabs or restart the app.'


### PR DESCRIPTION
This PR closes issue #926.

## Bug fixes
- Fix spelling mistake in migration
- Make sure `ca-certificates` is installed
- Remove `clear` keyword'
- Remove unnecessary curl and NodeJS installation in `init.sh` (The NodeJS installation was failing anyways because `curl` was installed after the NodeJS installation attempt)