### PR TITLE
feat: implement extension update support

### DIFF
--- a/core/main/src/main/java/com/rk/extension/Extension.kt
+++ b/core/main/src/main/java/com/rk/extension/Extension.kt
@@ -5,7 +5,11 @@ import android.content.pm.PackageManager
 import dalvik.system.PathClassLoader
 import java.io.File
 import java.util.Date
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
+
+data class ExtensionStats(val downloadCount: Int?, val rating: Float?, val size: Long?)
 
 sealed interface Extension {
     val id: ExtensionId
@@ -23,13 +27,9 @@ sealed interface Extension {
     val readmeUrl: String
     val changelogUrl: String
 
-    suspend fun calcSize(): Long
-
-    suspend fun getRating(): Float?
+    suspend fun getStats(): ExtensionStats
 
     suspend fun getReviews(): List<Review>
-
-    suspend fun getDownloadCount(): Int?
 }
 
 data class Review(val rating: Int, val text: String, val author: String, val date: Date, val authorResponse: String?)
@@ -69,8 +69,6 @@ data class StoreExtension(val manifest: ExtensionManifest, val verified: Boolean
     override val hasSettings: Boolean
         get() = manifest.hasSettings
 
-    override suspend fun getRating() = null
-
     override val iconUrl: String
         get() = ExtensionRegistry.getIconUrl(manifest.id)
 
@@ -80,11 +78,9 @@ data class StoreExtension(val manifest: ExtensionManifest, val verified: Boolean
     override val changelogUrl
         get() = ExtensionRegistry.getChangelogUrl(manifest.id)
 
-    override suspend fun calcSize() = 0L // TODO
+    override suspend fun getStats() = ExtensionRegistry.getStats(manifest.id)
 
     override suspend fun getReviews(): List<Review> = emptyList()
-
-    override suspend fun getDownloadCount() = ExtensionRegistry.getDownloadCount(manifest.id)
 }
 
 /** Extensions that are installed locally (from disk). */
@@ -145,76 +141,79 @@ data class LocalExtension(
     override val changelogUrl
         get() = "$installPath/CHANGELOG.md"
 
-    override suspend fun calcSize(): Long {
-        var totalSize = 0L
-        val stack = ArrayDeque<File>()
-        stack.add(File(installPath))
-
-        loop@ while (stack.isNotEmpty()) {
-            val current = stack.removeLast()
-            runCatching {
-                if (current.isDirectory()) {
-                    val files = current.listFiles() ?: continue@loop
-                    stack.addAll(files)
-                } else {
-                    totalSize += current.length()
-                }
-            }
-        }
-        return totalSize
+    override suspend fun getStats(): ExtensionStats {
+        return ExtensionStats(null, null, calcSize())
     }
 
-    override suspend fun getRating() = null
+    private suspend fun calcSize(): Long {
+        return withContext(Dispatchers.IO) {
+            var totalSize = 0L
+            val stack = ArrayDeque<File>()
+            stack.add(File(installPath))
+
+            loop@ while (stack.isNotEmpty()) {
+                val current = stack.removeLast()
+                runCatching {
+                    if (current.isDirectory()) {
+                        val files = current.listFiles() ?: continue@loop
+                        stack.addAll(files)
+                    } else {
+                        totalSize += current.length()
+                    }
+                }
+            }
+            totalSize
+        }
+    }
 
     override suspend fun getReviews(): List<Review> = emptyList()
-
-    override suspend fun getDownloadCount() = null
 }
 
 data class UpdatableExtension(val installed: LocalExtension, val store: StoreExtension) : Extension {
     override val id
-        get() = installed.id
+        get() = store.id
 
     override val name
-        get() = installed.name
+        get() = store.name
 
     override val version
         get() = installed.version
 
+    val newVersion: String
+        get() = store.version
+
     override val author
-        get() = installed.author
+        get() = store.author
 
     override val description
-        get() = installed.description
+        get() = store.description
 
     override val tags
-        get() = installed.tags
+        get() = store.tags
 
     override val repository
-        get() = installed.repository
+        get() = store.repository
 
     override val license
-        get() = installed.license
+        get() = store.license
 
     override val hasSettings: Boolean
         get() = installed.hasSettings
 
     override val iconUrl
-        get() = installed.iconUrl
+        get() = store.iconUrl
 
     override val readmeUrl
-        get() = installed.readmeUrl
+        get() = store.readmeUrl
 
     override val changelogUrl
-        get() = installed.changelogUrl
+        get() = store.changelogUrl
 
-    override suspend fun calcSize() = installed.calcSize()
-
-    override suspend fun getRating() = store.getRating()
+    override suspend fun getStats() = store.getStats()
 
     override suspend fun getReviews() = store.getReviews()
 
-    override suspend fun getDownloadCount() = store.getDownloadCount()
+    fun isUpdatable() = installed.version != store.version
 }
 
 fun LocalExtension.classLoader(parent: ClassLoader?) = PathClassLoader(apkFile.absolutePath, parent)

--- a/core/main/src/main/java/com/rk/extension/ExtensionManager.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionManager.kt
@@ -42,6 +42,33 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
         }
     }
 
+    fun isInstalled(extensionId: ExtensionId) = localExtensions.containsKey(extensionId)
+
+    fun getExtension(extensionId: ExtensionId): Extension? {
+        val local = localExtensions[extensionId]
+        val store = storeExtension[extensionId]
+
+        return when {
+            local != null && store != null -> UpdatableExtension(local, store)
+            local != null -> local
+            store != null -> store
+            else -> null
+        }
+    }
+
+    fun getSyncedExtensions(): List<Extension> {
+        val allIds = localExtensions.keys + storeExtension.keys
+        return allIds.mapNotNull { id -> getExtension(id) }
+    }
+
+    fun getLocalExtensions(): List<Extension> {
+        return getSyncedExtensions().filterIsInstance<LocalExtension>()
+    }
+
+    fun getStoreExtensions(): List<Extension> {
+        return getSyncedExtensions().filter { it is StoreExtension || it is UpdatableExtension }
+    }
+
     suspend fun indexLocalExtensions() =
         mutex.withLock {
             localExtensions.clear()
@@ -182,11 +209,4 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
             delete()
         } else if (name.startsWith(pkgName)) delete()
     }
