### PR TITLE
fix(core): fix crash when LSP symbol rename fails

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainContent.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContent.kt
@@ -82,7 +82,7 @@ fun MainContent(
 
             CommandPalette(
                 progress = if (mainViewModel.showCommandPalette) 1f else mainViewModel.draggingPaletteProgress.value,
-                commands = CommandProvider.globalCommands,
+                commands = CommandProvider.commandList,
                 lastUsedCommand = lastUsedCommand,
                 initialChildCommands = mainViewModel.commandPaletteInitialChildCommands,
                 initialPlaceholder = mainViewModel.commandPaletteInitialPlaceholder,

--- a/core/main/src/main/java/com/rk/commands/CommandProvider.kt
+++ b/core/main/src/main/java/com/rk/commands/CommandProvider.kt
@@ -48,7 +48,7 @@ import com.rk.utils.errorDialog
 import kotlinx.coroutines.launch
 
 object CommandProvider {
-    var globalCommands = listOf<Command>()
+    var commandList = listOf<Command>()
 
     lateinit var TerminalCommand: TerminalCommand
     lateinit var SettingsCommand: SettingsCommand
@@ -84,7 +84,7 @@ object CommandProvider {
     lateinit var FormatDocumentCommand: FormatDocumentCommand
     lateinit var FormatSelectionCommand: FormatSelectionCommand
 
-    fun buildCommands(mainViewModel: MainViewModel): List<Command> {
+    fun buildCommands(mainViewModel: MainViewModel) {
         val mainActivity = MainActivity.instance!!
         val commandContext = CommandContext(mainActivity, mainViewModel)
 
@@ -122,7 +122,8 @@ object CommandProvider {
         FormatDocumentCommand = FormatDocumentCommand(commandContext)
         FormatSelectionCommand = FormatSelectionCommand(commandContext)
 
-        return listOf(
+        commandList =
+            listOf(
                 TerminalCommand,
                 SettingsCommand,
                 NewFileCommand,
@@ -158,7 +159,6 @@ object CommandProvider {
                 FormatSelectionCommand,
                 *getMutatorCommands(commandContext).toTypedArray(),
             )
-            .also { globalCommands = it }
     }
 
     fun getMutatorCommands(commandContext: CommandContext): List<Command> {
@@ -193,12 +193,12 @@ object CommandProvider {
 
     fun getForId(id: String, commands: List<Command>): Command? = findRecursive(id, commands)
 
-    fun getForId(id: String): Command? = findRecursive(id, globalCommands)
+    fun getForId(id: String): Command? = findRecursive(id, commandList)
 
-    fun getParentCommand(command: Command): Command? = findParent(command, globalCommands)
+    fun getParentCommand(command: Command): Command? = findParent(command, commandList)
 
     fun getForKeyCombination(keyCombination: KeyCombination): Command? {
-        return globalCommands.find { it.defaultKeybinds == keyCombination }
+        return commandList.find { it.defaultKeybinds == keyCombination }
     }
 
     private fun findParent(target: Command, commands: List<Command>): Command? {

--- a/core/main/src/main/java/com/rk/commands/KeybindingsManager.kt
+++ b/core/main/src/main/java/com/rk/commands/KeybindingsManager.kt
@@ -111,7 +111,7 @@ object KeybindingsManager {
         val customCommandIds = customKeybinds.map { it.commandId }.toSet()
 
         // If no custom keybind is set, proceed with default keybindings
-        for (command in CommandProvider.globalCommands) {
+        for (command in CommandProvider.commandList) {
             if (customCommandIds.contains(command.id)) continue
             command.defaultKeybinds?.let { keybindMap[it] = command.id }
         }

--- a/core/main/src/main/java/com/rk/settings/editor/EditExtraKeys.kt
+++ b/core/main/src/main/java/com/rk/settings/editor/EditExtraKeys.kt
@@ -188,7 +188,7 @@ fun EditExtraKeys(modifier: Modifier = Modifier) {
 @Composable
 private fun CommandSelectionDialog(commandIds: SnapshotStateList<String>, onDismiss: () -> Unit) {
     val dialogCommands =
-        CommandProvider.globalCommands.map { command ->
+        CommandProvider.commandList.map { command ->
             val existingCommands = command.childCommands
             val patchedChildCommands =
                 if (existingCommands.isEmpty()) {

--- a/core/main/src/main/java/com/rk/settings/editor/EditToolbarActions.kt
+++ b/core/main/src/main/java/com/rk/settings/editor/EditToolbarActions.kt
@@ -144,7 +144,7 @@ fun EditToolbarActions(modifier: Modifier = Modifier) {
 @Composable
 private fun CommandSelectionDialog(commandIds: SnapshotStateList<String>, onDismiss: () -> Unit) {
     val dialogCommands =
-        CommandProvider.globalCommands.map { command ->
+        CommandProvider.commandList.map { command ->
             val existingCommands = command.childCommands
             val patchedChildCommands =
                 if (existingCommands.isEmpty()) {

--- a/core/main/src/main/java/com/rk/settings/keybinds/KeybindingsScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/keybinds/KeybindingsScreen.kt
@@ -67,7 +67,7 @@ fun KeybindingsScreen() {
     var refreshTrigger by remember { mutableIntStateOf(0) }
     var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
 
-    val commands = CommandProvider.globalCommands
+    val commands = CommandProvider.commandList
     val filteredCommands =
         if (searchQuery.text.isEmpty()) {
             commands


### PR DESCRIPTION
- Fix `NullPointerException` when LSP symbol rename fails (e.g. in HTML files; see #863)
- Few changes to `CommandProvider`