### PR TITLE
fix: make brand names ("Git" and "GitHub") no longer translatable

### DIFF
--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -197,7 +197,7 @@
     <string name="about_desc">About Xed-Editor</string>
     <string name="version">Version</string>
     <string name="version_code">Version code</string>
-    <string name="github">GitHub</string>
+    <string name="github" translatable="false">GitHub</string>
     <string name="github_desc">Star it on GitHub 🤩</string>
     <string name="telegram">Telegram group</string>
     <string name="telegram_desc">Report issues, feature requests etc.</string>
@@ -627,7 +627,7 @@
     <string name="extension_validation_failed">Extension validation failed</string>
     <string name="general">General</string>
     <string name="advanced">Advanced</string>
-    <string name="git">Git</string>
+    <string name="git" translatable="false">Git</string>
     <string name="git_desc">Configure version control system</string>
     <string name="credentials">Credentials</string>
     <string name="credentials_desc">Credentials for accessing remote repositories</string>


### PR DESCRIPTION
Make brand names such as `Git` and `GitHub` no longer translatable. They should be the same in every language.