### PR TITLE
fix: fix tab wipe by adding unique keys to pager

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainContent.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContent.kt
@@ -205,6 +205,7 @@ fun MainContent(
                 modifier = Modifier.fillMaxSize().clipToBounds(),
                 beyondViewportPageCount = mainViewModel.tabs.size,
                 userScrollEnabled = false,
+                key = { mainViewModel.tabs.getOrNull(it).hashCode() },
             ) { page ->
                 if (page < mainViewModel.tabs.size) {
                     mainViewModel.tabs[page].Content()


### PR DESCRIPTION
This PR closes #1255 
CC: @andr0d1v 

## Change
- Add `key` parameter to the pager in `MainContent.kt` using tab hash codes to ensure proper state management and tracking during tab changes.