### PR TITLE
chore: enhance file drawer and remove debug extension

### DIFF
--- a/core/extension/src/main/java/com/rk/extension/ExtensionManager.kt
+++ b/core/extension/src/main/java/com/rk/extension/ExtensionManager.kt
@@ -61,19 +61,6 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
         withContext(Dispatchers.IO) {
             val extensions = ExtensionRegistry.fetchExtensions()
             storeExtension.clear()
-            // TODO: Remove debug line below
-            storeExtension["com.rk.store"] =
-                StoreExtension(
-                    manifest =
-                        ExtensionManifest(
-                            id = "com.rk.store",
-                            name = "Store",
-                            mainClass = "com.rk.store.Store",
-                            author = ExtensionAuthor(displayName = "KonerDev", github = "KonerDev"),
-                            repository = "https://bitbucket.org/KonerDev/Xed-Store",
-                        ),
-                    verified = true,
-                )
             storeExtension.putAll(extensions.associate { it.id to StoreExtension(it) })
         }
 

--- a/core/main/src/main/java/com/rk/commands/CommandPalette.kt
+++ b/core/main/src/main/java/com/rk/commands/CommandPalette.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -35,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -50,7 +52,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.rk.components.XedDialog
-import com.rk.components.compose.preferences.base.PreferenceTemplate
+import com.rk.components.compose.utils.addIf
 import com.rk.icons.XedIcon
 import com.rk.resources.strings
 import com.rk.settings.Settings
@@ -208,11 +210,12 @@ fun CommandItem(
             }
         }
 
-    Column {
-        PreferenceTemplate(
-            enabled = enabled,
-            modifier =
-                Modifier.clickable(
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier =
+            Modifier.fillMaxWidth()
+                .clickable(
                     enabled = enabled,
                     onClick = {
                         Settings.last_used_command = command.id
@@ -223,80 +226,77 @@ fun CommandItem(
                             command.action(ActionContext(activity!!))
                         }
                     },
-                ),
-            verticalPadding = 8.dp,
-            title = {
-                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                    XedIcon(
-                        icon = command.getIcon(),
-                        modifier = Modifier.padding(end = 8.dp).size(16.dp),
-                        contentDescription = command.getLabel(),
-                        tint =
-                            if (command is ToggleableCommand && command.isOn()) {
-                                MaterialTheme.colorScheme.primary
-                            } else LocalContentColor.current,
-                    )
-
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                            command.prefix?.let { Text(text = "$it: ", color = MaterialTheme.colorScheme.primary) }
-                            Text(
-                                text = highlightedString,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.weight(1f),
-                                color =
-                                    if (command is ToggleableCommand && command.isOn()) {
-                                        MaterialTheme.colorScheme.primary
-                                    } else {
-                                        Color.Unspecified
-                                    },
-                            )
-                            if (recentlyUsed) {
-                                Text(
-                                    text = stringResource(strings.recently_used),
-                                    fontFamily = FontFamily.Monospace,
-                                    fontSize = 10.sp,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    maxLines = 1,
-                                    modifier = Modifier.padding(start = 8.dp),
-                                )
-                            }
-                        }
-
-                        if (!isSubpage) {
-                            CommandProvider.getParentCommand(command)?.getLabel()?.let {
-                                Text(
-                                    text = it,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    fontSize = 12.sp,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                                )
-                            }
-                        }
-                    }
-                }
-            },
-            endWidget = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    keyCombination?.let {
-                        Text(
-                            text = keyCombination.getDisplayName(),
-                            fontFamily = FontFamily.Monospace,
-                            style = Typography.bodySmall,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                    if (childCommands.isNotEmpty()) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                            contentDescription = null,
-                            modifier = Modifier.height(16.dp),
-                        )
-                    }
-                }
-            },
+                )
+                .addIf(!enabled) { alpha(0.38f) }
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        XedIcon(
+            icon = command.getIcon(),
+            modifier = Modifier.size(16.dp),
+            contentDescription = command.getLabel(),
+            tint =
+                if (command is ToggleableCommand && command.isOn()) {
+                    MaterialTheme.colorScheme.primary
+                } else LocalContentColor.current,
         )
