### PR TITLE
feat: refactor icon handling system

### DIFF
--- a/core/main/src/main/java/com/rk/commands/editor/CopyCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/CopyCommand.kt
@@ -18,7 +18,7 @@ class CopyCommand : EditorCommand() {
         editorActionContext.editor.copyText()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.copy)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.copy)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_C, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/CutCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/CutCommand.kt
@@ -23,7 +23,7 @@ class CutCommand : EditorCommand() {
         return editorNonActionContext.editorTab.editorState.editable
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.cut)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.cut)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_X, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/DuplicateLineCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/DuplicateLineCommand.kt
@@ -23,7 +23,7 @@ class DuplicateLineCommand : EditorCommand() {
         return editorNonActionContext.editorTab.editorState.editable
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.duplicate_line)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.duplicate_line)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_D, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/EmulateKeyCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/EmulateKeyCommand.kt
@@ -46,7 +46,7 @@ class EmulateKeyCommand : EditorCommand() {
 
     override fun action(editorActionContext: EditorActionContext) {}
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.keyboard)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.keyboard)
 
     override val childCommands: List<Command> by lazy {
         val keyEvents = KeyEvent::class.java.fields

--- a/core/main/src/main/java/com/rk/commands/editor/JumpToLineCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/JumpToLineCommand.kt
@@ -18,7 +18,7 @@ class JumpToLineCommand : EditorCommand() {
         editorActionContext.editorTab.editorState.showJumpToLineDialog = true
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.arrow_outward)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.arrow_outward)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_G, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/LowerCaseCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/LowerCaseCommand.kt
@@ -22,5 +22,5 @@ class LowerCaseCommand : EditorCommand() {
         }
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.letters)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.letters)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/PasteCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/PasteCommand.kt
@@ -23,7 +23,7 @@ class PasteCommand : EditorCommand() {
         return editorNonActionContext.editorTab.editorState.editable
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.paste)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.paste)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_V, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/RedoCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/RedoCommand.kt
@@ -26,7 +26,7 @@ class RedoCommand : EditorCommand() {
         return editorState.editable && editorState.canRedo
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.redo)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.redo)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_Y, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/RefreshCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/RefreshCommand.kt
@@ -31,7 +31,7 @@ class RefreshCommand : EditorCommand() {
         }
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.refresh)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.refresh)
 
     override val defaultKeybinds: KeyCombination =
         KeyCombination(keyCode = KeyEvent.KEYCODE_R, ctrl = true, shift = true)

--- a/core/main/src/main/java/com/rk/commands/editor/ReplaceCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/ReplaceCommand.kt
@@ -22,7 +22,7 @@ class ReplaceCommand : EditorCommand() {
         }
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.find_replace)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.find_replace)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_H, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/RunCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/RunCommand.kt
@@ -43,7 +43,7 @@ class RunCommand : EditorCommand() {
         return RunnerManager.isRunnable(editorNonActionContext.editorTab.file)
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.run)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.run)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_F5)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/SaveCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/SaveCommand.kt
@@ -26,7 +26,7 @@ class SaveCommand : EditorCommand() {
         return editorNonActionContext.editorTab.file.canWrite()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.save)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.save)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_S, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/SearchCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/SearchCommand.kt
@@ -22,7 +22,7 @@ class SearchCommand : EditorCommand() {
         }
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.search)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.search)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_F, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/SelectAllCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/SelectAllCommand.kt
@@ -18,7 +18,7 @@ class SelectAllCommand : EditorCommand() {
         editorActionContext.editor.selectAll()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.select_all)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.select_all)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_A, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/SelectWordCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/SelectWordCommand.kt
@@ -18,7 +18,7 @@ class SelectWordCommand : EditorCommand() {
         editorActionContext.editor.selectCurrentWord()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.select)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.select)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_W, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/ShareCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/ShareCommand.kt
@@ -48,5 +48,5 @@ class ShareCommand : EditorCommand() {
         }
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.send)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.send)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/SortLinesAscendingCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/SortLinesAscendingCommand.kt
@@ -34,5 +34,5 @@ class SortLinesAscendingCommand : EditorCommand() {
         editor.text.replace(startLine, 0, endLine, endLineColumn, ascendingLines)
     }
 
-    override fun getIcon() = Icon.DrawableRes(drawables.sort_by_alphabet)
+    override fun getIcon() = Icon.ResourceIcon(drawables.sort_by_alphabet)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/SortLinesDescendingCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/SortLinesDescendingCommand.kt
@@ -34,5 +34,5 @@ class SortLinesDescendingCommand : EditorCommand() {
         editor.text.replace(startLine, 0, endLine, endLineColumn, descendingLine)
     }
 
-    override fun getIcon() = Icon.DrawableRes(drawables.sort_by_alphabet)
+    override fun getIcon() = Icon.ResourceIcon(drawables.sort_by_alphabet)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/SyntaxHighlightingCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/SyntaxHighlightingCommand.kt
@@ -16,7 +16,7 @@ class SyntaxHighlightingCommand : EditorCommand() {
 
     override fun action(editorActionContext: EditorActionContext) {}
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.edit_note)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.edit_note)
 
     override val childCommands: List<Command> by lazy {
         FileTypeManager.allTypes()
@@ -31,7 +31,7 @@ class SyntaxHighlightingCommand : EditorCommand() {
                         editorActionContext.editorTab.editorState.textmateScope = fileType.textmateScope!!
                     }
 
-                    override fun getIcon(): Icon = fileType.getIcon()
+                    override fun getIcon(): Icon = fileType.getResolvedIcon()
                 }
             }
     }

--- a/core/main/src/main/java/com/rk/commands/editor/ToggleReadOnlyCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/ToggleReadOnlyCommand.kt
@@ -36,9 +36,9 @@ class ToggleReadOnlyCommand : EditorCommand() {
     override fun getIcon(): Icon {
         val editorTab = commandContext.mainViewModel.currentTab as? EditorTab
         return if (editorTab?.editorState?.editable == true) {
-            Icon.DrawableRes(drawables.lock)
+            Icon.ResourceIcon(drawables.lock)
         } else {
-            Icon.DrawableRes(drawables.edit)
+            Icon.ResourceIcon(drawables.edit)
         }
     }
 

--- a/core/main/src/main/java/com/rk/commands/editor/ToggleWordWrapCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/ToggleWordWrapCommand.kt
@@ -19,7 +19,7 @@ class ToggleWordWrapCommand : EditorCommand() {
         editor.setWordwrap(!editor.isWordwrap, true, true)
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.edit_note)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.edit_note)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_Z, alt = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/UndoCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/UndoCommand.kt
@@ -26,7 +26,7 @@ class UndoCommand : EditorCommand() {
         return editorState.editable && editorState.canUndo
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.undo)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.undo)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_Z, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/editor/UpperCaseCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/UpperCaseCommand.kt
@@ -22,5 +22,5 @@ class UpperCaseCommand : EditorCommand() {
         }
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.letters)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.letters)
 }

--- a/core/main/src/main/java/com/rk/commands/global/CommandPaletteCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/CommandPaletteCommand.kt
@@ -18,7 +18,7 @@ class CommandPaletteCommand : GlobalCommand() {
         commandContext.mainViewModel.showCommandPalette()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.command_palette)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.command_palette)
 
     override val defaultKeybinds: KeyCombination =
         KeyCombination(keyCode = KeyEvent.KEYCODE_P, ctrl = true, shift = true)

--- a/core/main/src/main/java/com/rk/commands/global/NewFileCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/NewFileCommand.kt
@@ -19,7 +19,7 @@ class NewFileCommand : GlobalCommand() {
         addDialog = true
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.add)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.add)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_N, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/global/SaveAllCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/SaveAllCommand.kt
@@ -28,7 +28,7 @@ class SaveAllCommand : GlobalCommand() {
         return commandContext.mainViewModel.tabs.isNotEmpty()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.save)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.save)
 
     override val defaultKeybinds: KeyCombination =
         KeyCombination(keyCode = KeyEvent.KEYCODE_S, ctrl = true, shift = true)

