### PR TITLE
feat(core): implement `ImageProvider`

### DIFF
--- a/core/main/build.gradle.kts
+++ b/core/main/build.gradle.kts
@@ -7,26 +7,19 @@ plugins {
     alias(libs.plugins.ktfmt)
 }
 
-val gitCommitHash: Provider<String> = providers.exec {
-    commandLine("git", "rev-parse", "--short=8", "HEAD")
-}.standardOutput.asText.map { it.trim() }
+val gitCommitHash: Provider<String> =
+    providers.exec { commandLine("git", "rev-parse", "--short=8", "HEAD") }.standardOutput.asText.map { it.trim() }
 
+val fullGitCommitHash: Provider<String> = providers.exec { commandLine("git", "rev-parse", "HEAD") }.standardOutput.asText.map { it.trim() }
 
-val fullGitCommitHash: Provider<String> = providers.exec {
-    commandLine("git", "rev-parse", "HEAD")
-}.standardOutput.asText.map { it.trim() }
-
-val gitCommitDate: Provider<String> = providers.exec {
-    commandLine("git", "show", "-s", "--format=%cI", "HEAD")
-}.standardOutput.asText.map { it.trim() }
+val gitCommitDate: Provider<String> =
+    providers.exec { commandLine("git", "show", "-s", "--format=%cI", "HEAD") }.standardOutput.asText.map { it.trim() }
 
 android {
     namespace = "com.rk.xededitor"
     compileSdk = 36
 
-    buildFeatures {
-        buildConfig = true
-    }
+    buildFeatures { buildConfig = true }
 
     defaultConfig {
         minSdk = 26
@@ -43,9 +36,7 @@ android {
             isMinifyEnabled = false
             isShrinkResources = false
 
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
-            )
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
 
         debug {
@@ -59,32 +50,27 @@ android {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
     }
-    kotlin {
-        jvmToolchain(21)
-    }
+    kotlin { jvmToolchain(21) }
 
     buildFeatures {
         viewBinding = true
         compose = true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "2.2.20"
+    composeOptions { kotlinCompilerExtensionVersion = "2.2.20" }
+}
+
+val runPrecompileScript by
+    tasks.registering(GenerateSupportedLocales::class) {
+        group = "build setup"
+        description = "Update supported_locales.json in assets"
+
+        resDir.set(layout.projectDirectory.dir("../resources/src/main/res"))
+
+        outputFile.set(layout.projectDirectory.file("src/main/assets/supported_locales.json"))
     }
-}
 
-val runPrecompileScript by tasks.registering(GenerateSupportedLocales::class) {
-    group = "build setup"
-    description = "Update supported_locales.json in assets"
-
-    resDir.set(layout.projectDirectory.dir("../resources/src/main/res"))
-
-    outputFile.set(layout.projectDirectory.file("src/main/assets/supported_locales.json"))
-}
-
-tasks.named("preBuild") {
-    dependsOn(runPrecompileScript)
-}
+tasks.named("preBuild") { dependsOn(runPrecompileScript) }
 
 dependencies {
     implementation(libs.appcompat)
@@ -120,8 +106,8 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.androidx.documentfile)
     implementation(libs.compose.dnd)
- implementation(libs.androidx.material.icons.core)
-    //implementation("androidx.compose.material:material-icons-extended:1.7.8")
+    implementation(libs.androidx.material.icons.core)
+    // implementation("androidx.compose.material:material-icons-extended:1.7.8")
 
     // Modules
     implementation(project(":editor"))
@@ -129,36 +115,37 @@ dependencies {
     implementation(project(":language-textmate"))
     implementation(project(":core:resources"))
     implementation(project(":core:components"))
-    //implementation(project(":core:extension"))
+    // implementation(project(":core:extension"))
     implementation(project(":core:terminal-view"))
     implementation(project(":core:terminal-emulator"))
     implementation(libs.androidx.lifecycle.process)
+    implementation(libs.androidsvg.aar)
 }
 
 abstract class GenerateSupportedLocales : DefaultTask() {
-    @get:InputDirectory
-    abstract val resDir: DirectoryProperty
+    @get:InputDirectory abstract val resDir: DirectoryProperty
 
-    @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+    @get:OutputFile abstract val outputFile: RegularFileProperty
 
     @TaskAction
     fun generate() {
         val locales = mutableListOf<String>()
 
-        resDir.get().asFile.listFiles { file ->
-            file.isDirectory && file.name.startsWith("values")
-        }?.forEach { dir ->
-            val folderName = dir.name
-            val locale = when {
-                folderName == "values" -> "en"
-                folderName.startsWith("values-") ->
-                    folderName.removePrefix("values-").replace("-r", "-")
+        resDir
+            .get()
+            .asFile
+            .listFiles { file -> file.isDirectory && file.name.startsWith("values") }
+            ?.forEach { dir ->
+                val folderName = dir.name
+                val locale =
+                    when {
+                        folderName == "values" -> "en"
+                        folderName.startsWith("values-") -> folderName.removePrefix("values-").replace("-r", "-")
 
-                else -> null
+                        else -> null
+                    }
+                locale?.let { locales.add(it) }
             }
-            locale?.let { locales.add(it) }
-        }
 
         locales.sort()
 
@@ -169,4 +156,3 @@ abstract class GenerateSupportedLocales : DefaultTask() {
         logger.lifecycle("✅ Generated ${outFile.path}")
     }
 }
-

--- a/core/main/src/main/java/com/rk/App.kt
+++ b/core/main/src/main/java/com/rk/App.kt
@@ -10,20 +10,21 @@ import com.rk.activities.main.SessionManager
 import com.rk.crashhandler.CrashHandler
 import com.rk.editor.Editor
 import com.rk.editor.FontCache
+import com.rk.lsp.MarkdownImageProvider
 import com.rk.resources.Res
 import com.rk.settings.Preference
 import com.rk.settings.Settings
-import com.rk.xededitor.BuildConfig
 import com.rk.settings.debugOptions.startThemeFlipperIfNotRunning
 import com.rk.theme.updateThemes
 import com.rk.utils.application
+import com.rk.xededitor.BuildConfig
+import java.io.File
+import java.util.Locale
+import java.util.concurrent.Executors
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import java.io.File
-import java.util.Locale
-import java.util.concurrent.Executors
 
 @OptIn(DelicateCoroutinesApi::class)
 class App : Application() {
@@ -37,10 +38,7 @@ class App : Application() {
         }
 
         val isFDroid by lazy {
-            val targetSdkVersion =
-                application!!
-                    .applicationInfo
-                    .targetSdkVersion
+            val targetSdkVersion = application!!.applicationInfo.targetSdkVersion
             targetSdkVersion == 28
         }
     }
@@ -56,6 +54,7 @@ class App : Application() {
         Res.application = this
 
         updateThemes()
+        MarkdownImageProvider.register()
 
         val currentLocale = Locale.forLanguageTag(Settings.currentLang)
         val appLocale = LocaleListCompat.create(currentLocale)
@@ -64,9 +63,7 @@ class App : Application() {
         GlobalScope.launch(Dispatchers.IO) {
             launch { Editor.initGrammarRegistry() }
 
-            launch(Dispatchers.IO) {
-                SessionManager.preloadSession()
-            }
+            launch(Dispatchers.IO) { SessionManager.preloadSession() }
 
             launch(Dispatchers.IO) {
                 val fontPath = Settings.selected_font_path
@@ -78,17 +75,10 @@ class App : Application() {
             }
 
             if (Settings.restore_sessions) {
-                launch(Dispatchers.IO) {
-                    Preference.preloadAllSettings()
-                }
+                launch(Dispatchers.IO) { Preference.preloadAllSettings() }
             }
 
-            launch {
-                DocumentProvider.setDocumentProviderEnabled(
-                    this@App,
-                    Settings.expose_home_dir,
-                )
-            }
+            launch { DocumentProvider.setDocumentProviderEnabled(this@App, Settings.expose_home_dir) }
 
             launch(Dispatchers.IO) {
                 getTempDir().apply {
@@ -98,9 +88,7 @@ class App : Application() {
                 }
             }
 
-            launch {
-                runCatching { UpdateChecker.checkForUpdates("dev") }
-            }
+            launch { runCatching { UpdateChecker.checkForUpdates("dev") } }
 
             Settings.visits = Settings.visits + 1
 
@@ -117,8 +105,7 @@ class App : Application() {
 
         if (BuildConfig.DEBUG || Settings.strict_mode) {
             StrictMode.setVmPolicy(
-                StrictMode.VmPolicy
-                    .Builder()
+                StrictMode.VmPolicy.Builder()
                     .apply {
                         detectAll()
                         penaltyLog()
@@ -128,7 +115,8 @@ class App : Application() {
                                 violation.cause?.let { throw it }
                             }
                         }
-                    }.build(),
+                    }
+                    .build()
             )
         }
     }

--- a/core/main/src/main/java/com/rk/lsp/MarkdownImageProvider.kt
+++ b/core/main/src/main/java/com/rk/lsp/MarkdownImageProvider.kt
@@ -1,0 +1,103 @@
+package com.rk.lsp
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.util.Base64
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.scale
+import com.caverock.androidsvg.SVG
+import io.github.rosemoe.sora.lsp.editor.text.SimpleMarkdownRenderer
+
+/**
+ * A custom image provider implementation for rendering images within Markdown content in the editor.
+ *
+ * This class specifically handles Base64 encoded strings. It supports loading and rendering:
+ * - **SVG Images:** Parsed using AndroidSVG, with automatic scaling to ensure a minimum visibility size.
+ * - **Raster Images:** Decoded via `BitmapFactory` (e.g., PNG, JPEG), with automatic downscaling to fit within a maximum width.
+ *
+ * Implements [SimpleMarkdownRenderer.ImageProvider] to integrate with the sora-editor's Markdown rendering.
+ */
+class MarkdownImageProvider : SimpleMarkdownRenderer.ImageProvider {
+    companion object {
+        fun register() {
+            SimpleMarkdownRenderer.globalImageProvider = MarkdownImageProvider()
+        }
+    }
+
+    /**
+     * Attempts to load an image from the given source string.
+     *
+     * @param src Source string (e.g., data URI, file path, URL)
+     * @return A [Drawable] if successful, or null if the image cannot be loaded.
+     */
+    override fun load(src: String): Drawable? {
+        if (!src.startsWith("data:")) return null
+
+        val mime = src.substringAfter("data:").substringBefore(";")
+        val payload = src.substringAfter("base64,", "")
+
+        if (payload.isEmpty()) return null
+
+        val imageByteArray =
+            try {
+                Base64.decode(payload, Base64.DEFAULT)
+            } catch (_: Exception) {
+                return null
+            }
+
+        return when (mime) {
+            "image/svg+xml" -> loadSvg(imageByteArray)
+            else -> loadRaster(imageByteArray)
+        }
+    }
+
+    private fun loadSvg(imageByteArray: ByteArray): Drawable? {
+        val svgText = String(imageByteArray)
+        val svg =
+            try {
+                SVG.getFromString(svgText)
+            } catch (_: Exception) {
+                return null
+            }
+
+        val originalWidth = svg.documentWidth
+        val originalHeight = svg.documentHeight
+
+        val clampedWidth = originalWidth.coerceIn(175f, 800f)
+        val clampedHeight = originalHeight.coerceIn(175f, 800f)
+
+        val scaleX = clampedWidth / originalWidth
+        val scaleY = clampedHeight / originalHeight
+        val scale = minOf(scaleX, scaleY)
+
+        val scaledWidth = (originalWidth * scale).toInt()
+        val scaledHeight = (originalHeight * scale).toInt()
+
+        val bitmap = createBitmap(scaledWidth, scaledHeight)
+        val canvas = Canvas(bitmap)
+
+        canvas.scale(scale, scale)
+        svg.renderToCanvas(canvas)
+
+        return BitmapDrawable(bitmap)
+    }
+
+    private fun loadRaster(imageByteArray: ByteArray): Drawable? {
+        val bitmap = BitmapFactory.decodeByteArray(imageByteArray, 0, imageByteArray.size) ?: return null
+        val scaledBitmap = scaleIfNeeded(bitmap, 800)
+        return BitmapDrawable(scaledBitmap)
+    }
+
+    /** Scale down a bitmap to maxWidth preserving aspect ratio. If bitmap width is already <= maxWidth, the original bitmap is returned. */
+    private fun scaleIfNeeded(bmp: Bitmap, maxWidth: Int): Bitmap {
+        val currentWidth = bmp.width
+        if (currentWidth <= maxWidth) return bmp
+        val ratio = maxWidth.toFloat() / currentWidth.toFloat()
+
+        val newHeight = (bmp.height * ratio).toInt()
+        return bmp.scale(maxWidth, newHeight)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ runner = "1.7.0"
 benchmarkJunit4 = "1.4.1"
 lifecycleProcess = "2.10.0"
 composeDnd = "0.4.0"
+androidsvgAar = "1.4"
 
 [libraries]
 androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
@@ -125,6 +126,7 @@ androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profi
 androidx-runner = { group = "androidx.test", name = "runner", version.ref = "runner" }
 androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-junit4", version.ref = "benchmarkJunit4" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
+androidsvg-aar = { group = "com.caverock", name = "androidsvg-aar", version.ref = "androidsvgAar" }
 
 [plugins]
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
## Description
This PR implements an `ImageProvider` for the LSP popup windows (signature, hover, etc.) that supports SVG files. This addition required a new dependency (`androidsvg` for parsing and displaying the SVG file).

## Screenshots
For example, the built-in HTML and CSS language servers display little baseline icons to represent the compatibility.
<img width="970" height="827" alt="grafik" src="https://github.com/user-attachments/assets/cabd28e7-5ef9-4b91-98b8-23bafc2e9752" />
