### PR TITLE
refactor: refactor drawer state management

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainActivity.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainActivity.kt
@@ -16,10 +16,11 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.rk.commands.KeybindingsManager
+import com.rk.drawer.DrawerPersistence
+import com.rk.drawer.DrawerViewModel
 import com.rk.file.FileManager
 import com.rk.file.FilePermission
 import com.rk.file.toFileObject
-import com.rk.filetree.DrawerPersistence
 import com.rk.lsp.LspRegistry
 import com.rk.resources.getFilledString
 import com.rk.resources.strings
@@ -38,6 +39,7 @@ import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
     val viewModel: MainViewModel by viewModels()
+    val drawerViewModel: DrawerViewModel by viewModels()
     val fileManager = FileManager(this)
 
     // suspend (isForeground) -> Unit
@@ -58,7 +60,7 @@ class MainActivity : AppCompatActivity() {
         isPaused = true
         GlobalScope.launch(Dispatchers.IO) {
             SessionManager.saveSession(viewModel.tabs, viewModel.currentTabIndex)
-            DrawerPersistence.saveState()
+            DrawerPersistence.saveState(drawerViewModel)
             foregroundListener.values.forEach { it.invoke(false) }
 
             LspRegistry.updateConfiguration(this@MainActivity)

--- a/core/main/src/main/java/com/rk/activities/main/MainContent.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContent.kt
@@ -48,6 +48,7 @@ import com.mohamedrejeb.compose.dnd.reorder.rememberReorderState
 import com.rk.commands.CommandPalette
 import com.rk.commands.CommandProvider
 import com.rk.components.compose.utils.addIf
+import com.rk.drawer.DrawerViewModel
 import com.rk.editor.preloadSelectionColor
 import com.rk.filetree.FileAction
 import com.rk.filetree.FileActionContext
@@ -74,6 +75,7 @@ import kotlinx.coroutines.launch
 fun MainContent(
     innerPadding: PaddingValues,
     mainViewModel: MainViewModel,
+    drawerViewModel: DrawerViewModel,
     fileTreeViewModel: FileTreeViewModel,
     drawerState: DrawerState,
 ) {
@@ -82,7 +84,7 @@ fun MainContent(
 
     preloadSelectionColor()
 
-    FileActionDialogs(fileTreeViewModel, scope, context)
+    FileActionDialogs(drawerViewModel, fileTreeViewModel, scope, context)
 
     if (mainViewModel.isDraggingPalette || mainViewModel.showCommandPalette) {
         val lastUsedCommand = CommandProvider.getForId(Settings.last_used_command)
@@ -297,6 +299,8 @@ private fun TabItemContent(
     val context = LocalContext.current
     val density = LocalDensity.current
 
+    val drawerViewModel = (context as MainActivity).drawerViewModel
+
     val isSelected = mainViewModel.currentTabIndex == index
     val backgroundColor = MaterialTheme.colorScheme.surfaceVariant
 
@@ -382,7 +386,8 @@ private fun TabItemContent(
                                 leadingIcon = { XedIcon(action.icon, contentDescription = action.title) },
                                 enabled = action.isEnabled(it),
                                 onClick = {
-                                    val context = FileActionContext(it, root, fileTreeViewModel, context)
+                                    val context =
+                                        FileActionContext(it, root, fileTreeViewModel, drawerViewModel, context)
                                     action.action(context)
                                     showFileActionMenu = false
                                 },
@@ -395,7 +400,8 @@ private fun TabItemContent(
                                 leadingIcon = { XedIcon(action.icon, contentDescription = action.title) },
                                 enabled = action.isEnabled(files),
                                 onClick = {
-                                    val context = MultiFileActionContext(files, root, fileTreeViewModel, context)
+                                    val context =
+                                        MultiFileActionContext(files, root, fileTreeViewModel, drawerViewModel, context)
                                     action.action(context)
                                     showFileActionMenu = false
                                 },

--- a/core/main/src/main/java/com/rk/activities/main/MainContentHost.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContentHost.kt
@@ -30,11 +30,9 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.rk.components.ResponsiveDrawer
-import com.rk.filetree.DrawerContent
-import com.rk.filetree.DrawerPersistence
+import com.rk.drawer.DrawerContent
+import com.rk.drawer.DrawerPersistence
 import com.rk.filetree.FileTreeViewModel
-import com.rk.filetree.createServices
-import com.rk.filetree.isLoading
 import com.rk.git.GitViewModel
 import com.rk.resources.getString
 import com.rk.resources.strings
@@ -46,8 +44,8 @@ import com.rk.utils.dialog
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.launch
 
-var fileTreeViewModel = WeakReference<FileTreeViewModel?>(null)
 var gitViewModel = WeakReference<GitViewModel?>(null)
+var fileTreeViewModel = WeakReference<FileTreeViewModel?>(null)
 var searchViewModel = WeakReference<SearchViewModel?>(null)
 
 var snackbarHostStateRef: WeakReference<SnackbarHostState?> = WeakReference(null)
@@ -60,8 +58,8 @@ fun MainActivity.MainContentHost(
     fileTreeViewModel: FileTreeViewModel = viewModel(),
     searchViewModel: SearchViewModel = viewModel(),
 ) {
-    com.rk.activities.main.fileTreeViewModel = WeakReference(fileTreeViewModel)
     com.rk.activities.main.gitViewModel = WeakReference(gitViewModel)
+    com.rk.activities.main.fileTreeViewModel = WeakReference(fileTreeViewModel)
     com.rk.activities.main.searchViewModel = WeakReference(searchViewModel)
 
     XedTheme {
@@ -155,6 +153,7 @@ fun MainActivity.MainContentHost(
                         XedTopBar(
                             drawerState = drawerState,
                             viewModel = viewModel,
+                            drawerViewModel = drawerViewModel,
                             fullScreen = Settings.fullscreen,
                             onDrag = { dragAmount ->
                                 accumulator += dragAmount
@@ -182,19 +181,20 @@ fun MainActivity.MainContentHost(
                 ) { innerPadding ->
                     MainContent(
                         innerPadding = innerPadding,
-                        drawerState = drawerState,
                         mainViewModel = viewModel,
+                        drawerViewModel = drawerViewModel,
                         fileTreeViewModel = fileTreeViewModel,
+                        drawerState = drawerState,
                     )
                 }
             }
 
             val sheetContent: @Composable ColumnScope.() -> Unit = {
                 LaunchedEffect(Unit) {
-                    isLoading = true
-                    DrawerPersistence.restoreState()
-                    createServices()
-                    isLoading = false
+                    drawerViewModel.isLoading = true
+                    drawerViewModel.setupBuiltinServices(gitViewModel)
+                    DrawerPersistence.restoreState(drawerViewModel)
+                    drawerViewModel.isLoading = false
                 }
                 DrawerContent(Settings.fullscreen)
             }

--- a/core/main/src/main/java/com/rk/activities/main/TopBar.kt
+++ b/core/main/src/main/java/com/rk/activities/main/TopBar.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import com.rk.components.GlobalToolbarActions
 import com.rk.components.isPermanentDrawer
+import com.rk.drawer.DrawerViewModel
 import com.rk.resources.strings
 import com.rk.terminal.isV
 import com.rk.utils.toast
@@ -29,6 +30,7 @@ import kotlinx.coroutines.launch
 fun XedTopBar(
     drawerState: DrawerState,
     viewModel: MainViewModel,
+    drawerViewModel: DrawerViewModel,
     fullScreen: Boolean,
     onDrag: (Float) -> Unit = {},
     onDragEnd: () -> Unit = {},
@@ -59,7 +61,7 @@ fun XedTopBar(
                 }
             },
             actions = {
-                GlobalToolbarActions(viewModel)
+                GlobalToolbarActions(viewModel, drawerViewModel)
 
                 if (viewModel.tabs.isNotEmpty()) {
                     val tab =

--- a/core/main/src/main/java/com/rk/commands/CommandAPI.kt
+++ b/core/main/src/main/java/com/rk/commands/CommandAPI.kt
@@ -3,14 +3,21 @@ package com.rk.commands
 import android.app.Activity
 import com.rk.activities.main.MainActivity
 import com.rk.activities.main.MainViewModel
+import com.rk.drawer.DrawerViewModel
 import com.rk.editor.Editor
 import com.rk.icons.Icon
 import com.rk.lsp.LspConnector
 import com.rk.tabs.editor.EditorTab
 
-data class CommandContext(private val provider: () -> MainViewModel) {
+data class CommandContext(
+    private val mainViewModelProvider: () -> MainViewModel,
+    private val drawerViewModelProvider: () -> DrawerViewModel,
+) {
     val mainViewModel: MainViewModel
-        get() = provider()
+        get() = mainViewModelProvider()
+
+    val drawerViewModel: DrawerViewModel
+        get() = drawerViewModelProvider()
 }
 
 data class ActionContext(val currentActivity: Activity)
@@ -29,7 +36,11 @@ data class LspActionContext(
 data class LspNonActionContext(val editorTab: EditorTab, val lspConnector: LspConnector)
 
 abstract class Command {
-    protected val commandContext = CommandContext { MainActivity.instance!!.viewModel }
+    protected val commandContext =
+        CommandContext(
+            mainViewModelProvider = { MainActivity.instance!!.viewModel },
+            drawerViewModelProvider = { MainActivity.instance!!.drawerViewModel },
+        )
     abstract val id: String
     open val prefix: String? = null
 

--- a/core/main/src/main/java/com/rk/commands/global/SearchCodeCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/SearchCodeCommand.kt
@@ -5,7 +5,6 @@ import com.rk.commands.ActionContext
 import com.rk.commands.GlobalCommand
 import com.rk.commands.KeyCombination
 import com.rk.components.codeSearchDialog
-import com.rk.filetree.currentDrawerTab
 import com.rk.icons.Icon
 import com.rk.resources.drawables
 import com.rk.resources.getString
@@ -21,7 +20,7 @@ class SearchCodeCommand : GlobalCommand() {
     }
 
     override fun isEnabled(): Boolean {
-        return currentDrawerTab != null
+        return commandContext.drawerViewModel.currentDrawerTab != null
     }
 
     override fun getIcon(): Icon = Icon.DrawableRes(drawables.search)

--- a/core/main/src/main/java/com/rk/commands/global/SearchFileFolderCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/SearchFileFolderCommand.kt
@@ -6,7 +6,6 @@ import com.rk.commands.GlobalCommand
 import com.rk.commands.KeyCombination
 import com.rk.components.fileSearchDialog
 import com.rk.filetree.FileTreeTab
-import com.rk.filetree.currentDrawerTab
 import com.rk.icons.Icon
 import com.rk.resources.drawables
 import com.rk.resources.getString
@@ -22,7 +21,7 @@ class SearchFileFolderCommand : GlobalCommand() {
     }
 
     override fun isEnabled(): Boolean {
-        return currentDrawerTab is FileTreeTab
+        return commandContext.drawerViewModel.currentDrawerTab is FileTreeTab
     }
 
     override fun getIcon(): Icon = Icon.DrawableRes(drawables.search)

--- a/core/main/src/main/java/com/rk/components/GlobalToolbarActions.kt
+++ b/core/main/src/main/java/com/rk/components/GlobalToolbarActions.kt
@@ -27,13 +27,13 @@ import com.rk.activities.main.fileTreeViewModel
 import com.rk.activities.main.searchViewModel
 import com.rk.commands.ActionContext
 import com.rk.commands.CommandProvider
+import com.rk.drawer.DrawerViewModel
 import com.rk.file.FileObject
 import com.rk.file.FileWrapper
 import com.rk.file.child
 import com.rk.file.createFileIfNot
 import com.rk.file.toFileObject
 import com.rk.filetree.FileTreeTab
-import com.rk.filetree.currentDrawerTab
 import com.rk.icons.CreateNewFile
 import com.rk.icons.XedIcon
 import com.rk.icons.XedIcons
@@ -54,7 +54,7 @@ var codeSearchDialog by mutableStateOf(false)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun GlobalToolbarActions(viewModel: MainViewModel) {
+fun GlobalToolbarActions(viewModel: MainViewModel, drawerViewModel: DrawerViewModel) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var tempFileNameDialog by remember { mutableStateOf(false) }
@@ -79,10 +79,10 @@ fun GlobalToolbarActions(viewModel: MainViewModel) {
         }
     }
 
-    if (fileSearchDialog && currentDrawerTab is FileTreeTab) {
+    if (fileSearchDialog && drawerViewModel.currentDrawerTab is FileTreeTab) {
         FileSearchDialog(
             searchViewModel = searchViewModel.get()!!,
-            projectFile = (currentDrawerTab as FileTreeTab).root,
+            projectFile = (drawerViewModel.currentDrawerTab as FileTreeTab).root,
             onFinish = { fileSearchDialog = false },
             onSelect = { projectFile, fileObject ->
                 scope.launch {
@@ -103,11 +103,11 @@ fun GlobalToolbarActions(viewModel: MainViewModel) {
         )
     }
 
-    if (codeSearchDialog && currentDrawerTab is FileTreeTab) {
+    if (codeSearchDialog && drawerViewModel.currentDrawerTab is FileTreeTab) {
         CodeSearchDialog(
             mainViewModel = viewModel,
             searchViewModel = searchViewModel.get()!!,
-            projectFile = (currentDrawerTab as FileTreeTab).root,
+            projectFile = (drawerViewModel.currentDrawerTab as FileTreeTab).root,
             onFinish = { codeSearchDialog = false },
         )
     }

--- a/core/main/src/main/java/com/rk/drawer/AddProjectSheet.kt
+++ b/core/main/src/main/java/com/rk/drawer/AddProjectSheet.kt
@@ -1,0 +1,158 @@
+package com.rk.drawer
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.os.storage.StorageManager
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import com.rk.activities.main.MainActivity
+import com.rk.components.AddDialogItem
+import com.rk.file.FileObject
+import com.rk.file.FileWrapper
+import com.rk.file.sandboxHomeDir
+import com.rk.icons.Icon
+import com.rk.resources.drawables
+import com.rk.resources.strings
+import com.rk.settings.Settings
+import com.rk.settings.app.InbuiltFeatures
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddProjectSheet(
+    onDismiss: () -> Unit,
+    onAddProject: (FileObject) -> Unit,
+    openFolder: ManagedActivityResultLauncher<Uri?, Uri?>,
+    showPrivateFileWarning: (onOK: () -> Unit) -> Unit,
+    showGitCloneDialog: () -> Unit,
+) {
+    val context = LocalContext.current
+    val activity = context as MainActivity
+    val lifecycleScope = remember { activity.lifecycleScope }
+
+    val viewModel = activity.drawerViewModel
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(modifier = Modifier.Companion.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 0.dp)) {
+            AddDialogItem(
+                icon = Icon.DrawableRes(drawables.file_symlink),
+                title = stringResource(strings.open_directory),
+                description = stringResource(strings.open_dir_desc),
+                onClick = {
+                    openFolder.launch(null)
+                    onDismiss()
+                },
+            )
+
+            // Open Path option
+            val is11Plus = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+            val isManager = is11Plus && Environment.isExternalStorageManager()
+            val legacyPermission =
+                ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) !=
+                    PackageManager.PERMISSION_GRANTED ||
+                    ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) !=
+                        PackageManager.PERMISSION_GRANTED
+
+            val storage = Environment.getExternalStorageDirectory()
+            if ((isManager || (!is11Plus && legacyPermission)) && storage.canWrite() && storage.canRead()) {
+                AddDialogItem(
+                    icon = Icon.DrawableRes(drawables.android),
+                    title = stringResource(strings.internal_storage),
+                    description = stringResource(strings.open_internal_storage),
+                    onClick = {
+                        viewModel.addFileTreeTab(FileWrapper(storage))
+                        onDismiss()
+                    },
+                )
+            }
+
+            if (isManager) {
+                val storageManager = context.getSystemService(StorageManager::class.java)
+                val volumes = storageManager.storageVolumes
+
+                volumes.forEach { volume ->
+                    val root = volume.directory ?: return@forEach
+                    if (root == storage) return@forEach
+                    if (!root.canRead() || !root.canWrite() || root.listFiles() == null) return@forEach
+
+                    val name = volume.getDescription(context)
+                    val removable = volume.isRemovable
+                    val description = if (removable) strings.open_removable_storage else strings.open_internal_storage
+
+                    AddDialogItem(
+                        icon = Icon.DrawableRes(drawables.sd_card),
+                        title = name,
+                        description = stringResource(description),
+                    ) {
+                        viewModel.addFileTreeTab(FileWrapper(root))
+                        onDismiss()
+                    }
+                }
+            }
+
+            if (InbuiltFeatures.debugMode.state.value) {
+                AddDialogItem(
+                    icon = Icon.DrawableRes(drawables.build),
+                    title = stringResource(strings.private_files),
+                    description = stringResource(strings.private_files_desc),
+                    onClick = {
+                        if (!Settings.has_shown_private_data_dir_warning) {
+                            showPrivateFileWarning {
+                                Settings.has_shown_private_data_dir_warning = true
+                                lifecycleScope.launch { onAddProject(FileWrapper(activity.filesDir.parentFile!!)) }
+                            }
+                        } else {
+                            lifecycleScope.launch { onAddProject(FileWrapper(activity.filesDir.parentFile!!)) }
+                        }
+                        onDismiss()
+                    },
+                )
+            }
+
+            // Clone repository option
+            if (InbuiltFeatures.git.state.value) {
+                AddDialogItem(
+                    icon = Icon.DrawableRes(drawables.git),
+                    title = stringResource(strings.clone_repo),
+                    description = stringResource(strings.clone_repo_desc),
+                    onClick = {
+                        showGitCloneDialog()
+                        onDismiss()
+                    },
+                )
+            }
+
+            // Terminal Home option
+            AddDialogItem(
+                icon = Icon.DrawableRes(drawables.terminal),
+                title = stringResource(strings.terminal_home),
+                description = stringResource(strings.terminal_home_desc),
+                onClick = {
+                    if (!Settings.has_shown_terminal_dir_warning) {
+                        showPrivateFileWarning {
+                            Settings.has_shown_terminal_dir_warning = true
+                            lifecycleScope.launch { onAddProject(FileWrapper(sandboxHomeDir())) }
+                        }
+                    } else {
+                        lifecycleScope.launch { onAddProject(FileWrapper(sandboxHomeDir())) }
+                    }
+                    onDismiss()
+                },
+            )
+        }
+    }
+}

--- a/core/main/src/main/java/com/rk/drawer/Drawer.kt
+++ b/core/main/src/main/java/com/rk/drawer/Drawer.kt
@@ -1,13 +1,7 @@
-package com.rk.filetree
+package com.rk.drawer
 
-import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
-import android.net.Uri
-import android.os.Build
-import android.os.Environment
-import android.os.storage.StorageManager
-import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.Crossfade
@@ -30,12 +24,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailDefaults
 import androidx.compose.material3.NavigationRailItem
@@ -48,7 +40,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -61,199 +52,34 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.lifecycleScope
-import com.rk.DefaultScope
 import com.rk.activities.main.MainActivity
-import com.rk.activities.main.fileTreeViewModel
 import com.rk.activities.main.gitViewModel
-import com.rk.components.AddDialogItem
 import com.rk.components.DoubleInputDialog
-import com.rk.file.FileObject
-import com.rk.file.FileWrapper
-import com.rk.file.child
-import com.rk.file.sandboxHomeDir
 import com.rk.file.toFileObject
-import com.rk.git.GitTab
+import com.rk.filetree.ProjectCloseConfirmationDialog
 import com.rk.git.ProgressCoordinator
-import com.rk.icons.Icon
 import com.rk.icons.XedIcon
 import com.rk.resources.drawables
 import com.rk.resources.getString
 import com.rk.resources.strings
-import com.rk.settings.Settings
-import com.rk.settings.app.InbuiltFeatures
-import com.rk.utils.application
 import com.rk.utils.dialog
-import com.rk.utils.readObject
-import com.rk.utils.toast
-import com.rk.utils.writeObject
-import java.io.File
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
+import java.io.File
 
-object DrawerPersistence {
-    private val saveMutex = Mutex()
-
-    private const val DRAWER_TABS = "drawerTabs"
-    private const val CURRENT_DRAWER_TAB = "currentDrawerTab"
-    private const val EXPANDED_FILE_TREE_NODES = "expandedFileTree"
-
-    suspend fun saveState() {
-        saveMutex.withLock {
-            val file = FileWrapper(application!!.filesDir.child(DRAWER_TABS))
-            val serializableList = ArrayList(drawerTabs)
-            file.writeObject(serializableList)
-
-            val currentTabFile = FileWrapper(application!!.filesDir.child(CURRENT_DRAWER_TAB))
-            if (currentDrawerTab != null) {
-                currentTabFile.writeObject(currentDrawerTab!!)
-            } else {
-                currentTabFile.delete()
-            }
-
-            val expandedNodeFile = FileWrapper(application!!.filesDir.child(EXPANDED_FILE_TREE_NODES))
-            fileTreeViewModel.get()?.getExpandedNodes()?.let { expandedNodeFile.writeObject(it) }
-        }
-    }
-
-    suspend fun restoreState() {
-        saveMutex.withLock {
-            runCatching {
-                    val loadedTabs =
-                        withContext(Dispatchers.IO) {
-                            val file = FileWrapper(application!!.filesDir.child(DRAWER_TABS))
-
-                            if (file.exists() && file.canRead()) {
-                                file.readObject() as? ArrayList<DrawerTab> ?: emptyList()
-                            } else {
-                                emptyList()
-                            }
-                        }
-
-                    // Update the existing state list on Main thread
-                    withContext(Dispatchers.Main) {
-                        drawerTabs.clear()
-                        drawerTabs.addAll(loadedTabs)
-                    }
-
-                    val currentTabFile = FileWrapper(application!!.filesDir.child(CURRENT_DRAWER_TAB))
-                    if (currentTabFile.exists() && currentTabFile.canRead()) {
-                        selectTab(currentTabFile.readObject() as DrawerTab)
-                    }
-
-                    val expandedNodeFile = FileWrapper(application!!.filesDir.child(EXPANDED_FILE_TREE_NODES))
-                    if (expandedNodeFile.exists() && expandedNodeFile.canRead()) {
-                        fileTreeViewModel
-                            .get()
-                            ?.setExpandedNodes(expandedNodeFile.readObject() as Map<FileObject, Boolean>)
-                    }
-                }
-                .onFailure {
-                    it.printStackTrace()
-                    toast(strings.project_restore_failed)
-                }
-        }
-    }
-}
-
-fun createServices() {
-    serviceTabs.clear()
-    serviceTabs.add(GitTab(gitViewModel.get()!!))
-}
-
-var drawerTabs = mutableStateListOf<DrawerTab>()
-var serviceTabs = mutableStateListOf<DrawerTab>()
-var currentDrawerTab by mutableStateOf<DrawerTab?>(null)
-var currentServiceTab by mutableStateOf<DrawerTab?>(null)
-
-@OptIn(DelicateCoroutinesApi::class)
-fun addProject(fileObject: FileObject, save: Boolean = false) {
-    val alreadyExistingProject = drawerTabs.find { it is FileTreeTab && it.root == fileObject }
-    if (alreadyExistingProject != null) {
-        selectTab(alreadyExistingProject)
-        return
-    }
-    val tab = FileTreeTab(fileObject)
-    tab.onAdded()
-    drawerTabs.add(tab)
-    selectTab(tab)
-    if (save) {
-        GlobalScope.launch(Dispatchers.IO) { DrawerPersistence.saveState() }
-    }
-}
-
-@OptIn(DelicateCoroutinesApi::class)
-fun addProject(tab: DrawerTab, save: Boolean = false) {
-    tab.onAdded()
-    drawerTabs.add(tab)
-    selectTab(tab)
-    if (save) {
-        GlobalScope.launch(Dispatchers.IO) { DrawerPersistence.saveState() }
-    }
-}
-
-@OptIn(DelicateCoroutinesApi::class)
-fun removeProject(fileObject: FileObject, save: Boolean = false) {
-    val index = drawerTabs.indexOfFirst { it is FileTreeTab && it.root == fileObject }
-    if (index == -1) return
-
-    if (currentDrawerTab == drawerTabs[index]) {
-        val tabBefore = drawerTabs.getOrNull(index - 1)
-        val tabAfter = drawerTabs.getOrNull(index + 1)
-        selectTab(tabBefore ?: tabAfter)
-    }
-
-    drawerTabs[index].onRemoved()
-    drawerTabs.removeAt(index)
-
-    if (save) {
-        GlobalScope.launch(Dispatchers.IO) { DrawerPersistence.saveState() }
-    }
-}
-
-@OptIn(DelicateCoroutinesApi::class)
-fun removeProject(tab: DrawerTab, save: Boolean = false) {
-    val index = drawerTabs.indexOf(tab)
-    if (index == -1) return
-
-    if (currentDrawerTab == drawerTabs[index]) {
-        val tabBefore = drawerTabs.getOrNull(index - 1)
-        val tabAfter = drawerTabs.getOrNull(index + 1)
-        selectTab(tabBefore ?: tabAfter)
-    }
-
-    drawerTabs[index].onRemoved()
-    drawerTabs.removeAt(index)
-
-    if (save) {
-        GlobalScope.launch(Dispatchers.IO) { DrawerPersistence.saveState() }
-    }
-}
-
-fun validateValue(value: String): String? {
+private fun validateValue(value: String): String? {
     return when {
         value.isBlank() -> strings.value_empty_err.getString()
         else -> null
     }
 }
 
-fun selectTab(tab: DrawerTab?) {
-    currentDrawerTab = tab
-    currentServiceTab = null
-}
-
-var isLoading by mutableStateOf(true)
-
 @Composable
 fun DrawerContent(fullscreen: Boolean) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+
+    val mainActivity = LocalActivity.current as MainActivity
+    val viewModel = mainActivity.drawerViewModel
 
     val openFolder =
         rememberLauncherForActivityResult(
@@ -269,13 +95,13 @@ fun DrawerContent(fullscreen: Boolean) {
                         }
                         .onFailure { it.printStackTrace() }
 
-                    scope.launch { addProject(it.toFileObject(expectedIsFile = false)) }
+                    scope.launch { viewModel.addFileTreeTab(it.toFileObject(expectedIsFile = false)) }
                 }
             },
         )
 
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        if (isLoading) {
+        if (viewModel.isLoading) {
             CircularProgressIndicator()
         } else {
             Row(horizontalArrangement = Arrangement.Start, modifier = Modifier.fillMaxSize()) {
@@ -369,7 +195,7 @@ fun DrawerContent(fullscreen: Boolean) {
                                                 repoURLError = null
                                                 repoBranchError = null
                                                 if (success) {
-                                                    addProject(fileObject)
+                                                    viewModel.addFileTreeTab(fileObject)
                                                 }
                                             },
                                         )
@@ -387,22 +213,22 @@ fun DrawerContent(fullscreen: Boolean) {
                 ) {
                     Column(modifier = Modifier.fillMaxHeight()) {
                         LazyColumn(modifier = Modifier.weight(1f, fill = true), state = lazyListState) {
-                            items(drawerTabs) { tab ->
+                            items(items = viewModel.drawerTabs) { tab ->
                                 if (!tab.isSupported()) return@items
                                 NavigationRailItem(
-                                    selected = currentDrawerTab == tab,
+                                    selected = viewModel.currentDrawerTab == tab,
                                     icon = { XedIcon(tab.getIcon()) },
                                     onClick = {
-                                        if (currentDrawerTab == tab && currentServiceTab == null) {
+                                        if (viewModel.currentDrawerTab == tab && viewModel.currentServiceTab == null) {
                                             closeProjectDialog = true
                                         } else {
-                                            selectTab(tab)
+                                            viewModel.selectDrawerTab(tab)
                                         }
                                     },
                                     label = { Text(tab.getName(), maxLines = 1, overflow = TextOverflow.Ellipsis) },
                                     colors =
                                         NavigationRailItemDefaults.colors().let {
-                                            if (currentServiceTab == null) it
+                                            if (viewModel.currentServiceTab == null) it
                                             else
                                                 it.copy(
                                                     selectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -428,16 +254,16 @@ fun DrawerContent(fullscreen: Boolean) {
                         if (showHorizontalDivider) HorizontalDivider()
 
                         Column(modifier = Modifier.wrapContentHeight().padding(vertical = 8.dp)) {
-                            serviceTabs.forEach { tab ->
+                            viewModel.serviceTabs.forEach { tab ->
                                 if (!tab.isSupported()) return@forEach
                                 NavigationRailItem(
-                                    selected = currentServiceTab == tab,
+                                    selected = viewModel.currentServiceTab == tab,
                                     icon = { XedIcon(icon = tab.getIcon()) },
                                     onClick = {
-                                        if (currentServiceTab == tab) {
-                                            currentServiceTab = null
+                                        if (viewModel.currentServiceTab == tab) {
+                                            viewModel.unselectServiceTab()
                                         } else {
-                                            currentServiceTab = tab
+                                            viewModel.selectServiceTab(tab)
                                         }
                                     },
                                     label = { Text(tab.getName(), maxLines = 1, overflow = TextOverflow.Ellipsis) },
@@ -451,8 +277,8 @@ fun DrawerContent(fullscreen: Boolean) {
                 VerticalDivider()
 
                 Surface {
-                    Crossfade(targetState = currentDrawerTab, label = "file tree") { tab ->
-                        if (currentServiceTab == null) {
+                    Crossfade(targetState = viewModel.currentDrawerTab, label = "file tree") { tab ->
+                        if (viewModel.currentServiceTab == null) {
                             if (tab != null) {
                                 tab.Content(modifier = Modifier.fillMaxSize())
                             } else {
@@ -476,16 +302,16 @@ fun DrawerContent(fullscreen: Boolean) {
                         }
                     }
 
-                    Crossfade(targetState = currentServiceTab) { tab ->
+                    Crossfade(targetState = viewModel.currentServiceTab) { tab ->
                         tab?.Content(modifier = Modifier.fillMaxSize())
                     }
                 }
 
                 if (showAddDialog) {
-                    AddProjectDialog(
+                    AddProjectSheet(
                         onDismiss = { showAddDialog = false },
                         openFolder = openFolder,
-                        onAddProject = { fileObject -> scope.launch { addProject(fileObject, true) } },
+                        onAddProject = { fileObject -> scope.launch { viewModel.addFileTreeTab(fileObject, true) } },
                         showPrivateFileWarning = { callback ->
                             dialog(
                                 title = strings.attention.getString(),
@@ -553,141 +379,18 @@ fun DrawerContent(fullscreen: Boolean) {
                     )
                 }
 
+                val currentDrawerTab = viewModel.currentDrawerTab
                 if (closeProjectDialog && currentDrawerTab != null) {
                     ProjectCloseConfirmationDialog(
-                        projectName = currentDrawerTab!!.getName(),
+                        projectName = currentDrawerTab.getName(),
                         onConfirm = {
                             closeProjectDialog = false
-                            removeProject(currentDrawerTab!!)
+                            viewModel.removeDrawerTab(currentDrawerTab)
                         },
                         onDismiss = { closeProjectDialog = false },
                     )
                 }
             }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun AddProjectDialog(
-    onDismiss: () -> Unit,
-    onAddProject: (FileObject) -> Unit,
-    openFolder: ManagedActivityResultLauncher<Uri?, Uri?>,
-    showPrivateFileWarning: (onOK: () -> Unit) -> Unit,
-    showGitCloneDialog: () -> Unit,
-) {
-    val context = LocalContext.current
-    val activity = context as? MainActivity
-    val lifecycleScope = remember { activity?.lifecycleScope ?: DefaultScope }
-
-    ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 0.dp)) {
-            AddDialogItem(
-                icon = Icon.DrawableRes(drawables.file_symlink),
-                title = stringResource(strings.open_directory),
-                description = stringResource(strings.open_dir_desc),
-                onClick = {
-                    openFolder.launch(null)
-                    onDismiss()
-                },
-            )
-
-            // Open Path option
-            val is11Plus = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-            val isManager = is11Plus && Environment.isExternalStorageManager()
-            val legacyPermission =
-                ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE) !=
-                    PackageManager.PERMISSION_GRANTED ||
-                    ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) !=
-                        PackageManager.PERMISSION_GRANTED
-
-            val storage = Environment.getExternalStorageDirectory()
-            if ((isManager || (!is11Plus && legacyPermission)) && storage.canWrite() && storage.canRead()) {
-                AddDialogItem(
-                    icon = Icon.DrawableRes(drawables.android),
-                    title = stringResource(strings.internal_storage),
-                    description = stringResource(strings.open_internal_storage),
-                    onClick = {
-                        addProject(FileWrapper(storage))
-                        onDismiss()
-                    },
-                )
-            }
-
-            if (isManager) {
-                val storageManager = context.getSystemService(StorageManager::class.java)
-                val volumes = storageManager.storageVolumes
-
-                volumes.forEach { volume ->
-                    val root = volume.directory ?: return@forEach
-                    if (root == storage) return@forEach
-                    if (!root.canRead() || !root.canWrite() || root.listFiles() == null) return@forEach
-
-                    val name = volume.getDescription(context)
-                    val removable = volume.isRemovable
-                    val description = if (removable) strings.open_removable_storage else strings.open_internal_storage
-
-                    AddDialogItem(
-                        icon = Icon.DrawableRes(drawables.sd_card),
-                        title = name,
-                        description = stringResource(description),
-                    ) {
-                        addProject(FileWrapper(root))
-                        onDismiss()
-                    }
-                }
-            }
-
-            if (InbuiltFeatures.debugMode.state.value) {
-                AddDialogItem(
-                    icon = Icon.DrawableRes(drawables.build),
-                    title = stringResource(strings.private_files),
-                    description = stringResource(strings.private_files_desc),
-                    onClick = {
-                        if (!Settings.has_shown_private_data_dir_warning) {
-                            showPrivateFileWarning {
-                                Settings.has_shown_private_data_dir_warning = true
-                                lifecycleScope.launch { onAddProject(FileWrapper(activity!!.filesDir.parentFile!!)) }
-                            }
-                        } else {
-                            lifecycleScope.launch { onAddProject(FileWrapper(activity!!.filesDir.parentFile!!)) }
-                        }
-                        onDismiss()
-                    },
-                )
-            }
-
-            // Clone repository option
-            if (InbuiltFeatures.git.state.value) {
-                AddDialogItem(
-                    icon = Icon.DrawableRes(drawables.git),
-                    title = stringResource(strings.clone_repo),
-                    description = stringResource(strings.clone_repo_desc),
-                    onClick = {
-                        showGitCloneDialog()
-                        onDismiss()
-                    },
-                )
-            }
-
-            // Terminal Home option
-            AddDialogItem(
-                icon = Icon.DrawableRes(drawables.terminal),
-                title = stringResource(strings.terminal_home),
-                description = stringResource(strings.terminal_home_desc),
-                onClick = {
-                    if (!Settings.has_shown_terminal_dir_warning) {
-                        showPrivateFileWarning {
-                            Settings.has_shown_terminal_dir_warning = true
-                            lifecycleScope.launch { onAddProject(FileWrapper(sandboxHomeDir())) }
-                        }
-                    } else {
-                        lifecycleScope.launch { onAddProject(FileWrapper(sandboxHomeDir())) }
-                    }
-                    onDismiss()
-                },
-            )
         }
     }
 }

--- a/core/main/src/main/java/com/rk/drawer/DrawerPersistence.kt
+++ b/core/main/src/main/java/com/rk/drawer/DrawerPersistence.kt
@@ -1,0 +1,77 @@
+package com.rk.drawer
+
+import com.rk.activities.main.fileTreeViewModel
+import com.rk.file.FileObject
+import com.rk.file.FileWrapper
+import com.rk.file.child
+import com.rk.resources.strings
+import com.rk.utils.application
+import com.rk.utils.readObject
+import com.rk.utils.toast
+import com.rk.utils.writeObject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+object DrawerPersistence {
+    private val saveMutex = Mutex()
+
+    private const val DRAWER_TABS = "drawerTabs"
+    private const val CURRENT_DRAWER_TAB = "currentDrawerTab"
+    private const val EXPANDED_FILE_TREE_NODES = "expandedFileTree"
+
+    suspend fun saveState(viewModel: DrawerViewModel) {
+        saveMutex.withLock {
+            val file = FileWrapper(application!!.filesDir.child(DRAWER_TABS))
+            val serializableList = ArrayList(viewModel.drawerTabs)
+            file.writeObject(serializableList)
+
+            val currentTabFile = FileWrapper(application!!.filesDir.child(CURRENT_DRAWER_TAB))
+            if (viewModel.currentDrawerTab != null) {
+                currentTabFile.writeObject(viewModel.currentDrawerTab!!)
+            } else {
+                currentTabFile.delete()
+            }
+
+            val expandedNodeFile = FileWrapper(application!!.filesDir.child(EXPANDED_FILE_TREE_NODES))
+            fileTreeViewModel.get()?.getExpandedNodes()?.let { expandedNodeFile.writeObject(it) }
+        }
+    }
+
+    suspend fun restoreState(viewModel: DrawerViewModel) {
+        saveMutex.withLock {
+            runCatching {
+                    val loadedTabs =
+                        withContext(Dispatchers.IO) {
+                            val file = FileWrapper(application!!.filesDir.child(DRAWER_TABS))
+
+                            if (file.exists() && file.canRead()) {
+                                file.readObject() as? ArrayList<DrawerTab> ?: emptyList()
+                            } else {
+                                emptyList()
+                            }
+                        }
+
+                    // Update the existing state list on Main thread
+                    withContext(Dispatchers.Main) { viewModel.forcePushDrawerTabs(loadedTabs) }
+
+                    val currentTabFile = FileWrapper(application!!.filesDir.child(CURRENT_DRAWER_TAB))
+                    if (currentTabFile.exists() && currentTabFile.canRead()) {
+                        viewModel.selectDrawerTab(currentTabFile.readObject() as DrawerTab)
+                    }
+
+                    val expandedNodeFile = FileWrapper(application!!.filesDir.child(EXPANDED_FILE_TREE_NODES))
+                    if (expandedNodeFile.exists() && expandedNodeFile.canRead()) {
+                        fileTreeViewModel
+                            .get()
+                            ?.setExpandedNodes(expandedNodeFile.readObject() as Map<FileObject, Boolean>)
+                    }
+                }
+                .onFailure {
+                    it.printStackTrace()
+                    toast(strings.project_restore_failed)
+                }
+        }
+    }
+}

--- a/core/main/src/main/java/com/rk/drawer/DrawerTab.kt
+++ b/core/main/src/main/java/com/rk/drawer/DrawerTab.kt
@@ -1,4 +1,4 @@
-package com.rk.filetree
+package com.rk.drawer
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/core/main/src/main/java/com/rk/drawer/DrawerViewModel.kt
+++ b/core/main/src/main/java/com/rk/drawer/DrawerViewModel.kt
@@ -1,0 +1,149 @@
+package com.rk.drawer
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.rk.file.FileObject
+import com.rk.filetree.FileTreeTab
+import com.rk.git.GitTab
+import com.rk.git.GitViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class DrawerViewModel : ViewModel() {
+    var isLoading by mutableStateOf(true)
+
+    private val _drawerTabs = mutableStateListOf<DrawerTab>()
+    private val _serviceTabs = mutableStateListOf<DrawerTab>()
+
+    val drawerTabs: List<DrawerTab>
+        get() = _drawerTabs.toList()
+
+    val serviceTabs: List<DrawerTab>
+        get() = _serviceTabs.toList()
+
+    var currentDrawerTabIndex by mutableIntStateOf(0)
+        private set
+
+    val currentDrawerTab: DrawerTab?
+        get() = _drawerTabs.getOrNull(currentDrawerTabIndex)
+
+    var currentServiceTabIndex by mutableIntStateOf(0)
+        private set
+
+    val currentServiceTab: DrawerTab?
+        get() = _serviceTabs.getOrNull(currentServiceTabIndex)
+
+    internal fun setupBuiltinServices(gitViewModel: GitViewModel) {
+        _serviceTabs.clear()
+        _serviceTabs.add(GitTab(gitViewModel))
+        currentServiceTabIndex = -1
+    }
+
+    fun addFileTreeTab(fileObject: FileObject, save: Boolean = false) {
+        val existingIndex = _drawerTabs.indexOfFirst { it is FileTreeTab && it.root == fileObject }
+
+        if (existingIndex != -1) {
+            selectDrawerTab(existingIndex)
+            return
+        }
+
+        val tab = FileTreeTab(fileObject)
+        addDrawerTab(tab, save)
+    }
+
+    fun addDrawerTab(tab: DrawerTab, save: Boolean = false) {
+        tab.onAdded()
+
+        _drawerTabs.add(tab)
+        selectDrawerTab(_drawerTabs.lastIndex)
+
+        if (save) persistAsync()
+    }
+
+    fun removeFileTreeTab(fileObject: FileObject, save: Boolean = false) {
+        val index = _drawerTabs.indexOfFirst { it is FileTreeTab && it.root == fileObject }
+        if (index == -1) return
+
+        removeDrawerTab(index, save)
+    }
+
+    fun removeDrawerTab(drawerTab: DrawerTab, save: Boolean = false) {
+        val index = _drawerTabs.indexOf(drawerTab)
+        if (index == -1) return
+
+        removeDrawerTab(index, save)
+    }
+
+    fun removeDrawerTab(index: Int, save: Boolean = false) {
+        if (index !in _drawerTabs.indices) return
+
+        val isActive = currentDrawerTabIndex == index
+
+        _drawerTabs[index].onRemoved()
+        _drawerTabs.removeAt(index)
+
+        if (_drawerTabs.isEmpty()) {
+            unselectDrawerTab()
+        } else if (isActive) {
+            val newIndex =
+                when {
+                    index - 1 >= 0 -> index - 1
+                    index <= _drawerTabs.lastIndex -> index
+                    else -> _drawerTabs.lastIndex
+                }
+            selectDrawerTab(newIndex)
+        } else {
+            if (currentDrawerTabIndex > index) {
+                currentDrawerTabIndex -= 1
+            }
+        }
+
+        if (save) persistAsync()
+    }
+
+    fun selectDrawerTab(drawerTab: DrawerTab) {
+        val index = _drawerTabs.indexOf(drawerTab)
+        if (index != -1) selectDrawerTab(index)
+    }
+
+    fun selectDrawerTab(index: Int) {
+        if (index !in _drawerTabs.indices) return
+
+        currentDrawerTabIndex = index
+        currentServiceTabIndex = -1
+    }
+
+    fun unselectDrawerTab() {
+        currentDrawerTabIndex = -1
+        currentServiceTabIndex = -1
+    }
+
+    fun selectServiceTab(serviceTab: DrawerTab) {
+        val index = _serviceTabs.indexOf(serviceTab)
+        if (index != -1) selectServiceTab(index)
+    }
+
+    fun selectServiceTab(index: Int) {
+        if (index !in _serviceTabs.indices) return
+
+        currentServiceTabIndex = index
+    }
+
+    fun unselectServiceTab() {
+        currentServiceTabIndex = -1
+    }
+
+    fun forcePushDrawerTabs(drawerTabs: List<DrawerTab>) {
+        _drawerTabs.clear()
+        _drawerTabs.addAll(drawerTabs)
+    }
+
+    private fun persistAsync() {
+        viewModelScope.launch(Dispatchers.IO) { DrawerPersistence.saveState(this@DrawerViewModel) }
+    }
+}

--- a/core/main/src/main/java/com/rk/filetree/FileAction.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileAction.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.outlined.Refresh
 import androidx.lifecycle.viewModelScope
 import com.rk.activities.main.MainActivity
 import com.rk.activities.terminal.Terminal
+import com.rk.drawer.DrawerViewModel
 import com.rk.file.FileObject
 import com.rk.file.FileOperations
 import com.rk.file.FileWrapper
@@ -31,6 +32,7 @@ data class FileActionContext(
     val file: FileObject,
     val root: FileObject?,
     val viewModel: FileTreeViewModel,
+    val drawerViewModel: DrawerViewModel,
     val context: Context,
 )
 
@@ -38,6 +40,7 @@ data class MultiFileActionContext(
     val files: List<FileObject>,
     val root: FileObject?,
     val viewModel: FileTreeViewModel,
+    val drawerViewModel: DrawerViewModel,
     val context: Context,
 )
 
@@ -277,11 +280,12 @@ object OpenAsProjectAction : FileAction() {
     override val title = strings.open_as_project.getString()
 
     override fun action(context: FileActionContext) {
-        addProject(context.file, true)
+        context.drawerViewModel.addFileTreeTab(context.file, true)
     }
 
     override fun isEnabled(file: FileObject): Boolean {
-        return drawerTabs.none { it is FileTreeTab && it.root == file }
+        val drawerViewModel = MainActivity.instance?.drawerViewModel ?: return false
+        return drawerViewModel.drawerTabs.none { it is FileTreeTab && it.root == file }
     }
 
     override val type = FileActionType(file = false, folder = true, rootFolder = true)

--- a/core/main/src/main/java/com/rk/filetree/FileActionDialogs.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileActionDialogs.kt
@@ -13,6 +13,7 @@ import com.rk.activities.main.MainActivity
 import com.rk.activities.main.drawerStateRef
 import com.rk.components.PropertiesDialog
 import com.rk.components.SingleInputDialog
+import com.rk.drawer.DrawerViewModel
 import com.rk.file.FileObject
 import com.rk.file.FileOperations
 import com.rk.resources.fillPlaceholders
@@ -27,7 +28,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 @Composable
-fun FileActionDialogs(viewModel: FileTreeViewModel, scope: CoroutineScope, context: Context) {
+fun FileActionDialogs(
+    drawerViewModel: DrawerViewModel,
+    viewModel: FileTreeViewModel,
+    scope: CoroutineScope,
+    context: Context,
+) {
     if (viewModel.showRenameDialog) {
         val file = viewModel.renameFile ?: return
         SingleInputDialog(
@@ -91,7 +97,7 @@ fun FileActionDialogs(viewModel: FileTreeViewModel, scope: CoroutineScope, conte
                                     }
 
                                     if (file == root) {
-                                        removeProject(file, true)
+                                        drawerViewModel.removeFileTreeTab(file, true)
                                     }
 
                                     MainActivity.instance?.viewModel?.also { viewModel ->
@@ -192,7 +198,7 @@ fun FileActionDialogs(viewModel: FileTreeViewModel, scope: CoroutineScope, conte
         ProjectCloseConfirmationDialog(
             projectName = root.getAppropriateName(),
             onConfirm = {
-                removeProject(root)
+                drawerViewModel.removeFileTreeTab(root)
                 viewModel.closeCloseProjectConfirmation()
             },
             onDismiss = { viewModel.closeCloseProjectConfirmation() },

--- a/core/main/src/main/java/com/rk/filetree/FileTree.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTree.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewModelScope
 import com.rk.activities.main.MainActivity
 import com.rk.activities.main.searchViewModel
+import com.rk.drawer.DrawerViewModel
 import com.rk.file.FileObject
 import com.rk.icons.XedIcon
 import com.rk.resources.getString
@@ -67,6 +68,7 @@ fun FileTree(
     onFileClick: FileTreeNode.(FileTreeNode) -> Unit,
     onSearchClick: () -> Unit = {},
     viewModel: FileTreeViewModel,
+    drawerViewModel: DrawerViewModel,
 ) {
     // Auto-expand root node on first composition
     LaunchedEffect(rootNode.file) {
@@ -107,7 +109,7 @@ fun FileTree(
                 modifier = Modifier.weight(1f),
             ) {
                 if (viewModel.isAnyFileSelected(rootNode.file)) {
-                    SelectionActions(viewModel, rootNode)
+                    SelectionActions(viewModel, drawerViewModel, rootNode)
                 } else {
                     FileTreeActions(viewModel, onSearchClick)
                 }
@@ -143,7 +145,7 @@ fun FileTree(
 }
 
 @Composable
-private fun SelectionActions(viewModel: FileTreeViewModel, rootNode: FileTreeNode) {
+private fun SelectionActions(viewModel: FileTreeViewModel, drawerViewModel: DrawerViewModel, rootNode: FileTreeNode) {
     val selectedFiles = viewModel.getSelectedFiles(rootNode.file)
     val actions = remember(selectedFiles, rootNode.file) { getActions(selectedFiles, rootNode.file) }
     var expanded by remember { mutableStateOf(false) }
@@ -174,7 +176,8 @@ private fun SelectionActions(viewModel: FileTreeViewModel, rootNode: FileTreeNod
                         IconButton(
                             enabled = action.isEnabled(file),
                             onClick = {
-                                val context = FileActionContext(file, rootNode.file, viewModel, context)
+                                val context =
+                                    FileActionContext(file, rootNode.file, viewModel, drawerViewModel, context)
                                 action.action(context)
 
                                 viewModel.unselectAllFiles(rootNode.file)
@@ -187,7 +190,14 @@ private fun SelectionActions(viewModel: FileTreeViewModel, rootNode: FileTreeNod
                         IconButton(
                             enabled = action.isEnabled(selectedFiles),
                             onClick = {
-                                val context = MultiFileActionContext(selectedFiles, rootNode.file, viewModel, context)
+                                val context =
+                                    MultiFileActionContext(
+                                        selectedFiles,
+                                        rootNode.file,
+                                        viewModel,
+                                        drawerViewModel,
+                                        context,
+                                    )
                                 action.action(context)
 
                                 viewModel.unselectAllFiles(rootNode.file)
@@ -215,7 +225,14 @@ private fun SelectionActions(viewModel: FileTreeViewModel, rootNode: FileTreeNod
                                         leadingIcon = { XedIcon(action.icon, contentDescription = action.title) },
                                         enabled = action.isEnabled(file),
                                         onClick = {
-                                            val context = FileActionContext(file, rootNode.file, viewModel, context)
+                                            val context =
+                                                FileActionContext(
+                                                    file,
+                                                    rootNode.file,
+                                                    viewModel,
+                                                    drawerViewModel,
+                                                    context,
+                                                )
                                             action.action(context)
 
                                             viewModel.unselectAllFiles(rootNode.file)
@@ -230,7 +247,13 @@ private fun SelectionActions(viewModel: FileTreeViewModel, rootNode: FileTreeNod
                                         enabled = action.isEnabled(selectedFiles),
                                         onClick = {
                                             val context =
-                                                MultiFileActionContext(selectedFiles, rootNode.file, viewModel, context)
+                                                MultiFileActionContext(
+                                                    selectedFiles,
+                                                    rootNode.file,
+                                                    viewModel,
+                                                    drawerViewModel,
+                                                    context,
+                                                )
                                             action.action(context)
 
                                             viewModel.unselectAllFiles(rootNode.file)

--- a/core/main/src/main/java/com/rk/filetree/FileTreeTab.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeTab.kt
@@ -45,6 +45,7 @@ import com.rk.activities.main.searchViewModel
 import com.rk.components.AddDialogItem
 import com.rk.components.codeSearchDialog
 import com.rk.components.fileSearchDialog
+import com.rk.drawer.DrawerTab
 import com.rk.file.FileObject
 import com.rk.file.FileWrapper
 import com.rk.file.UriWrapper
@@ -78,6 +79,7 @@ class FileTreeTab(val root: FileObject) : DrawerTab() {
         val scope = rememberCoroutineScope()
         val context = LocalContext.current
         val mainViewModel = MainActivity.instance?.viewModel
+        val drawerViewModel = MainActivity.instance?.drawerViewModel
 
         LaunchedEffect(root) {
             if (InbuiltFeatures.git.state.value) {
@@ -100,6 +102,7 @@ class FileTreeTab(val root: FileObject) : DrawerTab() {
             modifier = Modifier.fillMaxSize().systemBarsPadding(),
             rootNode = root.toFileTreeNode(),
             viewModel = fileTreeViewModel.get()!!,
+            drawerViewModel = drawerViewModel!!,
             onFileClick = { node ->
                 scope.launch(Dispatchers.IO) {
                     mainViewModel?.editorManager?.openFile(node.file, projectRoot = root, switchToTab = true)
@@ -266,7 +269,8 @@ class FileTreeTab(val root: FileObject) : DrawerTab() {
 
     override fun isSupported(): Boolean {
         if (runBlocking { !root.exists() } || !root.isDirectory()) {
-            removeProject(this@FileTreeTab, true)
+            val drawerViewModel = MainActivity.instance?.drawerViewModel ?: return false
+            drawerViewModel.removeDrawerTab(this@FileTreeTab, true)
             return false
         }
         return true

--- a/core/main/src/main/java/com/rk/git/GitTab.kt
+++ b/core/main/src/main/java/com/rk/git/GitTab.kt
@@ -66,11 +66,10 @@ import com.rk.activities.main.fileTreeViewModel
 import com.rk.components.SingleInputDialog
 import com.rk.components.compose.utils.addIf
 import com.rk.components.getDrawerWidth
+import com.rk.drawer.DrawerTab
 import com.rk.file.toFileWrapper
-import com.rk.filetree.DrawerTab
 import com.rk.filetree.FileNameIcon
 import com.rk.filetree.FileTreeTab
-import com.rk.filetree.currentDrawerTab
 import com.rk.icons.Icon
 import com.rk.resources.drawables
 import com.rk.resources.getString
@@ -660,7 +659,8 @@ class GitTab(val viewModel: GitViewModel) : DrawerTab() {
 
     override fun isSupported(): Boolean {
         if (!InbuiltFeatures.git.state.value) return false
-        val tab = currentDrawerTab ?: return false
+        val drawerViewModel = MainActivity.instance?.drawerViewModel ?: return false
+        val tab = drawerViewModel.currentDrawerTab ?: return false
         if (tab !is FileTreeTab) return false
 
         val rootDir = File(tab.root.getAbsolutePath())


### PR DESCRIPTION
## Changes
- Relocate drawer-related components to a new `com.rk.drawer` package
- Introduce `DrawerViewModel` to manage drawer and service tabs, replacing global state
- Extract `AddProjectSheet` from `Drawer.kt` into a standalone component
- Update `MainActivity` to host and provide `DrawerViewModel`
- Refactor `MainContent`, `TopBar`, and `GlobalToolbarActions` to utilize the new view model
- Update `FileAction` and commands to perform tab operations through `DrawerViewModel`
- Adapt `DrawerPersistence` to handle state saving and restoration using the ViewModel context