+
+        Column(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                command.prefix?.let { Text(text = "$it: ", color = MaterialTheme.colorScheme.primary) }
+                Text(
+                    text = highlightedString,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color =
+                        if (command is ToggleableCommand && command.isOn()) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            Color.Unspecified
+                        },
+                )
+                if (recentlyUsed) {
+                    Text(
+                        text = stringResource(strings.recently_used),
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 10.sp,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+
+            if (!isSubpage) {
+                CommandProvider.getParentCommand(command)?.getLabel()?.let {
+                    Text(
+                        text = it,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                    )
+                }
+            }
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            keyCombination?.let {
+                Text(
+                    text = keyCombination.getDisplayName(),
+                    fontFamily = FontFamily.Monospace,
+                    style = Typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+            if (childCommands.isNotEmpty()) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                    contentDescription = null,
+                    modifier = Modifier.height(16.dp),
+                )
+            }
+        }
     }
 }

--- a/core/main/src/main/java/com/rk/components/StateScreen.kt
+++ b/core/main/src/main/java/com/rk/components/StateScreen.kt
@@ -3,6 +3,7 @@ package com.rk.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -24,6 +25,11 @@ fun StateScreen(painter: Painter, text: String, color: Color = LocalContentColor
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Icon(painter = painter, contentDescription = null, modifier = Modifier.size(48.dp), tint = color)
-        Text(text = text, color = color, modifier = Modifier.padding(top = 8.dp), textAlign = TextAlign.Center)
+        Text(
+            text = text,
+            color = color,
+            modifier = Modifier.fillMaxWidth(0.5f).padding(top = 8.dp),
+            textAlign = TextAlign.Center,
+        )
     }
 }

--- a/core/main/src/main/java/com/rk/filetree/FileTreeNodeItem.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeNodeItem.kt
@@ -1,7 +1,9 @@
 package com.rk.filetree
 
