### PR TITLE
feat(core): focus input fields automatically

### DIFF
--- a/core/main/src/main/java/com/rk/components/SingleInputDialog.kt
+++ b/core/main/src/main/java/com/rk/components/SingleInputDialog.kt
@@ -6,8 +6,12 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.TextFieldValue
 import com.rk.resources.strings
 import com.rk.icons.Error
 import com.rk.icons.XedIcons
@@ -26,6 +30,12 @@ fun SingleInputDialog(
     confirmEnabled: Boolean = true,
     errorMessage: String? = null
 ) {
+    val focusRequester = remember { FocusRequester() }
+
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(text = inputValue, selection = TextRange(inputValue.length)))
+    }
+
     AlertDialog(
         onDismissRequest = {
             onDismiss()
@@ -35,11 +45,16 @@ fun SingleInputDialog(
         text = {
             Column {
                 OutlinedTextField(
-                    value = inputValue,
+                    value = textFieldValue,
                     singleLine = singleLineMode,
-                    onValueChange = onInputValueChange,
+                    onValueChange = {
+                        textFieldValue = it
+                        onInputValueChange(it.text)
+                    },
                     label = { Text(inputLabel) },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester),
                     isError = errorMessage != null,
                     supportingText = {
                         if (errorMessage != null) {
@@ -63,6 +78,10 @@ fun SingleInputDialog(
                         imeAction = ImeAction.Done
                     )
                 )
+
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()
+                }
             }
         },
         confirmButton = {

--- a/core/main/src/main/java/com/rk/settings/lsp/LspSettings.kt
+++ b/core/main/src/main/java/com/rk/settings/lsp/LspSettings.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -27,6 +28,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
@@ -137,6 +140,8 @@ private fun ExternalLSP(
     onDismiss: () -> Unit,
     onConfirm: (host: String, port: String, extensions: List<String>) -> Unit
 ) {
+    val focusRequester = remember { FocusRequester() }
+
     var host by remember { mutableStateOf("localhost") }
     var port by remember { mutableStateOf("") }
     var extensions by remember { mutableStateOf("") }
@@ -195,6 +200,7 @@ private fun ExternalLSP(
                         }
                     },
                 )
+
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = port,
@@ -208,6 +214,7 @@ private fun ExternalLSP(
                         }
                     },
                     label = { Text(stringResource(strings.port_number)) },
+                    modifier = Modifier.focusRequester(focusRequester),
                     singleLine = true,
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     isError = portError != null,
@@ -226,6 +233,11 @@ private fun ExternalLSP(
                         }
                     },
                 )
+
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()
+                }
+
                 Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = extensions,


### PR DESCRIPTION
This PR ensures that in all dialogs in Xed-Editor, the first TextField is in focus, when opened. I'm using `TextFieldValue` to make sure that the cursor is always at the end when focused.