--- a/core/main/src/main/java/com/rk/commands/global/SearchCodeCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/SearchCodeCommand.kt
@@ -23,7 +23,7 @@ class SearchCodeCommand : GlobalCommand() {
         return commandContext.drawerViewModel.currentDrawerTab != null
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.search)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.search)
 
     override val defaultKeybinds: KeyCombination =
         KeyCombination(keyCode = KeyEvent.KEYCODE_F, ctrl = true, shift = true)

--- a/core/main/src/main/java/com/rk/commands/global/SearchFileFolderCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/SearchFileFolderCommand.kt
@@ -24,7 +24,7 @@ class SearchFileFolderCommand : GlobalCommand() {
         return commandContext.drawerViewModel.currentDrawerTab is FileTreeTab
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.search)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.search)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_P, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/global/SettingsCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/SettingsCommand.kt
@@ -21,7 +21,7 @@ class SettingsCommand : GlobalCommand() {
         activity.startActivity(Intent(activity, SettingsActivity::class.java))
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.settings)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.settings)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_COMMA, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/global/TerminalCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/global/TerminalCommand.kt
@@ -46,7 +46,7 @@ class TerminalCommand : GlobalCommand() {
 
     override fun isSupported(): Boolean = InbuiltFeatures.terminal.state.value
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.terminal)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.terminal)
 
     override val defaultKeybinds: KeyCombination = KeyCombination(keyCode = KeyEvent.KEYCODE_J, ctrl = true)
 }

--- a/core/main/src/main/java/com/rk/commands/lsp/FormatDocumentCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/lsp/FormatDocumentCommand.kt
@@ -23,5 +23,5 @@ class FormatDocumentCommand : LspCommand() {
         return lspNonActionContext.lspConnector.isFormattingSupported()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.auto_fix)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.auto_fix)
 }

--- a/core/main/src/main/java/com/rk/commands/lsp/FormatSelectionCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/lsp/FormatSelectionCommand.kt
@@ -23,5 +23,5 @@ class FormatSelectionCommand : LspCommand() {
         return lspNonActionContext.lspConnector.isRangeFormattingSupported()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.auto_fix)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.auto_fix)
 }

--- a/core/main/src/main/java/com/rk/commands/lsp/GoToDefinitionCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/lsp/GoToDefinitionCommand.kt
@@ -28,5 +28,5 @@ class GoToDefinitionCommand : LspCommand() {
         return lspNonActionContext.lspConnector.isGoToDefinitionSupported()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.jump_to_element)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.jump_to_element)
 }

--- a/core/main/src/main/java/com/rk/commands/lsp/GoToReferencesCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/lsp/GoToReferencesCommand.kt
@@ -28,5 +28,5 @@ class GoToReferencesCommand : LspCommand() {
         return lspNonActionContext.lspConnector.isGoToReferencesSupported()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.manage_search)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.manage_search)
 }

--- a/core/main/src/main/java/com/rk/commands/lsp/RenameSymbolCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/lsp/RenameSymbolCommand.kt
@@ -23,5 +23,5 @@ class RenameSymbolCommand : LspCommand() {
         return lspNonActionContext.lspConnector.isRenameSymbolSupported()
     }
 
-    override fun getIcon(): Icon = Icon.DrawableRes(drawables.manage_search)
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.manage_search)
 }

--- a/core/main/src/main/java/com/rk/components/AddDialogItem.kt
+++ b/core/main/src/main/java/com/rk/components/AddDialogItem.kt
@@ -1,5 +1,6 @@
 package com.rk.components
 
