### PR TITLE
fix: eruda script injection logic in HttpServer

### DIFF
--- a/core/main/src/main/java/com/rk/runner/runners/web/HttpServer.kt
+++ b/core/main/src/main/java/com/rk/runner/runners/web/HttpServer.kt
@@ -57,6 +57,11 @@ class HttpServer(
 
     private suspend fun serveFileWithEruda(file: FileObject): Response {
         return try {
+            val mime = URLConnection.guessContentTypeFromName(file.getName()) ?: "application/octet-stream"
+            if (mime != MIME_HTML) {
+                return serveFileWithoutEruda(file)
+            }
+
             val darkTheme = isDarkTheme(context)
             val erudaTheme = if (amoled.value && darkTheme) "AMOLED" else if (darkTheme) "Dark" else "Light"
             val erudaScript =
@@ -70,17 +75,13 @@ class HttpServer(
 
             val html = file.getInputStream().bufferedReader().use { it.readText() }
             val injected =
-                if (html.contains("</body>", ignoreCase = true)) {
-                    html.replace("</body>", "$erudaScript</body>", ignoreCase = true)
+                if (html.contains("<head>", ignoreCase = true)) {
+                    html.replace("<head>", "<head>$erudaScript", ignoreCase = true)
                 } else {
-                    html + erudaScript
+                    erudaScript + html
                 }
 
-            newFixedLengthResponse(
-                Status.OK,
-                URLConnection.guessContentTypeFromName(file.getName()) ?: "text/html",
-                injected,
-            )
+            newFixedLengthResponse(Status.OK, mime, injected)
         } catch (_: SecurityException) {
             forbiddenError(file)
         } catch (e: Exception) {


### PR DESCRIPTION
## Changes
- Only inject Eruda script into files with an HTML MIME type.
- Move the script injection point from the end of `</body>` to the beginning of `<head>`.
- Prepend instead of append the script as a fallback if the `<head>` tag is missing.