### PR TITLE
fix(core): allow 0 as a value for the editor colors

### DIFF
--- a/core/main/src/main/java/com/rk/theme/EditorColorSchemeBuilder.kt
+++ b/core/main/src/main/java/com/rk/theme/EditorColorSchemeBuilder.kt
@@ -14,6 +14,7 @@ private val EDITOR_COLOR_MAPPING: Map<String, Int> by lazy {
 }
 
 private fun String.toColorIntSafe(): Int = runCatching {
+    if (this == "0") return 0
     toColorInt()
 }.getOrElse { exception ->
     toast(exception.message)


### PR DESCRIPTION
This PR fixes a missing edge-case in the `EditorColorSchemeBuilder` that caused all themes that were converted with [vscode2xed](https://github.com/KonerDev/vscode2xed) to show `Unknown color` toasts at startup of the app.

The missing edge-case is that some `EditorColorScheme` colors support 0 as a valid value:
<img width="796" height="98" alt="grafik" src="https://github.com/user-attachments/assets/ed00b03b-ccd1-4338-93f0-f33f078d184f" />
