### PR TITLE
fix(core): remove old `plugin.json` fallback

### DIFF
--- a/core/extension/src/main/java/com/rk/extension/ExtensionManager.kt
+++ b/core/extension/src/main/java/com/rk/extension/ExtensionManager.kt
@@ -38,18 +38,14 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
     }
 
     internal fun validateExtensionDir(dir: File): Result<ExtensionInfo> {
-        var extensionJson = dir.resolve("plugin.json")
+        val extensionJson = dir.resolve("manifest.json")
         if (!extensionJson.exists()) {
-            if (dir.resolve("manifest.json").exists()) {
-                extensionJson = dir.resolve("manifest.json")
-            } else {
-                return Result.failure(Exception("Missing manifest.json"))
-            }
+            return Result.failure(Exception("Missing manifest.json"))
         }
         val extensionInfo =
             runCatching { Gson().fromJson(extensionJson.readText(), ExtensionInfo::class.java) }
                 .getOrElse {
-                    return Result.failure(Exception("Invalid plugin.json", it))
+                    return Result.failure(Exception("Invalid manifest.json", it))
                 }
 
         val hasApk = dir.listFiles()?.any { it.extension == "apk" } == true
@@ -153,10 +149,7 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
         withContext(Dispatchers.IO) {
             baseDir.listFiles()?.forEach { dir ->
                 if (dir.isDirectory) {
-                    var extensionJson = dir.resolve("plugin.json")
-                    if (extensionJson.exists().not()) {
-                        extensionJson = dir.resolve("manifest.json")
-                    }
+                    val extensionJson = dir.resolve("manifest.json")
                     if (extensionJson.exists()) {
                         runCatching {
                             val extensionInfo = Gson().fromJson(extensionJson.readText(), ExtensionInfo::class.java)

--- a/core/extension/src/main/java/com/rk/extension/ExtensionRegistry.kt
+++ b/core/extension/src/main/java/com/rk/extension/ExtensionRegistry.kt
@@ -17,11 +17,11 @@ object ExtensionRegistry {
 
     suspend fun fetchExtensions() =
         withContext(Dispatchers.IO) {
-            val extensions = GitHubApi.fetchContents("plugins")
+            val extensions = GitHubApi.fetchContents("extensions")
             extensions
                 .filter { it.type == "dir" }
                 .mapNotNull { extDir ->
-                    val extensionPath = "${extDir.path}/plugin.json"
+                    val extensionPath = "${extDir.path}/extension.json"
                     val extensionInfo =
                         try {
                             val extensionFileInfo = GitHubApi.fetchContents(extensionPath).first()
@@ -65,7 +65,7 @@ object ExtensionRegistry {
 
     suspend fun downloadExtension(id: ExtensionId, targetDir: File) =
         withContext(Dispatchers.IO) {
-            val contents = GitHubApi.fetchContents("plugins/$id")
+            val contents = GitHubApi.fetchContents("extensions/$id")
 
             contents.forEach { item ->
                 when (item.type) {

--- a/core/main/src/main/java/com/rk/settings/extension/Extensions.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/Extensions.kt
@@ -162,7 +162,7 @@ fun Extensions(modifier: Modifier = Modifier) {
         Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
             InfoBlock(
                 modifier =
-                    Modifier.clickable { activity?.openUrl("https://xed-editor.github.io/Xed-Docs/docs/plugins/") },
+                    Modifier.clickable { activity?.openUrl("https://xed-editor.github.io/Xed-Docs/docs/extensions/") },
                 icon = { Icon(imageVector = Icons.Outlined.Info, contentDescription = null) },
                 text = stringResource(strings.info_ext),
             )


### PR DESCRIPTION
## Refactor
- Remove old `plugin.json` fallback (only support `manifest.json` now)
- Replace `plugin` term with `extension` everywhere for consistency

## TODOS
@RohitKushvaha01 
- [x] Rename the [`PluginRegistry`](https://github.com/Xed-Editor/PluginRegistry) repo to `Extension-Registry`
- [x] Rename the [`pluginTemplate`](https://github.com/Xed-Editor/pluginTemplate) repo to `Extension-Template` (to match naming conventions of `Theme-Template`)