+import android.content.res.Resources
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -19,7 +20,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.rk.components.compose.utils.addIf
@@ -29,7 +32,7 @@ import java.io.File
 
 @Composable
 fun AddDialogItem(
-    @DrawableRes icon: Int,
+    @DrawableRes resId: Int,
     title: String,
     description: String? = null,
     enabled: Boolean = true,
@@ -40,7 +43,33 @@ fun AddDialogItem(
         description = description,
         onClick = onClick,
         enabled = enabled,
-        icon = { Icon(painter = painterResource(icon), contentDescription = null, modifier = Modifier.size(24.dp)) },
+        icon = { Icon(painter = painterResource(resId), contentDescription = null, modifier = Modifier.size(24.dp)) },
+    )
+}
+
+@Composable
+fun AddDialogItem(
+    @DrawableRes resId: Int,
+    resources: Resources,
+    title: String,
+    description: String? = null,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    AddDialogItem(
+        title = title,
+        description = description,
+        onClick = onClick,
+        enabled = enabled,
+        icon = {
+            val theme = LocalContext.current.theme
+
+            Icon(
+                imageVector = ImageVector.vectorResource(theme = theme, resId = resId, res = resources),
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+        },
     )
 }
 
@@ -94,9 +123,20 @@ fun AddDialogItem(
     onClick: () -> Unit,
 ) {
     when (icon) {
-        is Icon.DrawableRes -> {
+        is Icon.ResourceIcon -> {
             AddDialogItem(
-                icon = icon.drawableRes,
+                resId = icon.drawableRes,
+                title = title,
+                description = description,
+                onClick = onClick,
+                enabled = enabled,
+            )
+        }
+
+        is Icon.ExternalResourceIcon -> {
+            AddDialogItem(
+                resId = icon.drawableRes,
+                resources = icon.resources,
                 title = title,
                 description = description,
                 onClick = onClick,

--- a/core/main/src/main/java/com/rk/components/GlobalToolbarActions.kt
+++ b/core/main/src/main/java/com/rk/components/GlobalToolbarActions.kt
@@ -115,7 +115,7 @@ fun GlobalToolbarActions(viewModel: MainViewModel, drawerViewModel: DrawerViewMo
     if (addDialog) {
         ModalBottomSheet(onDismissRequest = { addDialog = false }) {
             Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 0.dp)) {
-                AddDialogItem(icon = drawables.file, title = stringResource(strings.temp_file)) {
+                AddDialogItem(resId = drawables.file, title = stringResource(strings.temp_file)) {
                     val intent = Intent(Intent.ACTION_CREATE_DOCUMENT)
                     intent.addCategory(Intent.CATEGORY_OPENABLE)
                     intent.setType("application/octet-stream")
@@ -162,7 +162,7 @@ fun GlobalToolbarActions(viewModel: MainViewModel, drawerViewModel: DrawerViewMo
                     }
                 }
 
-                AddDialogItem(icon = drawables.file_symlink, title = stringResource(strings.open_file)) {
+                AddDialogItem(resId = drawables.file_symlink, title = stringResource(strings.open_file)) {
                     addDialog = false
                     MainActivity.instance?.apply {
                         fileManager.requestOpenFile(mimeType = "*/*") {

--- a/core/main/src/main/java/com/rk/drawer/AddProjectSheet.kt
+++ b/core/main/src/main/java/com/rk/drawer/AddProjectSheet.kt
@@ -49,7 +49,7 @@ fun AddProjectSheet(
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.Companion.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 0.dp)) {
             AddDialogItem(
-                icon = Icon.DrawableRes(drawables.file_symlink),
+                icon = Icon.ResourceIcon(drawables.file_symlink),
                 title = stringResource(strings.open_directory),
                 description = stringResource(strings.open_dir_desc),
                 onClick = {
@@ -70,7 +70,7 @@ fun AddProjectSheet(
             val storage = Environment.getExternalStorageDirectory()
             if ((isManager || (!is11Plus && legacyPermission)) && storage.canWrite() && storage.canRead()) {
                 AddDialogItem(
-                    icon = Icon.DrawableRes(drawables.android),
+                    icon = Icon.ResourceIcon(drawables.android),
                     title = stringResource(strings.internal_storage),
                     description = stringResource(strings.open_internal_storage),
                     onClick = {
@@ -94,7 +94,7 @@ fun AddProjectSheet(
                     val description = if (removable) strings.open_removable_storage else strings.open_internal_storage
 
                     AddDialogItem(
-                        icon = Icon.DrawableRes(drawables.sd_card),
+                        icon = Icon.ResourceIcon(drawables.sd_card),
                         title = name,
                         description = stringResource(description),
                     ) {
@@ -106,7 +106,7 @@ fun AddProjectSheet(
 
             if (InbuiltFeatures.debugMode.state.value) {
                 AddDialogItem(
-                    icon = Icon.DrawableRes(drawables.build),
+                    icon = Icon.ResourceIcon(drawables.build),
                     title = stringResource(strings.private_files),
                     description = stringResource(strings.private_files_desc),
                     onClick = {
@@ -126,7 +126,7 @@ fun AddProjectSheet(
             // Clone repository option
             if (InbuiltFeatures.git.state.value) {
                 AddDialogItem(
-                    icon = Icon.DrawableRes(drawables.git),
+                    icon = Icon.ResourceIcon(drawables.git),
                     title = stringResource(strings.clone_repo),
                     description = stringResource(strings.clone_repo_desc),
                     onClick = {
@@ -138,7 +138,7 @@ fun AddProjectSheet(
 
             // Terminal Home option
             AddDialogItem(
-                icon = Icon.DrawableRes(drawables.terminal),
+                icon = Icon.ResourceIcon(drawables.terminal),
                 title = stringResource(strings.terminal_home),
                 description = stringResource(strings.terminal_home_desc),
                 onClick = {

--- a/core/main/src/main/java/com/rk/file/BuiltinFileType.kt
+++ b/core/main/src/main/java/com/rk/file/BuiltinFileType.kt
@@ -82,8 +82,8 @@ interface FileType {
         get() = null
 
     val textmateScope: String?
-    val icon: Int?
-    val iconOverride: Map<String, Int>?
+    val icon: Icon?
+    val iconOverride: Map<String, Icon>?
         get() = null
 
     val name: String
@@ -105,11 +105,9 @@ interface FileType {
      *
      * @return An [Icon] representing the file type icon.
      */
-    fun getIcon(): Icon {
+    fun getResolvedIcon(): Icon {
         val iconPackFile = currentIconPack.value?.getIconFileForFileType(this)
-        return iconPackFile?.let { Icon.SvgIcon(it) }
-            ?: icon?.let { Icon.DrawableRes(it) }
-            ?: Icon.DrawableRes(drawables.file)
+        return iconPackFile?.let { Icon.SvgIcon(it) } ?: icon ?: Icon.ResourceIcon(drawables.file)
     }
 }
 
@@ -168,8 +166,8 @@ enum class BuiltinFileType(
     override val extensions: List<String>,
     override val names: List<String>? = null,
     override val textmateScope: String?,
-    override val icon: Int?,
-    override val iconOverride: Map<String, Int>? = null,
+    override val icon: Icon?,
+    override val iconOverride: Map<String, Icon>? = null,
     override val title: String,
     override val markdownNames: List<String> = emptyList(),
 ) : FileType {
@@ -177,46 +175,71 @@ enum class BuiltinFileType(
     JAVASCRIPT(
         extensions = listOf("js", "mjs", "cjs", "jscsrc", "jshintrc", "mut"),
         textmateScope = "source.js",
-        icon = js,
+        icon = Icon.ResourceIcon(js),
         title = "JavaScript",
         markdownNames = listOf("javascript"),
     ),
     TYPESCRIPT(
         extensions = listOf("ts", "mts", "cts"),
         textmateScope = "source.ts",
-        icon = ts,
+        icon = Icon.ResourceIcon(ts),
         title = "TypeScript",
         markdownNames = listOf("typescript"),
     ),
-    JSX(extensions = listOf("jsx"), textmateScope = "source.js.jsx", icon = react, title = "JavaScript JSX"),
-    TSX(extensions = listOf("tsx"), textmateScope = "source.tsx", icon = react, title = "TypeScript JSX"),
+    JSX(
+        extensions = listOf("jsx"),
+        textmateScope = "source.js.jsx",
+        icon = Icon.ResourceIcon(react),
+        title = "JavaScript JSX",
+    ),
+    TSX(
+        extensions = listOf("tsx"),
+        textmateScope = "source.tsx",
+        icon = Icon.ResourceIcon(react),
+        title = "TypeScript JSX",
+    ),
     HTML(
         extensions = listOf("html", "htm", "xhtml", "xht"),
         textmateScope = "text.html.basic",
-        icon = html,
+        icon = Icon.ResourceIcon(html),
         title = "HTML",
     ),
-    HTMX(extensions = listOf("htmx"), textmateScope = "text.html.htmx", icon = html, title = "HTMX"),
-    CSS(extensions = listOf("css"), textmateScope = "source.css", icon = css, title = "CSS"),
-    SCSS(extensions = listOf("scss", "sass"), textmateScope = "source.css.scss", icon = sass, title = "SCSS"),
-    LESS(extensions = listOf("less"), textmateScope = "source.css.less", icon = less, title = "Less"),
-    JSON(extensions = listOf("json", "jsonl", "jsonc"), textmateScope = "source.json", icon = json, title = "JSON"),
+    HTMX(extensions = listOf("htmx"), textmateScope = "text.html.htmx", icon = Icon.ResourceIcon(html), title = "HTMX"),
+    CSS(extensions = listOf("css"), textmateScope = "source.css", icon = Icon.ResourceIcon(css), title = "CSS"),
+    SCSS(
+        extensions = listOf("scss", "sass"),
+        textmateScope = "source.css.scss",
+        icon = Icon.ResourceIcon(sass),
+        title = "SCSS",
+    ),
+    LESS(
+        extensions = listOf("less"),
+        textmateScope = "source.css.less",
+        icon = Icon.ResourceIcon(less),
+        title = "Less",
+    ),
+    JSON(
+        extensions = listOf("json", "jsonl", "jsonc"),
+        textmateScope = "source.json",
+        icon = Icon.ResourceIcon(json),
+        title = "JSON",
+    ),
     MARKDOWN(
         extensions = listOf("md", "markdown", "mdown", "mkd", "mkdn", "mdoc", "mdtext", "mdtxt", "mdwn"),
         textmateScope = "text.html.markdown",
-        icon = markdown,
+        icon = Icon.ResourceIcon(markdown),
         title = "Markdown",
     ),
     XML(
         extensions = listOf("xml", "xaml", "dtd", "plist", "ascx", "csproj", "wxi", "wxl", "wxs", "svg"),
         textmateScope = "text.xml",
-        icon = xml,
+        icon = Icon.ResourceIcon(xml),
         title = "XML",
     ),
     YAML(
         extensions = listOf("yaml", "yml", "eyaml", "eyml", "cff"),
         textmateScope = "source.yaml",
-        icon = yaml,
+        icon = Icon.ResourceIcon(yaml),
         title = "YAML",
     ),
 
@@ -224,46 +247,51 @@ enum class BuiltinFileType(
     PYTHON(
         extensions = listOf("py", "pyi"),
         textmateScope = "source.python",
-        icon = python,
+        icon = Icon.ResourceIcon(python),
         title = "Python",
         markdownNames = listOf("python"),
     ),
-    JAVA(extensions = listOf("java", "jav", "bsh"), textmateScope = "source.java", icon = java, title = "Java"),
+    JAVA(
+        extensions = listOf("java", "jav", "bsh"),
+        textmateScope = "source.java",
+        icon = Icon.ResourceIcon(java),
+        title = "Java",
+    ),
     GROOVY(
         extensions = listOf("gsh", "groovy", "gradle", "gvy", "gy"),
         textmateScope = "source.groovy",
-        icon = groovy,
-        iconOverride = mapOf("gradle" to gradle),
+        icon = Icon.ResourceIcon(groovy),
+        iconOverride = mapOf("gradle" to Icon.ResourceIcon(gradle)),
         title = "Groovy",
     ),
-    C(extensions = listOf("c"), textmateScope = "source.c", icon = c, title = "C"),
+    C(extensions = listOf("c"), textmateScope = "source.c", icon = Icon.ResourceIcon(c), title = "C"),
     CPP(
         extensions = listOf("cpp", "cxx", "cc", "c++", "h", "hpp", "hh", "hxx", "h++"),
         textmateScope = "source.cpp",
-        icon = cpp,
+        icon = Icon.ResourceIcon(cpp),
         title = "C++",
     ),
     CSHARP(
         extensions = listOf("cs", "csx"),
         textmateScope = "source.cs",
-        icon = csharp,
+        icon = Icon.ResourceIcon(csharp),
         title = "C#",
         markdownNames = listOf("csharp"),
     ),
     RUBY(
         extensions = listOf("rb", "erb", "gemspec"),
         textmateScope = "source.ruby",
-        icon = ruby,
+        icon = Icon.ResourceIcon(ruby),
         title = "Ruby",
         markdownNames = listOf("ruby"),
     ),
-    LUA(extensions = listOf("lua", "luau"), textmateScope = "source.lua", icon = lua, title = "Lua"),
-    GO(extensions = listOf("go"), textmateScope = "source.go", icon = go, title = "Go"),
-    PHP(extensions = listOf("php"), textmateScope = "source.php", icon = php, title = "PHP"),
+    LUA(extensions = listOf("lua", "luau"), textmateScope = "source.lua", icon = Icon.ResourceIcon(lua), title = "Lua"),
+    GO(extensions = listOf("go"), textmateScope = "source.go", icon = Icon.ResourceIcon(go), title = "Go"),
+    PHP(extensions = listOf("php"), textmateScope = "source.php", icon = Icon.ResourceIcon(php), title = "PHP"),
     RUST(
         extensions = listOf("rs"),
         textmateScope = "source.rust",
-        icon = rust,
+        icon = Icon.ResourceIcon(rust),
         title = "Rust",
         markdownNames = listOf("rust"),
     ),
@@ -274,19 +302,29 @@ enum class BuiltinFileType(
         title = "Pascal",
         markdownNames = listOf("pascal"),
     ),
-    ZIG(extensions = listOf("zig"), textmateScope = "source.zig", icon = zig, title = "Zig"),
-    NIM(extensions = listOf("nim"), textmateScope = "source.nim", icon = nim, title = "Nim"),
-    SWIFT(extensions = listOf("swift"), textmateScope = "source.swift", icon = swift, title = "Swift"),
-    DART(extensions = listOf("dart"), textmateScope = "source.dart", icon = dart, title = "Dart"),
+    ZIG(extensions = listOf("zig"), textmateScope = "source.zig", icon = Icon.ResourceIcon(zig), title = "Zig"),
+    NIM(extensions = listOf("nim"), textmateScope = "source.nim", icon = Icon.ResourceIcon(nim), title = "Nim"),
+    SWIFT(
+        extensions = listOf("swift"),
+        textmateScope = "source.swift",
+        icon = Icon.ResourceIcon(swift),
+        title = "Swift",
+    ),
+    DART(extensions = listOf("dart"), textmateScope = "source.dart", icon = Icon.ResourceIcon(dart), title = "Dart"),
     ROCQ(extensions = listOf("v", "coq"), textmateScope = "source.coq", icon = null, title = "Rocq (Coq)"),
     KOTLIN(
         extensions = listOf("kt", "kts"),
         textmateScope = "source.kotlin",
-        icon = kotlin,
+        icon = Icon.ResourceIcon(kotlin),
         title = "Kotlin",
         markdownNames = listOf("kotlin"),
     ),
-    LISP(extensions = listOf("lisp", "clisp"), textmateScope = "source.lisp", icon = lisp, title = "Lisp"),
+    LISP(
+        extensions = listOf("lisp", "clisp"),
+        textmateScope = "source.lisp",
+        icon = Icon.ResourceIcon(lisp),
+        title = "Lisp",
+    ),
     SHELL(
         extensions =
             listOf(
@@ -309,15 +347,20 @@ enum class BuiltinFileType(
                 "ksh",
             ),
         textmateScope = "source.shell",
-        icon = shell,
+        icon = Icon.ResourceIcon(shell),
         title = "Shell script",
         markdownNames = listOf("shell", "console"),
     ),
-    WINDOWS_SHELL(extensions = listOf("cmd", "bat"), textmateScope = "source.batchfile", icon = shell, title = "Batch"),
+    WINDOWS_SHELL(
+        extensions = listOf("cmd", "bat"),
+        textmateScope = "source.batchfile",
+        icon = Icon.ResourceIcon(shell),
+        title = "Batch",
+    ),
     POWERSHELL(
         extensions = listOf("ps1", "psm1", "psd1"),
         textmateScope = "source.powershell",
-        icon = powershell,
+        icon = Icon.ResourceIcon(powershell),
         title = "PowerShell",
         markdownNames = listOf("powershell", "ps"),
     ),
@@ -327,58 +370,89 @@ enum class BuiltinFileType(
         extensions = emptyList(),
         names = listOf("cmakelists.txt"),
         textmateScope = "source.cmake",
-        icon = cmake,
+        icon = Icon.ResourceIcon(cmake),
         title = "CMake",
     ),
-    R(extensions = listOf("r"), textmateScope = "source.r", icon = r, title = "R", markdownNames = listOf("r")),
+    R(
+        extensions = listOf("r"),
+        textmateScope = "source.r",
+        icon = Icon.ResourceIcon(r),
+        title = "R",
+        markdownNames = listOf("r"),
+    ),
 
     // Data Files
-    SQL(extensions = listOf("sql", "dsql", "sqllite"), textmateScope = "source.sql", icon = sql, title = "SQL"),
-    TOML(extensions = listOf("toml"), textmateScope = "source.toml", icon = toml, title = "TOML"),
-    INI(extensions = listOf("ini"), textmateScope = "source.ini", icon = prop, title = "INI"),
+    SQL(
+        extensions = listOf("sql", "dsql", "sqllite"),
+        textmateScope = "source.sql",
+        icon = Icon.ResourceIcon(sql),
+        title = "SQL",
+    ),
+    TOML(extensions = listOf("toml"), textmateScope = "source.toml", icon = Icon.ResourceIcon(toml), title = "TOML"),
+    INI(extensions = listOf("ini"), textmateScope = "source.ini", icon = Icon.ResourceIcon(prop), title = "INI"),
     PROPERTIES(
         extensions =
             listOf("properties", "cfg", "conf", "config", "editorconfig", "gitconfig", "gitmodules", "gitattributes"),
         textmateScope = "source.properties",
-        icon = prop,
-        iconOverride = mapOf("gitmodules" to git, "gitattributes" to git, "gitconfig" to git),
+        icon = Icon.ResourceIcon(prop),
+        iconOverride =
+            mapOf(
+                "gitmodules" to Icon.ResourceIcon(git),
+                "gitattributes" to Icon.ResourceIcon(git),
+                "gitconfig" to Icon.ResourceIcon(git),
+            ),
         title = "Properties",
     ),
     IGNORE(
         extensions = listOf("gitignore", "gitignore_global", "gitkeep", "git-blame-ignore-revs"),
         textmateScope = "source.ignore",
-        icon = git,
+        icon = Icon.ResourceIcon(git),
         title = "Ignore",
     ),
-    DIFF(extensions = listOf("diff", "patch", "rej"), textmateScope = "source.diff", icon = diff, title = "Diff"),
+    DIFF(
+        extensions = listOf("diff", "patch", "rej"),
+        textmateScope = "source.diff",
+        icon = Icon.ResourceIcon(diff),
+        title = "Diff",
+    ),
 
     // Documents
     TEXT(
         extensions = listOf("txt"),
         textmateScope = null,
-        icon = text,
+        icon = Icon.ResourceIcon(text),
         title = "Plain text",
         markdownNames = listOf("plaintext", "text"),
     ),
     LOG(extensions = listOf("log"), textmateScope = "text.log", icon = null, title = "Log"),
-    LATEX(extensions = listOf("latex", "tex", "ltx"), textmateScope = "text.tex.latex", icon = latex, title = "LaTeX"),
+    LATEX(
+        extensions = listOf("latex", "tex", "ltx"),
+        textmateScope = "text.tex.latex",
+        icon = Icon.ResourceIcon(latex),
+        title = "LaTeX",
+    ),
     IMAGE(
         extensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp", "ico", "heic", "heif", "avif"),
         textmateScope = null,
-        icon = image,
+        icon = Icon.ResourceIcon(image),
         title = "Image",
     ),
     AUDIO(
         extensions = listOf("mp3", "wav", "flac", "ogg", "aac", "m4a", "wma", "opus"),
         textmateScope = null,
-        icon = audio,
+        icon = Icon.ResourceIcon(audio),
         title = "Audio",
     ),
-    VIDEO(extensions = listOf("mp4", "avi", "mov", "mkv", "webm"), textmateScope = null, icon = video, title = "Video"),
+    VIDEO(
+        extensions = listOf("mp4", "avi", "mov", "mkv", "webm"),
+        textmateScope = null,
+        icon = Icon.ResourceIcon(video),
+        title = "Video",
+    ),
     ARCHIVE(
         extensions = listOf("zip", "rar", "7z", "tar", "gz", "bz2", "xy"),
         textmateScope = null,
-        icon = archive,
+        icon = Icon.ResourceIcon(archive),
         title = "Archive",
     ),
     EXECUTABLE(
@@ -387,6 +461,6 @@ enum class BuiltinFileType(
         icon = null,
         title = "Executable",
     ),
-    APK(extensions = listOf("apk", "xapk", "apks"), textmateScope = null, icon = apk, title = "APK"),
+    APK(extensions = listOf("apk", "xapk", "apks"), textmateScope = null, icon = Icon.ResourceIcon(apk), title = "APK"),
     UNKNOWN(extensions = emptyList(), textmateScope = null, icon = null, title = strings.unknown.getString()),
 }

--- a/core/main/src/main/java/com/rk/filetree/FileAction.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileAction.kt
@@ -106,7 +106,7 @@ object RefreshAction : MultiFileAction() {
 }
 
 object TerminalAction : FileAction() {
-    override val icon = Icon.DrawableRes(drawables.terminal)
+    override val icon = Icon.ResourceIcon(drawables.terminal)
     override val title = strings.open_in_terminal.getString()
 
     override fun action(context: FileActionContext) {
@@ -173,7 +173,7 @@ object DeleteAction : MultiFileAction() {
 }
 
 object CopyAction : MultiFileAction() {
-    override val icon = Icon.DrawableRes(drawables.copy)
+    override val icon = Icon.ResourceIcon(drawables.copy)
     override val title = strings.copy.getString()
 
     override fun action(context: MultiFileActionContext) {
@@ -186,7 +186,7 @@ object CopyAction : MultiFileAction() {
 }
 
 object CutAction : MultiFileAction() {
-    override val icon = Icon.DrawableRes(drawables.cut)
+    override val icon = Icon.ResourceIcon(drawables.cut)
     override val title = strings.cut.getString()
 
     override fun action(context: MultiFileActionContext) {
@@ -198,7 +198,7 @@ object CutAction : MultiFileAction() {
 }
 
 object PasteAction : FileAction() {
-    override val icon = Icon.DrawableRes(drawables.paste)
+    override val icon = Icon.ResourceIcon(drawables.paste)
     override val title = strings.paste.getString()
 
     override fun action(context: FileActionContext) {
@@ -243,7 +243,7 @@ object PasteAction : FileAction() {
 }
 
 object OpenWithAction : FileAction() {
-    override val icon = Icon.DrawableRes(drawables.open_in_new)
+    override val icon = Icon.ResourceIcon(drawables.open_in_new)
     override val title = strings.open_with.getString()
 
     override fun action(context: FileActionContext) {
@@ -254,7 +254,7 @@ object OpenWithAction : FileAction() {
 }
 
 object SaveAsAction : FileAction() {
-    override val icon = Icon.DrawableRes(drawables.file_symlink)
+    override val icon = Icon.ResourceIcon(drawables.file_symlink)
     override val title = strings.save_as.getString()
 
     override fun action(context: FileActionContext) {
@@ -265,7 +265,7 @@ object SaveAsAction : FileAction() {
 }
 
 object AddFileAction : FileAction() {
-    override val icon = Icon.DrawableRes(drawables.arrow_downward)
+    override val icon = Icon.ResourceIcon(drawables.arrow_downward)
     override val title = strings.add_file.getString()
 
     override fun action(context: FileActionContext) {
@@ -276,7 +276,7 @@ object AddFileAction : FileAction() {
 }
 
 object OpenAsProjectAction : FileAction() {
-    override val icon = Icon.DrawableRes(drawables.folder_code)
+    override val icon = Icon.ResourceIcon(drawables.folder_code)
     override val title = strings.open_as_project.getString()
 
     override fun action(context: FileActionContext) {

--- a/core/main/src/main/java/com/rk/filetree/FileIcon.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileIcon.kt
@@ -2,25 +2,22 @@ package com.rk.filetree
 
 import android.content.Context
 import android.graphics.drawable.Drawable
-import android.graphics.drawable.PictureDrawable
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import com.caverock.androidsvg.SVG
 import com.rk.file.FileObject
 import com.rk.file.FileTypeManager
+import com.rk.icons.Icon
+import com.rk.icons.XedIcon
 import com.rk.icons.pack.currentIconPack
 import com.rk.icons.rememberSvgImageLoader
 import com.rk.resources.drawables
-import com.rk.resources.getDrawable
-import java.io.InputStream
+import com.rk.utils.loadSvg
 
 private val plain_file = drawables.file
 private val folder = drawables.folder
@@ -53,14 +50,14 @@ fun FileIcon(file: FileObject, iconTint: Color? = null, isExpanded: Boolean = fa
     val icon =
         when {
             file.isFile() -> getBuiltInFileIcon(file)
-            file.isDirectory() -> folder
-            file.isSymlink() -> fileSymlink
-            else -> unknown
+            file.isDirectory() -> Icon.ResourceIcon(folder)
+            file.isSymlink() -> Icon.ResourceIcon(fileSymlink)
+            else -> Icon.ResourceIcon(unknown)
         }
 
     val tint =
         iconTint
-            ?: if (icon == folder || icon == archive) {
+            ?: if (icon is Icon.ResourceIcon && (icon.drawableRes == folder || icon.drawableRes == archive)) {
                 MaterialTheme.colorScheme.primary
             } else MaterialTheme.colorScheme.secondary
 
@@ -75,12 +72,7 @@ fun FileIcon(file: FileObject, iconTint: Color? = null, isExpanded: Boolean = fa
             modifier = Modifier.size(20.dp),
         )
     } else {
-        Icon(
-            painter = painterResource(id = icon),
-            contentDescription = null,
-            tint = tint,
-            modifier = Modifier.size(20.dp),
-        )
+        XedIcon(icon = icon, contentDescription = null, tint = tint, modifier = Modifier.size(20.dp))
     }
 }
 
@@ -104,11 +96,11 @@ fun FileNameIcon(fileName: String, isDirectory: Boolean, iconTint: Color? = null
     val iconPackFile = currentIconPack.value?.getIconFileForName(fileName, isDirectory, isExpanded)
     val imageLoader = rememberSvgImageLoader()
 
-    val icon = if (isDirectory) folder else getBuiltInFileIcon(fileName)
+    val icon = if (isDirectory) Icon.ResourceIcon(folder) else getBuiltInFileIcon(fileName)
 
     val tint =
         iconTint
-            ?: if (icon == folder || icon == archive) {
+            ?: if (icon is Icon.ResourceIcon && (icon.drawableRes == folder || icon.drawableRes == archive)) {
                 MaterialTheme.colorScheme.primary
             } else MaterialTheme.colorScheme.secondary
 
@@ -123,12 +115,7 @@ fun FileNameIcon(fileName: String, isDirectory: Boolean, iconTint: Color? = null
             modifier = Modifier.size(20.dp),
         )
     } else {
-        Icon(
-            painter = painterResource(id = icon),
-            contentDescription = null,
-            tint = tint,
-            modifier = Modifier.size(20.dp),
-        )
+        XedIcon(icon = icon, contentDescription = null, tint = tint, modifier = Modifier.size(20.dp))
     }
 }
 
@@ -144,47 +131,30 @@ fun FileNameIcon(fileName: String, isDirectory: Boolean, iconTint: Color? = null
  * @param isDirectory Whether the file is a directory.
  * @return A [Drawable] representing the file icon.
  */
-fun getDrawableFileIcon(
-    context: Context,
-    fileName: String,
-    isDirectory: Boolean,
-    isExpanded: Boolean = false,
-): Drawable? {
-    fun loadSvg(inputStream: InputStream): Drawable? {
-        val svg =
-            try {
-                SVG.getFromInputStream(inputStream)
-            } catch (_: Exception) {
-                return null
-            }
-
-        val picture = svg.renderToPicture()
-        return PictureDrawable(picture)
-    }
-
+fun getDrawableFileIcon(fileName: String, isDirectory: Boolean, isExpanded: Boolean = false): Drawable? {
     val iconPackFile = currentIconPack.value?.getIconFileForName(fileName, isDirectory, isExpanded)
-    val icon = if (isDirectory) folder else getBuiltInFileIcon(fileName)
+    val icon = if (isDirectory) Icon.ResourceIcon(folder) else getBuiltInFileIcon(fileName)
 
-    val builtinIcon = icon.getDrawable(context)
+    val builtinIcon = icon.toDrawable()
     val iconPackIcon = iconPackFile?.inputStream()?.let { loadSvg(it) }
 
     return iconPackIcon ?: builtinIcon
 }
 
-private fun getBuiltInFileIcon(fileName: String): Int =
+private fun getBuiltInFileIcon(fileName: String): Icon =
     when (fileName) {
         "contract.sol",
         "LICENSE",
-        "NOTICE" -> text
+        "NOTICE" -> Icon.ResourceIcon(text)
         "gradlew",
-        "gradlew.bat" -> gradle
-        "README.md" -> info
+        "gradlew.bat" -> Icon.ResourceIcon(gradle)
+        "README.md" -> Icon.ResourceIcon(info)
 
         else -> {
             val ext = fileName.substringAfterLast('.', "")
             val type = FileTypeManager.fromExtension(ext)
-            type.iconOverride?.get(ext) ?: type.icon ?: plain_file
+            type.iconOverride?.get(ext) ?: type.icon ?: Icon.ResourceIcon(plain_file)
         }
     }
 
-private fun getBuiltInFileIcon(file: FileObject): Int = getBuiltInFileIcon(file.getName())
+private fun getBuiltInFileIcon(file: FileObject): Icon = getBuiltInFileIcon(file.getName())

--- a/core/main/src/main/java/com/rk/filetree/FileTreeTab.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeTab.kt
@@ -252,7 +252,7 @@ class FileTreeTab(val root: FileObject) : DrawerTab() {
                 drawables.outline_folder
             }
 
-        return Icon.DrawableRes(iconId)
+        return Icon.ResourceIcon(iconId)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/core/main/src/main/java/com/rk/git/GitTab.kt
+++ b/core/main/src/main/java/com/rk/git/GitTab.kt
@@ -654,7 +654,7 @@ class GitTab(val viewModel: GitViewModel) : DrawerTab() {
     }
 
     override fun getIcon(): Icon {
-        return Icon.DrawableRes(drawables.git)
+        return Icon.ResourceIcon(drawables.git)
     }
 
     override fun isSupported(): Boolean {

--- a/core/main/src/main/java/com/rk/icons/Icon.kt
+++ b/core/main/src/main/java/com/rk/icons/Icon.kt
@@ -1,14 +1,34 @@
 package com.rk.icons
 
+import android.content.res.Resources
+import android.graphics.drawable.Drawable
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.core.content.res.ResourcesCompat
+import com.rk.utils.application
+import com.rk.utils.loadSvg
 import java.io.File
 
 sealed class Icon {
-    class DrawableRes(@androidx.annotation.DrawableRes val drawableRes: Int) : Icon()
+    class ResourceIcon(@androidx.annotation.DrawableRes val drawableRes: Int) : Icon()
+
+    class ExternalResourceIcon(@androidx.annotation.DrawableRes val drawableRes: Int, val resources: Resources) : Icon()
 
     class VectorIcon(val vector: ImageVector) : Icon()
 
     class SvgIcon(val file: File) : Icon()
 
     class TextIcon(val text: String) : Icon()
+
+    fun toDrawable(): Drawable? {
+        return when (this) {
+            is ResourceIcon -> {
+                ResourcesCompat.getDrawable(application!!.resources, drawableRes, null)
+            }
+            is ExternalResourceIcon -> {
+                ResourcesCompat.getDrawable(resources, drawableRes, null)
+            }
+            is SvgIcon -> loadSvg(file.inputStream())
+            else -> null
+        }
+    }
 }

--- a/core/main/src/main/java/com/rk/icons/XedIcon.kt
+++ b/core/main/src/main/java/com/rk/icons/XedIcon.kt
@@ -8,8 +8,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
@@ -24,9 +26,20 @@ fun XedIcon(
     tint: Color = LocalContentColor.current,
 ) {
     when (icon) {
-        is Icon.DrawableRes -> {
+        is Icon.ResourceIcon -> {
             Icon(
                 painter = painterResource(icon.drawableRes),
+                contentDescription = contentDescription,
+                modifier = modifier,
+                tint = tint,
+            )
+        }
+
+        is Icon.ExternalResourceIcon -> {
+            val theme = LocalContext.current.theme
+
+            Icon(
+                imageVector = ImageVector.vectorResource(theme = theme, resId = icon.drawableRes, res = icon.resources),
                 contentDescription = contentDescription,
                 modifier = modifier,
                 tint = tint,

--- a/core/main/src/main/java/com/rk/lsp/FileIconProvider.kt
+++ b/core/main/src/main/java/com/rk/lsp/FileIconProvider.kt
@@ -1,7 +1,6 @@
 package com.rk.lsp
 
 import android.graphics.drawable.Drawable
-import com.rk.activities.main.MainActivity
 import com.rk.filetree.getDrawableFileIcon
 import io.github.rosemoe.sora.lang.completion.SimpleCompletionIconDrawer
 
@@ -29,7 +28,6 @@ class FileIconProvider : io.github.rosemoe.sora.lang.completion.FileIconProvider
      * @return A [Drawable] if successful, or null if no icon can be loaded.
      */
     override fun load(src: String, isFolder: Boolean): Drawable? {
-        val context = MainActivity.instance ?: return null
-        return getDrawableFileIcon(context, src.substringAfterLast('/'), isFolder)
+        return getDrawableFileIcon(src.substringAfterLast('/'), isFolder)
     }
 }

--- a/core/main/src/main/java/com/rk/lsp/LspServer.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspServer.kt
@@ -9,6 +9,7 @@ import com.rk.activities.main.MainActivity
 import com.rk.exec.TerminalCommand
 import com.rk.exec.launchTerminal
 import com.rk.file.FileObject
+import com.rk.icons.Icon
 import com.rk.tabs.editor.EditorTab
 import com.rk.tabs.editor.applyHighlightingAndConnectLSP
 import com.rk.theme.greenStatus
@@ -122,7 +123,7 @@ abstract class LspServer {
     abstract val languageName: String
     abstract val serverName: String
     abstract val supportedExtensions: List<String>
-    abstract val icon: Int?
+    abstract val icon: Icon?
 }
 
 @Composable

--- a/core/main/src/main/java/com/rk/lsp/servers/ExternalProcessServer.kt
+++ b/core/main/src/main/java/com/rk/lsp/servers/ExternalProcessServer.kt
@@ -7,7 +7,7 @@ import com.rk.lsp.LspServer
 import kotlin.random.Random
 
 // DO not put this in lsp registry
-class ExternalProcessServer(
+data class ExternalProcessServer(
     val command: String,
     override val supportedExtensions: List<String>,
     override val id: String = "${supportedExtensions.firstOrNull()}_${Random.nextInt()}",
@@ -17,17 +17,13 @@ class ExternalProcessServer(
     override val icon = supportedExtensions.firstOrNull()?.let { FileTypeManager.fromExtension(it).icon }
     override val canBeUninstalled = false
 
-    override suspend fun isInstalled(context: Context): Boolean {
-        return true
-    }
+    override suspend fun isInstalled(context: Context) = true
 
     override fun install(context: Context) {}
 
     override fun uninstall(context: Context) {}
 
-    override suspend fun isUpdatable(context: Context): Boolean {
-        return false
-    }
+    override suspend fun isUpdatable(context: Context) = false
 
     override fun update(context: Context) {}
 
@@ -37,35 +33,5 @@ class ExternalProcessServer(
         )
     }
 
-    override fun toString(): String {
-        return serverName
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-        if (!super.equals(other)) return false
-
-        other as ExternalProcessServer
-
-        if (icon != other.icon) return false
-        if (command != other.command) return false
-        if (supportedExtensions != other.supportedExtensions) return false
-        if (languageName != other.languageName) return false
-        if (id != other.id) return false
-        if (serverName != other.serverName) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = super.hashCode()
-        result = 31 * result + (icon ?: 0)
-        result = 31 * result + command.hashCode()
-        result = 31 * result + supportedExtensions.hashCode()
-        result = 31 * result + languageName.hashCode()
-        result = 31 * result + id.hashCode()
-        result = 31 * result + serverName.hashCode()
-        return result
-    }
+    override fun toString() = serverName
 }

--- a/core/main/src/main/java/com/rk/lsp/servers/ExternalSocketServer.kt
+++ b/core/main/src/main/java/com/rk/lsp/servers/ExternalSocketServer.kt
@@ -7,7 +7,7 @@ import com.rk.lsp.LspServer
 import kotlin.random.Random
 
 // DO not put this in lsp registry
-class ExternalSocketServer(
+data class ExternalSocketServer(
     val host: String,
     val port: Int,
     override val supportedExtensions: List<String>,
@@ -19,17 +19,13 @@ class ExternalSocketServer(
     override val icon = supportedExtensions.firstOrNull()?.let { FileTypeManager.fromExtension(it).icon }
     override val canBeUninstalled = false
 
-    override suspend fun isInstalled(context: Context): Boolean {
-        return true
-    }
+    override suspend fun isInstalled(context: Context) = true
 
     override fun install(context: Context) {}
 
     override fun uninstall(context: Context) {}
 
-    override suspend fun isUpdatable(context: Context): Boolean {
-        return false
-    }
+    override suspend fun isUpdatable(context: Context) = false
 
     override fun update(context: Context) {}
 
@@ -37,37 +33,5 @@ class ExternalSocketServer(
         return LspConnectionConfig.Socket(host = host, port = port)
     }
 
-    override fun toString(): String {
-        return serverName
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-        if (!super.equals(other)) return false
-
-        other as ExternalSocketServer
-
-        if (port != other.port) return false
-        if (icon != other.icon) return false
-        if (host != other.host) return false
-        if (supportedExtensions != other.supportedExtensions) return false
-        if (languageName != other.languageName) return false
-        if (id != other.id) return false
-        if (serverName != other.serverName) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = super.hashCode()
-        result = 31 * result + port
-        result = 31 * result + (icon ?: 0)
-        result = 31 * result + host.hashCode()
-        result = 31 * result + supportedExtensions.hashCode()
-        result = 31 * result + languageName.hashCode()
-        result = 31 * result + id.hashCode()
-        result = 31 * result + serverName.hashCode()
-        return result
-    }
+    override fun toString() = serverName
 }

--- a/core/main/src/main/java/com/rk/runner/ShellBasedRunners.kt
+++ b/core/main/src/main/java/com/rk/runner/ShellBasedRunners.kt
@@ -88,7 +88,7 @@ data class ShellBasedRunner(private val name: String, val regex: String) : Runne
     }
 
     override fun getIcon(context: Context): Icon {
-        return Icon.DrawableRes(drawables.bash)
+        return Icon.ResourceIcon(drawables.bash)
     }
 
     override suspend fun isRunning(): Boolean {

--- a/core/main/src/main/java/com/rk/runner/runners/Shell.kt
+++ b/core/main/src/main/java/com/rk/runner/runners/Shell.kt
@@ -37,7 +37,7 @@ class Shell : RunnerImpl() {
     }
 
     override fun getIcon(context: Context): Icon {
-        return Icon.DrawableRes(drawables.bash)
+        return Icon.ResourceIcon(drawables.bash)
     }
 
     override suspend fun isRunning(): Boolean {

--- a/core/main/src/main/java/com/rk/runner/runners/UniversalRunner.kt
+++ b/core/main/src/main/java/com/rk/runner/runners/UniversalRunner.kt
@@ -68,7 +68,7 @@ class UniversalRunner : RunnerImpl() {
     }
 
     override fun getIcon(context: Context): Icon {
-        return Icon.DrawableRes(drawables.run)
+        return Icon.ResourceIcon(drawables.run)
     }
 
     override suspend fun isRunning(): Boolean {

--- a/core/main/src/main/java/com/rk/runner/runners/web/html/HtmlRunner.kt
+++ b/core/main/src/main/java/com/rk/runner/runners/web/html/HtmlRunner.kt
@@ -53,7 +53,7 @@ class HtmlRunner : RunnerImpl() {
     }
 
     override fun getIcon(context: Context): Icon {
-        return Icon.DrawableRes(BuiltinFileType.HTML.icon!!)
+        return BuiltinFileType.HTML.icon!!
     }
 
     override suspend fun isRunning(): Boolean = httpServer?.isAlive == true

--- a/core/main/src/main/java/com/rk/runner/runners/web/markdown/MarkdownRunner.kt
+++ b/core/main/src/main/java/com/rk/runner/runners/web/markdown/MarkdownRunner.kt
@@ -26,7 +26,7 @@ class MarkdownRunner : RunnerImpl() {
     }
 
     override fun getIcon(context: Context): Icon {
-        return Icon.DrawableRes(BuiltinFileType.MARKDOWN.icon!!)
+        return BuiltinFileType.MARKDOWN.icon!!
     }
 
     override suspend fun isRunning(): Boolean {

--- a/core/main/src/main/java/com/rk/settings/editor/CommandSettings.kt
+++ b/core/main/src/main/java/com/rk/settings/editor/CommandSettings.kt
@@ -63,7 +63,7 @@ private fun buildAddActions(
 
             override fun isEnabled(): Boolean = !commandIds.contains(command.id)
 
-            override fun getIcon(): Icon = Icon.DrawableRes(drawables.arrow_outward)
+            override fun getIcon(): Icon = Icon.ResourceIcon(drawables.arrow_outward)
         }
     )
     addAll(

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
@@ -220,9 +220,9 @@ fun ExtensionStats(modifier: Modifier = Modifier, title: String, value: String, 
 }
 
 enum class ExtensionRoutes(val icon: Icon, val label: String, val route: String) {
-    OVERVIEW(Icon.DrawableRes(drawables.file), strings.overview.getString(), "overview"),
-    REVIEWS(Icon.DrawableRes(drawables.comment), strings.reviews.getString(), "reviews"),
-    CHANGELOG(Icon.DrawableRes(drawables.update), strings.changelog.getString(), "changelog"),
+    OVERVIEW(Icon.ResourceIcon(drawables.file), strings.overview.getString(), "overview"),
+    REVIEWS(Icon.ResourceIcon(drawables.comment), strings.reviews.getString(), "reviews"),
+    CHANGELOG(Icon.ResourceIcon(drawables.update), strings.changelog.getString(), "changelog"),
 }
 
 @Composable

--- a/core/main/src/main/java/com/rk/settings/keybinds/KeyUtils.kt
+++ b/core/main/src/main/java/com/rk/settings/keybinds/KeyUtils.kt
@@ -85,7 +85,7 @@ data object KeyUtils {
     }
 
     fun getKeyIcon(keyCode: Int): Icon {
-        return Icon.DrawableRes(
+        return Icon.ResourceIcon(
             when (keyCode) {
                 KeyEvent.KEYCODE_SHIFT_LEFT -> drawables.shift
                 KeyEvent.KEYCODE_DPAD_DOWN -> drawables.chevron_down

--- a/core/main/src/main/java/com/rk/settings/lsp/LspServerDetail.kt
+++ b/core/main/src/main/java/com/rk/settings/lsp/LspServerDetail.kt
@@ -48,6 +48,7 @@ import com.rk.components.SettingsToggle
 import com.rk.components.compose.preferences.base.PreferenceGroup
 import com.rk.components.compose.preferences.base.PreferenceGroupHeading
 import com.rk.components.compose.preferences.base.PreferenceLayout
+import com.rk.icons.XedIcon
 import com.rk.lsp.DefinitionPrevention
 import com.rk.lsp.LspConnectionStatus
 import com.rk.lsp.LspServer
@@ -154,8 +155,8 @@ fun LspServerDetail(navController: NavHostController, server: LspServer) {
             Column(modifier = Modifier.padding(16.dp)) {
                 Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
                     server.icon?.let {
-                        Icon(
-                            painter = painterResource(it),
+                        XedIcon(
+                            icon = it,
                             contentDescription = null,
                             modifier = Modifier.size(42.dp).padding(end = 8.dp),
                         )

--- a/core/main/src/main/java/com/rk/settings/lsp/LspSettings.kt
+++ b/core/main/src/main/java/com/rk/settings/lsp/LspSettings.kt
@@ -51,6 +51,8 @@ import com.rk.components.InfoBlock
 import com.rk.components.SettingsToggle
 import com.rk.components.compose.preferences.base.PreferenceGroup
 import com.rk.components.compose.preferences.base.PreferenceLayout
+import com.rk.icons.Icon
+import com.rk.icons.XedIcon
 import com.rk.lsp.LspPersistence
 import com.rk.lsp.LspRegistry
 import com.rk.lsp.LspServer
@@ -108,7 +110,7 @@ fun LspSettings(navController: NavController) {
         PreferenceGroup(heading = stringResource(strings.external)) {
             LspRegistry.externalServers.forEachIndexed { index, server ->
                 key(server.id) {
-                    val icon = server.icon ?: drawables.unknown_document
+                    val icon = server.icon ?: Icon.ResourceIcon(drawables.unknown_document)
                     SettingsToggle(
                         label = server.languageName,
                         default = true,
@@ -205,7 +207,7 @@ private fun LspServerItem(
     navController: NavController,
     refreshKey: Int,
 ) {
-    val icon = server.icon ?: drawables.unknown_document
+    val icon = server.icon ?: Icon.ResourceIcon(drawables.unknown_document)
     SettingsToggle(
         label = server.languageName,
         default = Preference.getBoolean("lsp_${server.id}", true),
@@ -274,9 +276,9 @@ fun rememberLspInstallStatus(context: Context, server: LspServer, refreshKey: In
 }
 
 @Composable
-private fun LspServerIcon(server: LspServer, i: Int) {
+private fun LspServerIcon(server: LspServer, icon: Icon) {
     BadgedBox(badge = { server.getDominantStatusColor()?.let { color -> Badge(containerColor = color) } }) {
-        Icon(modifier = Modifier.padding(start = 16.dp), painter = painterResource(i), contentDescription = null)
+        XedIcon(icon = icon, contentDescription = null, modifier = Modifier.padding(start = 16.dp))
     }
 }
 

--- a/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
@@ -361,7 +361,7 @@ open class EditorTab(override var file: FileObject, var projectRoot: FileObject?
                         Column(modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 0.dp)) {
                             editorState.runnersToShow.forEach { runner ->
                                 AddDialogItem(
-                                    icon = runner.getIcon(context) ?: Icon.DrawableRes(drawableRes = drawables.run),
+                                    icon = runner.getIcon(context) ?: Icon.ResourceIcon(drawableRes = drawables.run),
                                     title = runner.getName(),
                                 ) {
                                     DefaultScope.launch {

--- a/core/main/src/main/java/com/rk/utils/Utils.kt
+++ b/core/main/src/main/java/com/rk/utils/Utils.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.PictureDrawable
 import android.os.Build
 import android.telephony.TelephonyManager
 import android.text.Spanned
@@ -37,6 +39,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.core.net.toUri
 import com.blankj.utilcode.util.ThreadUtils
+import com.caverock.androidsvg.SVG
 import com.rk.activities.main.gitViewModel
 import com.rk.file.BuiltinFileType
 import com.rk.file.FileObject
@@ -55,6 +58,7 @@ import com.rk.theme.gitDeleted
 import com.rk.theme.gitModified
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
 import java.io.File
+import java.io.InputStream
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.text.NumberFormat
@@ -475,4 +479,16 @@ fun timeAgo(currentTimeMillis: Long, startTimeMillis: Long): String? {
         hours < 24 -> plurals.time_hours_ago.getQuantityString(hours, hours)
         else -> plurals.time_days_ago.getQuantityString(days, days)
     }
+}
+
+fun loadSvg(inputStream: InputStream): Drawable? {
+    val svg =
+        try {
+            SVG.getFromInputStream(inputStream)
+        } catch (_: Exception) {
+            return null
+        }
+
+    val picture = svg.renderToPicture()
+    return PictureDrawable(picture)
 }


### PR DESCRIPTION
## Changes
- Rename `Icon.DrawableRes` to `Icon.ResourceIcon` and introduce `Icon.ExternalResourceIcon` for extension or external resource loading.
- Update `BuiltinFileType`, `LspServer`, and all command classes to use the `Icon` sealed class instead of raw drawable resource IDs.
- Enhance `AddDialogItem` and `XedIcon` components to handle both internal and external resources.
- Centralize SVG loading logic into `Utils.kt` and add a `toDrawable()` helper to the `Icon` class.
- Refactor `FileIcon.kt` to return `Icon` objects and improve icon resolution logic.
- Convert `ExternalProcessServer` and `ExternalSocketServer` to data classes for improved equality checks and code clarity.
- Update LSP settings and detail views to utilize the refactored icon system.