### PR TITLE
fix: fix build and move hasSettings to manifest

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainContent.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContent.kt
@@ -53,11 +53,11 @@ import com.rk.editor.preloadSelectionColor
 import com.rk.filetree.FileAction
 import com.rk.filetree.FileActionContext
 import com.rk.filetree.FileActionDialogs
+import com.rk.filetree.FileActionProvider
 import com.rk.filetree.FileIcon
 import com.rk.filetree.FileTreeViewModel
 import com.rk.filetree.MultiFileAction
 import com.rk.filetree.MultiFileActionContext
-import com.rk.filetree.getActions
 import com.rk.icons.XedIcon
 import com.rk.resources.drawables
 import com.rk.resources.getString
@@ -376,7 +376,7 @@ private fun TabItemContent(
         tabState.file?.let {
             DropdownMenu(expanded = showFileActionMenu, onDismissRequest = { showFileActionMenu = false }) {
                 val root = (tabState as? EditorTab)?.projectRoot
-                val actions = remember(it) { getActions(it, root) }
+                val actions = remember(it) { FileActionProvider.getActions(it, root) }
 
                 actions.forEach { action ->
                     when (action) {

--- a/core/main/src/main/java/com/rk/extension/Extension.kt
+++ b/core/main/src/main/java/com/rk/extension/Extension.kt
@@ -16,6 +16,7 @@ sealed interface Extension {
     val tags: List<String>
     val repository: String
     val license: String?
+    val hasSettings: Boolean
 
     val iconUrl: String
 
@@ -64,6 +65,9 @@ data class StoreExtension(val manifest: ExtensionManifest, val verified: Boolean
 
     override val license
         get() = manifest.license
+
+    override val hasSettings: Boolean
+        get() = manifest.hasSettings
 
     override suspend fun getRating() = null
 
@@ -129,6 +133,9 @@ data class LocalExtension(
     override val license
         get() = manifest.license
 
+    override val hasSettings: Boolean
+        get() = manifest.hasSettings
+
     override val iconUrl
         get() = "$installPath/icon.png"
 
@@ -188,6 +195,9 @@ data class UpdatableExtension(val installed: LocalExtension, val store: StoreExt
 
     override val license
         get() = installed.license
+
+    override val hasSettings: Boolean
+        get() = installed.hasSettings
 
     override val iconUrl
         get() = installed.iconUrl

--- a/core/main/src/main/java/com/rk/extension/ExtensionAPI.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionAPI.kt
@@ -8,7 +8,5 @@ abstract class ExtensionAPI(protected val context: ExtensionContext) : Applicati
 
     abstract fun onUninstalled()
 
-    open val hasSettings = false
-
-    @Composable open fun SettingsUI() {}
+    @Composable open fun SettingsContent() {}
 }

--- a/core/main/src/main/java/com/rk/extension/ExtensionManifest.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionManifest.kt
@@ -18,6 +18,7 @@ data class ExtensionManifest(
     val repository: String,
     val license: String? = null,
     val tags: List<String> = emptyList(),
+    val hasSettings: Boolean = false,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/core/main/src/main/java/com/rk/filetree/FileTree.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTree.kt
@@ -147,7 +147,7 @@ fun FileTree(
 @Composable
 private fun SelectionActions(viewModel: FileTreeViewModel, drawerViewModel: DrawerViewModel, rootNode: FileTreeNode) {
     val selectedFiles = viewModel.getSelectedFiles(rootNode.file)
-    val actions = remember(selectedFiles, rootNode.file) { getActions(selectedFiles, rootNode.file) }
+    val actions = remember(selectedFiles, rootNode.file) { FileActionProvider.getActions(selectedFiles, rootNode.file) }
     var expanded by remember { mutableStateOf(false) }
 
     val context = LocalContext.current

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
@@ -68,16 +68,14 @@ fun ExtensionDetail(extension: Extension?, navController: NavController) {
     var isRefreshing by remember { mutableStateOf(false) }
     var refreshKey by remember { mutableIntStateOf(0) }
 
-    val api = extensionManager.loadedExtensions[extension]
-
     RefreshablePreferenceLayout(
         label = extension?.name ?: stringResource(strings.ext_not_found),
         backArrowVisible = true,
         isExpandedScreen = true,
         actions = {
-            if (api == null || !api.hasSettings) {
+            if (extension?.hasSettings == true) {
                 IconButton(
-                    enabled = api != null,
+                    enabled = extensionManager.isInstalled(extension.id),
                     onClick = { navController.navigate("${SettingsRoutes.ExtensionSettings.route}/{extensionId}") },
                 ) {
                     Icon(

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionSettings.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionSettings.kt
@@ -19,7 +19,7 @@ fun ExtensionSettings(extension: Extension?) {
         if (extension == null || api == null) {
             Text(stringResource(strings.ext_not_found_desc), modifier = Modifier.padding(horizontal = 16.dp))
         } else {
-            api.SettingsUI()
+            api.SettingsContent()
         }
     }
 }


### PR DESCRIPTION
## Changes
- Move `hasSettings` property from `ExtensionAPI` to `ExtensionManifest` and the `Extension` interface to allow checking for settings support without initializing the extension.
- Rename `ExtensionAPI.SettingsUI()` to `ExtensionAPI.SettingsContent()`.
- Update `ExtensionDetail` to check settings availability via the extension manifest and verify installation status before enabling settings navigation.
- Relocate `getActions` utility calls to `FileActionProvider.getActions` therefore fixing broken build.