### PR TITLE
fix(core): fix crash because of duplicate command (Closes #1077)

### DIFF
--- a/core/main/src/main/java/com/rk/commands/CommandProvider.kt
+++ b/core/main/src/main/java/com/rk/commands/CommandProvider.kt
@@ -82,7 +82,6 @@ object CommandProvider {
         val commandContext = CommandContext(mainActivity, mainViewModel)
 
         registerBuiltin(DocumentationCommand(commandContext)) { DocumentationCommand = it }
-        registerBuiltin(DocumentationCommand(commandContext)) { DocumentationCommand = it }
         registerBuiltin(TerminalCommand(commandContext)) { TerminalCommand = it }
         registerBuiltin(SettingsCommand(commandContext)) { SettingsCommand = it }
         registerBuiltin(NewFileCommand(commandContext)) { NewFileCommand = it }


### PR DESCRIPTION
Removes duplicate command and therefore closes #1077.