-
-    fun isInstalled(extensionId: ExtensionId) = localExtensions.containsKey(extensionId)
-
-    fun getExtension(extensionId: ExtensionId) = localExtensions[extensionId] ?: storeExtension[extensionId]
-
-    fun getExtensionManifest(extensionId: ExtensionId) =
-        localExtensions[extensionId]?.manifest ?: storeExtension[extensionId]?.manifest
 }

--- a/core/main/src/main/java/com/rk/extension/ExtensionRegistry.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionRegistry.kt
@@ -16,7 +16,8 @@ import okhttp3.Request
 
 @Serializable private data class ExtensionDetail(val downloads: Int? = null, val download: DownloadUrls)
 
-@Serializable private data class DownloadUrls(val icon: String? = null, val readme: String? = null, val zip: String)
+@Serializable
+private data class DownloadUrls(val icon: String? = null, val readme: String? = null, val zip: String, val size: Int)
 
 object ExtensionRegistry {
     private const val TAG = "ExtensionRegistry"
@@ -45,16 +46,22 @@ object ExtensionRegistry {
 
     fun getChangelogUrl(id: String): String = "$BASE_URL/$id/CHANGELOG.md"
 
-    suspend fun getDownloadCount(id: String): Int? = getDetails(id)?.downloads
-
-    private suspend fun getDetails(id: String): ExtensionDetail? =
-        runCatching {
-                withContext(Dispatchers.IO) {
-                    val jsonString = requestJson("$BASE_URL/$id")
-                    json.decodeFromString<ExtensionDetail>(jsonString)
+    suspend fun getStats(id: String): ExtensionStats {
+        val details =
+            runCatching {
+                    withContext(Dispatchers.IO) {
+                        val jsonString = requestJson("$BASE_URL/$id")
+                        json.decodeFromString<ExtensionDetail>(jsonString)
+                    }
                 }
-            }
-            .getOrNull()
+                .getOrNull()
+
+        return ExtensionStats(
+            downloadCount = details?.downloads,
+            rating = null,
+            size = details?.download?.size?.toLong(),
+        )
+    }
 
     private fun requestJson(url: String): String {
         val req = Request.Builder().url(url).build()
@@ -69,7 +76,7 @@ object ExtensionRegistry {
     suspend fun downloadZip(manifest: ExtensionManifest, destFile: File): Boolean =
         withContext(Dispatchers.IO) {
             runCatching {
-                    val zipUrl = getDetails(manifest.id)?.download?.zip ?: error("Extension ZIP file was not found.")
+                    val zipUrl = "$BASE_URL/${manifest.id}/plugin.zip"
 
                     val request = Request.Builder().url(zipUrl).build()
                     client.newCall(request).execute().use { response ->

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionActionButton.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionActionButton.kt
@@ -14,11 +14,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.rk.extension.Extension
+import com.rk.extension.UpdatableExtension
 import com.rk.icons.Download
 import com.rk.icons.XedIcons
+import com.rk.resources.drawables
 import com.rk.resources.strings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -27,6 +30,8 @@ enum class InstallState {
     Idle,
     Installing,
     Installed,
+    Updatable,
+    Updating,
 }
 
 @Composable
@@ -36,6 +41,7 @@ fun ExtensionActionButton(
     scope: CoroutineScope,
     onInstallClick: suspend (Extension) -> Unit,
     onUninstallClick: suspend (Extension) -> Unit,
+    onUpdateClick: suspend (UpdatableExtension) -> Unit,
 ) {
     when (installState) {
         InstallState.Idle -> {
@@ -43,6 +49,11 @@ fun ExtensionActionButton(
                 onClick = { scope.launch { onInstallClick(extension) } },
                 shape = RoundedCornerShape(10.dp),
                 elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        contentColor = MaterialTheme.colorScheme.onSurface,
+                    ),
             ) {
                 Icon(XedIcons.Download, contentDescription = null, Modifier.size(18.dp))
                 Spacer(Modifier.width(6.dp))
@@ -81,6 +92,40 @@ fun ExtensionActionButton(
                 Icon(Icons.Outlined.Delete, contentDescription = stringResource(strings.delete), Modifier.size(18.dp))
                 Spacer(Modifier.width(6.dp))
                 Text(stringResource(strings.uninstall))
+            }
+        }
+
+        InstallState.Updatable -> {
+            val updatableExtension = extension as UpdatableExtension
+            Button(
+                onClick = { scope.launch { onUpdateClick(updatableExtension) } },
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(10.dp),
+                elevation = ButtonDefaults.buttonElevation(defaultElevation = 4.dp),
+            ) {
+                Icon(
+                    painterResource(drawables.update),
+                    contentDescription = stringResource(strings.update),
+                    Modifier.size(18.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(stringResource(strings.update))
+            }
+        }
+
+        InstallState.Updating -> {
+            Button(
+                onClick = {},
+                enabled = false,
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(10.dp),
+                colors = ButtonDefaults.buttonColors(disabledContentColor = MaterialTheme.colorScheme.onSurface),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(stringResource(strings.updating))
             }
         }
     }

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionCard.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionCard.kt
@@ -27,6 +27,7 @@ import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
 import com.rk.extension.Extension
+import com.rk.extension.UpdatableExtension
 import com.rk.resources.drawables
 import com.rk.theme.Typography
 
@@ -38,6 +39,7 @@ fun ExtensionCard(
     installState: InstallState = InstallState.Idle,
     onInstallClick: suspend (Extension) -> Unit,
     onUninstallClick: suspend (Extension) -> Unit,
+    onUpdateClick: suspend (UpdatableExtension) -> Unit,
     onClick: (Extension) -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
@@ -81,10 +83,21 @@ fun ExtensionCard(
                         style = Typography.labelMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
+
+                    val isUpdatable = extension is UpdatableExtension && extension.isUpdatable()
+                    if (isUpdatable) {
+                        Text(
+                            text = " → v${extension.newVersion}",
+                            style = Typography.labelMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 }
             }
 
-            ExtensionActionButton(extension, installState, scope, onInstallClick, onUninstallClick)
+            ExtensionActionButton(extension, installState, scope, onInstallClick, onUninstallClick, onUpdateClick)
         }
     }
 }

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
@@ -1,7 +1,9 @@
 package com.rk.settings.extension
 
+import android.content.Intent
 import androidx.activity.compose.LocalActivity
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -25,10 +27,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -42,6 +44,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import coil.request.CachePolicy
@@ -50,6 +53,7 @@ import com.rk.App.Companion.extensionManager
 import com.rk.activities.settings.SettingsRoutes
 import com.rk.components.compose.preferences.base.RefreshablePreferenceLayout
 import com.rk.extension.Extension
+import com.rk.extension.UpdatableExtension
 import com.rk.icons.Icon
 import com.rk.icons.XedIcon
 import com.rk.resources.drawables
@@ -67,12 +71,17 @@ fun ExtensionDetail(extension: Extension?, navController: NavController) {
 
     var isRefreshing by remember { mutableStateOf(false) }
     var refreshKey by remember { mutableIntStateOf(0) }
+    var showSourceCodeSheet by remember { mutableStateOf(false) }
 
     RefreshablePreferenceLayout(
         label = extension?.name ?: stringResource(strings.ext_not_found),
         backArrowVisible = true,
         isExpandedScreen = true,
         actions = {
+            IconButton(onClick = { showSourceCodeSheet = true }) {
+                Icon(painter = painterResource(drawables.xml), contentDescription = null)
+            }
+
             if (extension?.hasSettings == true) {
                 IconButton(
                     enabled = extensionManager.isInstalled(extension.id),
@@ -97,7 +106,11 @@ fun ExtensionDetail(extension: Extension?, navController: NavController) {
             var installState by remember {
                 mutableStateOf(
                     if (extensionManager.isInstalled(extension.id)) {
-                        InstallState.Installed
+                        if (extension is UpdatableExtension && extension.isUpdatable()) {
+                            InstallState.Updatable
+                        } else {
+                            InstallState.Installed
+                        }
                     } else {
                         InstallState.Idle
                     }
@@ -105,9 +118,13 @@ fun ExtensionDetail(extension: Extension?, navController: NavController) {
             }
 
             Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                AboutSection(extension, installState, { installState = it }, scope)
+                AboutSection(extension, refreshKey, installState, { installState = it }, scope)
             }
             TabSection(extension, scope, refreshKey, onLoaded = { isRefreshing = false })
+
+            if (showSourceCodeSheet) {
+                SourceCodeSheet(extension) { showSourceCodeSheet = false }
+            }
         }
     }
 }
@@ -115,14 +132,13 @@ fun ExtensionDetail(extension: Extension?, navController: NavController) {
 @Composable
 private fun AboutSection(
     extension: Extension,
+    refreshKey: Int,
     installState: InstallState,
     updateInstallState: (InstallState) -> Unit,
     scope: CoroutineScope,
 ) {
     val context = LocalContext.current
     val activity = LocalActivity.current as? AppCompatActivity
-
-    var showSourceCodeSheet by remember { mutableStateOf(false) }
 
     Row(verticalAlignment = Alignment.CenterVertically) {
         AsyncImage(
@@ -148,49 +164,83 @@ private fun AboutSection(
             )
 
             Row(verticalAlignment = Alignment.CenterVertically) {
-                ExtensionAuthorIcon(extension.author, Modifier.size(16.dp).padding(end = 4.dp))
+                Row(
+                    modifier =
+                        Modifier.clickable(
+                            enabled = extension.author.github != null,
+                            onClick = {
+                                val githubProfileUrl = extension.author.github.let { "https://github.com/$it" }
+                                val intent = Intent(Intent.ACTION_VIEW, githubProfileUrl.toUri())
+                                context.startActivity(intent)
+                            },
+                        ),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    ExtensionAuthorIcon(extension.author, Modifier.size(16.dp).padding(end = 4.dp))
+                    Text(
+                        text = "${extension.author}",
+                        style = Typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
                 Text(
-                    text = "${extension.author} • v${extension.version}",
+                    text = " • v${extension.version}",
                     style = Typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
-            }
-        }
 
-        IconButton(onClick = { showSourceCodeSheet = true }) {
-            Icon(painter = painterResource(drawables.xml), contentDescription = null)
+                val isUpdatable = extension is UpdatableExtension && extension.isUpdatable()
+                if (isUpdatable) {
+                    Text(
+                        text = " → v${extension.newVersion}",
+                        style = Typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
         }
 
         ExtensionActionButton(
             extension = extension,
             installState = installState,
             scope = scope,
-            onInstallClick = { runExtensionInstallAction(extension, updateInstallState, scope, context, activity) },
-            onUninstallClick = { runExtensionUninstallAction(extension, updateInstallState, activity) },
+            onInstallClick = { runExtensionInstallAction(it, updateInstallState, scope, context, activity) },
+            onUninstallClick = { runExtensionUninstallAction(it, updateInstallState, activity) },
+            onUpdateClick = { runExtensionUpdateAction(it, updateInstallState, scope, context, activity) },
         )
     }
 
-    val size by produceState("---") { value = formatFileSize(extension.calcSize()) }
-    val rating by
-        produceState<Pair<String, ImageVector?>>("---" to null) {
-            val rating = extension.getRating() ?: return@produceState
-            value = rating.toString() to Icons.Default.Star
+    var size by remember { mutableStateOf("---") }
+    var rating by remember { mutableStateOf("---") }
+    var downloadCount by remember { mutableStateOf("---") }
+    var showStar by remember { mutableStateOf(false) }
+
+    LaunchedEffect(refreshKey) {
+        val stats = extension.getStats()
+        stats.size?.let { size = formatFileSize(it) }
+        stats.rating?.let {
+            rating = it.toString()
+            showStar = true
         }
-    val downloadCount by
-        produceState("---") {
-            val count = extension.getDownloadCount() ?: return@produceState
-            value = formatNumberCompact(count)
-        }
-    Row(modifier = Modifier.padding(top = 8.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        ExtensionStats(Modifier.weight(1f), stringResource(strings.downloads).uppercase(), downloadCount)
-        ExtensionStats(Modifier.weight(1f), stringResource(strings.rating).uppercase(), rating.first, rating.second)
-        ExtensionStats(Modifier.weight(1f), stringResource(strings.size).uppercase(), size)
+        stats.downloadCount?.let { downloadCount = formatNumberCompact(it) }
     }
 
-    if (showSourceCodeSheet) {
-        SourceCodeSheet(extension) { showSourceCodeSheet = false }
+    Row(modifier = Modifier.padding(top = 8.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        ExtensionStats(Modifier.weight(1f), stringResource(strings.downloads).uppercase(), downloadCount)
+        ExtensionStats(
+            Modifier.weight(1f),
+            stringResource(strings.rating).uppercase(),
+            rating,
+            if (showStar) Icons.Default.Star else null,
+        )
+        ExtensionStats(Modifier.weight(1f), stringResource(strings.size).uppercase(), size)
     }
 }
 

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionScreen.kt
@@ -59,6 +59,7 @@ import com.rk.components.compose.preferences.base.PreferenceGroup
 import com.rk.components.compose.preferences.base.RefreshablePreferenceLayoutLazyColumn
 import com.rk.extension.Extension
 import com.rk.extension.StoreExtension
+import com.rk.extension.UpdatableExtension
 import com.rk.resources.drawables
 import com.rk.resources.strings
 import com.rk.theme.Typography
@@ -116,10 +117,10 @@ fun ExtensionScreen(navController: NavController) {
         remember(selectedCategory) {
             derivedStateOf {
                 when (selectedCategory) {
-                    ExtensionCategories.ALL -> extensionManager.localExtensions + extensionManager.storeExtension
-                    ExtensionCategories.LOCAL -> extensionManager.localExtensions
-                    ExtensionCategories.STORE -> extensionManager.storeExtension
-                }.map { it.value }
+                    ExtensionCategories.ALL -> extensionManager.getSyncedExtensions()
+                    ExtensionCategories.LOCAL -> extensionManager.getLocalExtensions()
+                    ExtensionCategories.STORE -> extensionManager.getStoreExtensions()
+                }
             }
         }
     val filteredExtensions by
@@ -211,24 +212,28 @@ fun ExtensionScreen(navController: NavController) {
 
         if (sortedExtension.isNotEmpty() || isIndexing || isFetching) {
             items(sortedExtension, key = { it.id }) { extension ->
-                var installState by remember {
-                    mutableStateOf(
-                        if (extensionManager.isInstalled(extension.id)) {
-                            InstallState.Installed
-                        } else {
-                            InstallState.Idle
-                        }
-                    )
-                }
+                var installState by
+                    remember(extension) {
+                        mutableStateOf(
+                            if (extensionManager.isInstalled(extension.id)) {
+                                if (extension is UpdatableExtension && extension.isUpdatable()) {
+                                    InstallState.Updatable
+                                } else {
+                                    InstallState.Installed
+                                }
+                            } else {
+                                InstallState.Idle
+                            }
+                        )
+                    }
 
                 ExtensionCard(
                     modifier = Modifier.padding(top = 8.dp, start = 16.dp, end = 16.dp),
                     extension = extension,
                     installState = installState,
-                    onInstallClick = {
-                        runExtensionInstallAction(extension, { installState = it }, scope, context, activity)
-                    },
-                    onUninstallClick = { runExtensionUninstallAction(extension, { installState = it }, activity) },
+                    onInstallClick = { runExtensionInstallAction(it, { installState = it }, scope, context, activity) },
+                    onUninstallClick = { runExtensionUninstallAction(it, { installState = it }, activity) },
+                    onUpdateClick = { runExtensionUpdateAction(it, { installState = it }, scope, context, activity) },
                     onClick = { navController.navigate("${SettingsRoutes.ExtensionDetail.route}/${it.id}") },
                 )
             }

--- a/core/main/src/main/java/com/rk/settings/extension/extensionActions.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/extensionActions.kt
@@ -5,12 +5,14 @@ import android.content.Context
 import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import com.rk.App
+import com.rk.App.Companion.extensionManager
 import com.rk.activities.settings.SettingsActivity
 import com.rk.extension.Extension
 import com.rk.extension.ExtensionError
 import com.rk.extension.InstallResult
 import com.rk.extension.LocalExtension
 import com.rk.extension.StoreExtension
+import com.rk.extension.UpdatableExtension
 import com.rk.extension.installExtensionFromZip
 import com.rk.extension.load
 import com.rk.file.toFileObject
@@ -34,7 +36,7 @@ suspend fun runExtensionUninstallAction(
     updateInstallState: (InstallState) -> Unit,
     activity: AppCompatActivity?,
 ) {
-    App.extensionManager.uninstallExtension(extension.id).onFailure {
+    extensionManager.uninstallExtension(extension.id).onFailure {
         errorDialog(it, activity)
         return
     }
@@ -58,7 +60,7 @@ suspend fun runExtensionInstallAction(
             loading.setMessage(strings.installing.getString())
 
             val result =
-                App.extensionManager.installStoreExtension(context, extension).getOrElse {
+                extensionManager.installStoreExtension(context, extension).getOrElse {
                     loading.hide()
                     errorDialog(it.message ?: strings.unknown_error.getString(), activity)
                     updateInstallState(InstallState.Idle)
@@ -80,6 +82,46 @@ suspend fun runExtensionInstallAction(
             loading?.hide()
             errorDialog(it, activity)
             updateInstallState(InstallState.Idle)
+        }
+}
+
+suspend fun runExtensionUpdateAction(
+    extension: UpdatableExtension,
+    updateInstallState: (InstallState) -> Unit,
+    scope: CoroutineScope,
+    context: Context,
+    activity: AppCompatActivity?,
+) {
+    updateInstallState(InstallState.Updating)
+    var loading: LoadingPopup? = null
+
+    runCatching {
+            loading = LoadingPopup(activity).show()
+            loading.setMessage(strings.updating.getString())
+
+            val result =
+                extensionManager.installStoreExtension(context, extension.store).getOrElse {
+                    loading.hide()
+                    errorDialog(it.message ?: strings.unknown_error.getString(), activity)
+                    updateInstallState(InstallState.Idle)
+                    return@runCatching
+                }
+
+            handleInstallResult(result, activity, { updateInstallState(InstallState.Idle) }) { ext ->
+                updateInstallState(InstallState.Installed)
+
+                scope.launch(Dispatchers.Default) {
+                    ext.load(application!!).onFailure {
+                        errorDialog(it.message ?: strings.unknown_error.getString(), activity)
+                    }
+                }
+            }
+            loading.hide()
+        }
+        .onFailure {
+            loading?.hide()
+            errorDialog(it, activity)
+            updateInstallState(InstallState.Updatable)
         }
 }
 

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -157,6 +157,7 @@
     <string name="name_empty_err">Name cannot be empty</string>
     <string name="value_empty_err">Value cannot be empty</string>
     <string name="installing">Installing…</string>
+    <string name="updating">Updating…</string>
     <string name="install_from_storage">Install from storage</string>
     <string name="no_ext">No extensions found.</string>
     <string name="loading">Loading…</string>

--- a/plugin-sdk/settings.gradle.kts
+++ b/plugin-sdk/settings.gradle.kts
@@ -1,6 +1,3 @@
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
-}
-
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0" }
 
 rootProject.name = "Xed-Editor-Sdk"


### PR DESCRIPTION
## Changes
- Add support for updating extensions, including `UpdatableExtension` logic to compare local and store versions.
- Introduce `InstallState.Updatable` and `InstallState.Updating` to the extension UI.
- Add `runExtensionUpdateAction` to handle the download and re-installation of updated extensions.
- Refactor extension metadata (downloads, rating, size) into a consolidated `ExtensionStats` object fetched via `ExtensionRegistry`.
- Update `ExtensionManager` to provide synced, local, and store-specific extension lists.
- Enhance `ExtensionDetail` with clickable author links and a source code shortcut.
- Improve `ExtensionCard` and `ExtensionActionButton` to display version increments and update progress.
- Update `foojay-resolver-convention` plugin version in `settings.gradle.kts`.