### PR TITLE
fix(core): add icon and enhance command label

### DIFF
--- a/core/main/src/main/java/com/rk/commands/CommandProvider.kt
+++ b/core/main/src/main/java/com/rk/commands/CommandProvider.kt
@@ -508,14 +508,14 @@ object CommandProvider {
                     },
                     isSupported = derivedStateOf { (viewModel.currentTab as? EditorTab)?.baseLspConnector?.isFormattingSupported() == true },
                     isEnabled = mutableStateOf(true),
-                    icon = mutableStateOf(ImageVector.vectorResource(drawables.manage_search))
+                    icon = mutableStateOf(ImageVector.vectorResource(drawables.auto_fix))
                 )
             )
 
             add(
                 Command(
-                    id = "lsp.format_document_range",
-                    label = mutableStateOf(stringResource(strings.format_document_range)),
+                    id = "lsp.format_selection",
+                    label = mutableStateOf(stringResource(strings.format_selection)),
                     action = { _, _ ->
                         val currentTab = viewModel.currentTab
                         if (currentTab is EditorTab) {
@@ -524,7 +524,7 @@ object CommandProvider {
                     },
                     isSupported = derivedStateOf { (viewModel.currentTab as? EditorTab)?.baseLspConnector?.isRangeFormattingSupported() == true },
                     isEnabled = mutableStateOf(true),
-                    icon = mutableStateOf(ImageVector.vectorResource(drawables.manage_search))
+                    icon = mutableStateOf(ImageVector.vectorResource(drawables.auto_fix))
                 )
             )
 

--- a/core/resources/src/main/res/drawable/auto_fix.xml
+++ b/core/resources/src/main/res/drawable/auto_fix.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7.5,5.6L10,7 8.6,4.5 10,2 7.5,3.4 5,2l1.4,2.5L5,7zM19.5,15.4L17,14l1.4,2.5L17,19l2.5,-1.4L22,19l-1.4,-2.5L22,14zM22,2l-2.5,1.4L17,2l1.4,2.5L17,7l2.5,-1.4L22,7l-1.4,-2.5zM14.37,7.29c-0.39,-0.39 -1.02,-0.39 -1.41,0L1.29,18.96c-0.39,0.39 -0.39,1.02 0,1.41l2.34,2.34c0.39,0.39 1.02,0.39 1.41,0L16.7,11.05c0.39,-0.39 0.39,-1.02 0,-1.41l-2.33,-2.35zM13.34,12.78l-2.12,-2.12 2.44,-2.44 2.12,2.12 -2.44,2.44z" />
+
+</vector>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -436,7 +436,7 @@
     <string name="go_to_references">Go to references</string>
     <string name="rename_symbol">Rename symbol</string>
     <string name="format_document">Format document</string>
-    <string name="format_document_range">Format document range</string>
+    <string name="format_selection">Format selection</string>
     <string name="go_to_definition_desc">Select one of the %d definitions to navigate to their location.</string>
     <string name="go_to_references_desc">Select one of the %d references to navigate to their location.</string>
     <string name="no_definitions_found">No definitions found.</string>


### PR DESCRIPTION
This PR adds proper icons for the two formatting commands and enhances one command label. I forgot these changes in #934 