### PR TITLE
fix(core): fix tab restoration issues

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainActivity.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainActivity.kt
@@ -119,6 +119,7 @@ class MainActivity : AppCompatActivity() {
 
             val file = uri.toFileObject(expectedIsFile = true)
 
+            viewModel.sessionRestored.await()
             viewModel.newTab(file, switchToTab = true)
             setIntent(Intent())
         }

--- a/core/main/src/main/java/com/rk/activities/main/MainContent.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContent.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -122,28 +121,28 @@ fun MainContent(
                 }
             }
 
-            LaunchedEffect(mainViewModel.tabs) {
-                if (mainViewModel.tabs.size != pagerState.pageCount) {
-                    if (Settings.smooth_tabs) {
-                        pagerState.animateScrollToPage(mainViewModel.currentTabIndex)
-                    } else {
-                        pagerState.scrollToPage(mainViewModel.currentTabIndex)
-                    }
-                }
-            }
+            //            LaunchedEffect(mainViewModel.tabs) {
+            //                if (mainViewModel.tabs.size != pagerState.pageCount) {
+            //                    if (Settings.smooth_tabs) {
+            //                        pagerState.animateScrollToPage(mainViewModel.currentTabIndex)
+            //                    } else {
+            //                        pagerState.scrollToPage(mainViewModel.currentTabIndex)
+            //                    }
+            //                }
+            //            }
 
-            LaunchedEffect(pagerState) {
-                snapshotFlow { pagerState.settledPage }
-                    .collect { settledPage ->
-                        if (
-                            mainViewModel.tabs.isNotEmpty() &&
-                                settledPage < mainViewModel.tabs.size &&
-                                mainViewModel.currentTabIndex != settledPage
-                        ) {
-                            mainViewModel.currentTabIndex = settledPage
-                        }
-                    }
-            }
+            //            LaunchedEffect(pagerState) {
+            //                snapshotFlow { pagerState.settledPage }
+            //                    .collect { settledPage ->
+            //                        if (
+            //                            mainViewModel.tabs.isNotEmpty() &&
+            //                                settledPage < mainViewModel.tabs.size &&
+            //                                mainViewModel.currentTabIndex != settledPage
+            //                        ) {
+            //                            mainViewModel.currentTabIndex = settledPage
+            //                        }
+            //                    }
+            //            }
 
             val reorderState = rememberReorderState<Tab>(dragAfterLongPress = true)
 

--- a/core/main/src/main/java/com/rk/tabs/base/TabRegistry.kt
+++ b/core/main/src/main/java/com/rk/tabs/base/TabRegistry.kt
@@ -7,7 +7,7 @@ import com.rk.tabs.image.ImageTab
 object TabRegistry {
     fun getTab(file: FileObject): Tab? {
         val ext = file.getName().substringAfterLast('.', "")
-        val type = FileType.Companion.fromExtension(ext)
+        val type = FileType.fromExtension(ext)
 
         return when (type) {
             FileType.IMAGE -> ImageTab(file)


### PR DESCRIPTION
This PR closes #1095

## Bug fixes
- Fix crash when restoring file that was changed externally
- Fix conflict of tab restoration and intent handling (#1095)
- Fix duplicate tab switching issue
	> @RohitKushvaha01 I commented out the code in `MainContent.kt`. This is no longer required, right? It seems to lead to race conditions.