### PR TITLE
fix(core): fix settings switch having unnecessary divider (Closes #937)

### DIFF
--- a/core/components/src/main/java/com/rk/components/compose/preferences/switch/PreferenceSwitch.kt
+++ b/core/components/src/main/java/com/rk/components/compose/preferences/switch/PreferenceSwitch.kt
@@ -39,7 +39,6 @@ fun PreferenceSwitch(
     onLongClick: (() -> Unit)? = null,
     enabled: Boolean = true,
     onClick: (() -> Unit)? = null,
-
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 

--- a/core/main/src/main/java/com/rk/components/SettingsToggle.kt
+++ b/core/main/src/main/java/com/rk/components/SettingsToggle.kt
@@ -10,32 +10,30 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.rk.components.compose.preferences.base.PreferenceTemplate
 import com.rk.components.compose.preferences.switch.PreferenceSwitch
-import com.rk.resources.getString
-import com.rk.resources.strings
-import com.rk.settings.app.InbuiltFeatures
-import com.rk.utils.dialog
 
 @Composable
-fun BasicToggle(modifier: Modifier = Modifier,label: String,description: String? = null,checked: Boolean,onSwitch:(Boolean)-> Unit) {
-    PreferenceSwitch(checked =  checked,
+fun BasicToggle(
+    modifier: Modifier = Modifier,
+    label: String,
+    description: String? = null,
+    checked: Boolean,
+    onSwitch: (Boolean) -> Unit
+) {
+    PreferenceSwitch(
+        checked = checked,
         description = description,
         onCheckedChange = {
             onSwitch.invoke(it)
         },
-        label = label,
-        onClick = {
-            onSwitch.invoke(checked.not())
-        })
+        label = label
+    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -73,22 +71,11 @@ fun SettingsToggle(
                 } else {
                     sideEffect?.invoke(state.value)
                 }
-
             },
             label = label,
             modifier = modifier,
             description = description,
-            enabled = isEnabled,
-            onClick = {
-                if (isSwitchLocked.not()) {
-                    state.value = !state.value
-                }
-                if (reactiveSideEffect != null) {
-                    state.value = reactiveSideEffect.invoke(state.value) == true
-                } else {
-                    sideEffect?.invoke(state.value)
-                }
-            }
+            enabled = isEnabled
         )
     } else {
         val interactionSource = remember { MutableInteractionSource() }

--- a/core/main/src/main/java/com/rk/settings/developer_options/DeveloperOptions.kt
+++ b/core/main/src/main/java/com/rk/settings/developer_options/DeveloperOptions.kt
@@ -65,6 +65,7 @@ fun DeveloperOptions(modifier: Modifier = Modifier, navController: NavController
                     })
                 }
             )
+
             SettingsToggle(
                 label = stringResource(strings.memory_usage),
                 description = memoryUsage.value,
@@ -72,39 +73,24 @@ fun DeveloperOptions(modifier: Modifier = Modifier, navController: NavController
                 default = false,
             )
 
-            var state by remember {
-                mutableStateOf(Settings.strict_mode)
-            }
-            PreferenceSwitch(checked = state,
-                onCheckedChange = {
-                    state = it
-                    Settings.strict_mode = state
-                },
+            SettingsToggle(
                 label = stringResource(strings.strict_mode),
                 description = stringResource(strings.strict_mode_desc),
-                modifier = modifier,
-                onClick = {
-                    state = !state
-                    Settings.strict_mode = state
-                })
+                showSwitch = true,
+                default = Settings.strict_mode,
+                sideEffect = {
+                    Settings.strict_mode = it
+                }
+            )
 
-
-            var state1 by remember {
-                mutableStateOf(Settings.anr_watchdog)
-            }
-            PreferenceSwitch(checked = state1,
-                onCheckedChange = {
-                    state1 = it
-                    Settings.anr_watchdog = state1
-                },
+            SettingsToggle(
                 label = stringResource(strings.anr_watchdog),
                 description = stringResource(strings.anr_watchdog_desc),
-                modifier = modifier,
-                onClick = {
-                    state1 = !state1
-                    Settings.anr_watchdog = state1
-                })
-
+                default = Settings.anr_watchdog,
+                sideEffect = {
+                    Settings.anr_watchdog = it
+                }
+            )
 
             SettingsToggle(
                 label = stringResource(strings.verbose_errors),
@@ -116,7 +102,6 @@ fun DeveloperOptions(modifier: Modifier = Modifier, navController: NavController
                 }
             )
 
-
             SettingsToggle(
                 label = stringResource(strings.desktop_mode),
                 description = stringResource(strings.desktop_mode_desc),
@@ -126,7 +111,6 @@ fun DeveloperOptions(modifier: Modifier = Modifier, navController: NavController
                     Settings.desktopMode = it
                 }
             )
-
 
             SettingsToggle(
                 label = "Theme Flipper",
@@ -140,16 +124,8 @@ fun DeveloperOptions(modifier: Modifier = Modifier, navController: NavController
                     }
                 }
             )