+import androidx.compose.animation.Animatable
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
@@ -60,9 +62,20 @@ fun FileTreeNodeItem(
     val isCut = viewModel.isNodeCut(node.file)
 
     val isFileSelected = viewModel.isFileSelected(root, node.file)
-    val selectionColor = MaterialTheme.colorScheme.surfaceContainer
+    val isFileFocused = viewModel.isFileFocused(root, node.file)
 
     val context = LocalContext.current
+    val surfaceColor = MaterialTheme.colorScheme.surface
+    val selectionColor = MaterialTheme.colorScheme.primaryContainer
+
+    val nodeBackground = remember { Animatable(surfaceColor) }
+    LaunchedEffect(isFileFocused, isFileSelected) {
+        if (isFileFocused || isFileSelected) {
+            nodeBackground.animateTo(selectionColor, animationSpec = tween(300))
+        } else {
+            nodeBackground.animateTo(surfaceColor, animationSpec = tween(300))
+        }
+    }
 
     // Load children when expanded
     LaunchedEffect(node.file, isExpanded) {
@@ -101,7 +114,8 @@ fun FileTreeNodeItem(
         Row(
             modifier =
                 Modifier.addIf(isCut) { alpha(0.5f) }
-                    .addIf(isFileSelected) { background(selectionColor) }
+                    .background(nodeBackground.value)
+                    //                    .addIf(isFileFocused || isFileSelected) { background(selectionColor) }
                     .combinedClickable(
                         onClick = {
                             if (viewModel.isAnyFileSelected(root)) {

--- a/core/main/src/main/java/com/rk/filetree/FileTreeViewModel.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeViewModel.kt
@@ -131,6 +131,7 @@ class FileTreeViewModel : ViewModel() {
     // File tree
     var sortMode by mutableStateOf(SortMode.entries[Settings.sort_mode])
     private val selectedFiles = mutableStateMapOf<FileObject, List<FileObject>>()
+    private val focusedFile = mutableStateMapOf<FileObject, FileObject>()
     private val fileListCache = mutableStateMapOf<FileObject, List<FileTreeNode>>()
     private val expandedNodes = mutableStateMapOf<FileObject, Boolean>()
     private val collapsedNameCache = mutableStateMapOf<FileObject, String>()
@@ -311,7 +312,15 @@ class FileTreeViewModel : ViewModel() {
         }
     }
 
+    fun isFileFocused(projectFile: FileObject, fileObject: FileObject) = focusedFile[projectFile] == fileObject
+
     suspend fun goToFolder(projectFile: FileObject, fileObject: FileObject) {
+        focusedFile[projectFile] = fileObject
+        viewModelScope.launch {
+            delay(1000)
+            focusedFile.remove(projectFile)
+        }
+
         var currentFile: FileObject? = fileObject
         while (currentFile != null && currentFile != projectFile) {
             expandedNodes[currentFile] = true

--- a/core/main/src/main/java/com/rk/search/FileSearchDialog.kt
+++ b/core/main/src/main/java/com/rk/search/FileSearchDialog.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.rk.components.XedDialog
-import com.rk.components.compose.preferences.base.PreferenceTemplate
 import com.rk.components.compose.utils.addIf
 import com.rk.file.FileObject
 import com.rk.file.toFileWrapper
@@ -123,34 +122,34 @@ fun SearchItem(
     val isHidden = fileObject.getName().startsWith(".") || fileObject.getAbsolutePath().contains("/.")
     val fileNameColor = getGitColor(fileObject) ?: Color.Unspecified
 
-    Column {
-        PreferenceTemplate(
-            modifier =
-                Modifier.clickable(
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier =
+            Modifier.fillMaxWidth()
+                .clickable(
                     enabled = true,
                     onClick = {
                         onDismissRequest()
                         onSelect(projectFile, fileObject)
                     },
-                ),
-            verticalPadding = 8.dp,
-            title = {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Box(modifier = Modifier.addIf(isHidden) { alpha(0.5f) }) { FileIcon(file = fileObject) }
+                )
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Box(modifier = Modifier.addIf(isHidden) { alpha(0.5f) }) { FileIcon(file = fileObject) }
 
-                    Column(modifier = Modifier.padding(start = 8.dp)) {
-                        Text(text = fileObject.getAppropriateName(), color = fileNameColor)
-                        Text(
-                            text = "." + fileObject.getAbsolutePath().removePrefix(projectFile.getAbsolutePath()),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            fontSize = 12.sp,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-                        )
-                    }
-                }
-            },
-            endWidget = {},
-        )
+        Column(modifier = Modifier.padding(start = 8.dp)) {
+            Text(
+                text = fileObject.getAppropriateName(),
+                color = fileNameColor,
+                style = MaterialTheme.typography.bodyLarge,
+            )
+            Text(
+                text = "." + fileObject.getAbsolutePath().removePrefix(projectFile.getAbsolutePath()),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+            )
+        }
     }
 }


### PR DESCRIPTION
## Changes
- **Command Palette**: Refactor `CommandPalette` to use a custom `Row` layout instead of `PreferenceTemplate`, improving control over spacing and styling. Added `alpha` transparency for disabled states and refined typography.
- **File Tree**: Implement a focused file state in `FileTreeViewModel` and add an animated background transition for focused or selected nodes in `FileTreeNodeItem`.
- **File Search**: Refactor `SearchItem` to use a standard `Row` layout, ensuring consistent styling with the command palette and improving item density.
- **State Screen**: Restrict the width of text in `StateScreen` to improve readability on large displays.
- **Refactor**: Remove unused imports of `PreferenceTemplate` in multiple UI components and remove debug store extension