-
-
-
-
-
-
-
         }
     }
-
 }
 
 

--- a/core/main/src/main/java/com/rk/settings/terminal/SettingsTerminalScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/terminal/SettingsTerminalScreen.kt
@@ -5,7 +5,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -35,7 +34,6 @@ import com.rk.components.SettingsToggle
 import com.rk.components.ValueSlider
 import com.rk.settings.app.InbuiltFeatures
 import com.rk.terminal.terminalView
-import com.rk.utils.isAppInstalled
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -55,12 +53,16 @@ fun SettingsTerminalScreen() {
 
         if (InbuiltFeatures.debugMode.state.value){
             PreferenceGroup {
-                SettingsToggle(label = stringResource(strings.failsafe_mode), description = stringResource(strings.failsafe_mode_desc), default = !Settings.sandbox, sideEffect = {
-                    Settings.sandbox = !it
-                })
+                SettingsToggle(
+                    label = stringResource(strings.failsafe_mode),
+                    description = stringResource(strings.failsafe_mode_desc),
+                    default = !Settings.sandbox,
+                    sideEffect = {
+                        Settings.sandbox = !it
+                    }
+                )
             }
         }
-
 
         ValueSlider(
             label = {
@@ -131,8 +133,6 @@ fun SettingsTerminalScreen() {
                         }
                     }
                 }
-
-
             }
 
             SettingsToggle(
@@ -252,7 +252,6 @@ fun SettingsTerminalScreen() {
             )
         }
 
-
         PreferenceGroup {
             SettingsToggle(
                 label = stringResource(strings.project_as_wk), description = stringResource(strings.project_as_wk_desc),
@@ -263,36 +262,32 @@ fun SettingsTerminalScreen() {
                 showSwitch = true,
             )
 
-
-            var state by remember { mutableStateOf(Settings.expose_home_dir) }
-            val sideEffect: (Boolean) -> Unit = {
-                if (it) {
-                    dialog(
-                        context = activity,
-                        title = strings.attention.getString(),
-                        msg = strings.saf_expose_warning.getString(),
-                        okString = strings.continue_action,
-                        onCancel = {},
-                        onOk = {
-                            Settings.expose_home_dir = true
-                            DocumentProvider.setDocumentProviderEnabled(context, true)
-                            state = true
-                        })
-                } else {
-                    Settings.expose_home_dir = false
-                    state = false
-                    DocumentProvider.setDocumentProviderEnabled(context, false)
-                }
-            }
-
+            var exposeHomeDirState by remember { mutableStateOf(Settings.expose_home_dir) }
             PreferenceSwitch(
-                checked = state,
-                onCheckedChange = { sideEffect(it) },
+                checked = exposeHomeDirState,
+                onCheckedChange = {
+                    if (it) {
+                        dialog(
+                            context = activity,
+                            title = strings.attention.getString(),
+                            msg = strings.saf_expose_warning.getString(),
+                            okString = strings.continue_action,
+                            onCancel = {},
+                            onOk = {
+                                Settings.expose_home_dir = true
+                                DocumentProvider.setDocumentProviderEnabled(context, true)
+                                exposeHomeDirState = true
+                            }
+                        )
+                    } else {
+                        Settings.expose_home_dir = false
+                        exposeHomeDirState = false
+                        DocumentProvider.setDocumentProviderEnabled(context, false)
+                    }
+                },
                 label = stringResource(strings.expose_saf),
-                description = stringResource(strings.expose_saf_desc),
-                onClick = { sideEffect(!state) })
-
+                description = stringResource(strings.expose_saf_desc)
+            )
         }
-
     }
 }


### PR DESCRIPTION
This PR closes issue #937 by removing the unnecessary divider for the `PreferenceSwitch`es in the settings.

Beyond that, it also migrates two `PreferenceSwitch` usages to the `SettingsToggle`.

Closes: #937