### PR TITLE
feat: unify version terminology

### DIFF
--- a/core/main/src/main/java/com/rk/extension/ExtensionManager.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionManager.kt
@@ -166,9 +166,9 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
             val pm = context.packageManager
             val xedVersionCode = PackageInfoCompat.getLongVersionCode(pm.getPackageInfo(context.packageName, 0))
 
-            if (extensionInfo.minAppVersion != -1 && xedVersionCode < extensionInfo.minAppVersion) {
+            if (extensionInfo.minAppVersion != null && xedVersionCode < extensionInfo.minAppVersion) {
                 return@withContext InstallResult.Error(ExtensionError.OUTDATED_CLIENT)
-            } else if (extensionInfo.maxAppVersion != -1 && xedVersionCode > extensionInfo.maxAppVersion) {
+            } else if (extensionInfo.maxAppVersion != null && xedVersionCode > extensionInfo.maxAppVersion) {
                 return@withContext InstallResult.Error(ExtensionError.OUTDATED_EXTENSION)
             }
 

--- a/core/main/src/main/java/com/rk/extension/ExtensionManager.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionManager.kt
@@ -168,7 +168,7 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
 
             if (extensionInfo.minAppVersion != -1 && xedVersionCode < extensionInfo.minAppVersion) {
                 return@withContext InstallResult.Error(ExtensionError.OUTDATED_CLIENT)
-            } else if (extensionInfo.targetAppVersion != -1 && xedVersionCode > extensionInfo.targetAppVersion) {
+            } else if (extensionInfo.maxAppVersion != -1 && xedVersionCode > extensionInfo.maxAppVersion) {
                 return@withContext InstallResult.Error(ExtensionError.OUTDATED_EXTENSION)
             }
 

--- a/core/main/src/main/java/com/rk/extension/ExtensionManifest.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionManifest.kt
@@ -13,8 +13,8 @@ data class ExtensionManifest(
     val version: String = "1.0.0",
     val description: String? = null,
     val author: ExtensionAuthor,
-    val minAppVersion: Int = -1, // -1 means supports all versions
-    val targetAppVersion: Int = -1, // -1 means supports all versions
+    val minAppVersion: Int? = null, // null means no minimum restriction
+    val maxAppVersion: Int? = null, // null means no maximum restriction
     val repository: String,
     val license: String? = null,
     val tags: List<String> = emptyList(),

--- a/core/main/src/main/java/com/rk/extension/ExtensionUtils.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionUtils.kt
@@ -39,7 +39,10 @@ fun LocalExtension.load(application: Application) = run {
     val xedVersionCode =
         PackageInfoCompat.getLongVersionCode(application.packageManager.getPackageInfo(application.packageName, 0))
 
-    if (!(minAppVersion <= xedVersionCode && maxAppVersion <= xedVersionCode)) {
+    if (
+        (minAppVersion != null && xedVersionCode < minAppVersion) ||
+            (maxAppVersion != null && xedVersionCode > maxAppVersion)
+    ) {
         return@run Result.failure(
             RuntimeException(
                 "Extension '${manifest.name}' (${manifest.version}) is not compatible with this version of Xed-Editor (min: $minAppVersion, max: $maxAppVersion, Xed-Editor: $xedVersionCode)"

--- a/core/main/src/main/java/com/rk/extension/ExtensionUtils.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionUtils.kt
@@ -34,7 +34,7 @@ fun LocalExtension.load(application: Application) = run {
     }
 
     val minAppVersion = manifest.minAppVersion
-    val maxAppVersion = manifest.targetAppVersion
+    val maxAppVersion = manifest.maxAppVersion
 
     val xedVersionCode =
         PackageInfoCompat.getLongVersionCode(application.packageManager.getPackageInfo(application.packageName, 0))

--- a/core/main/src/main/java/com/rk/filetree/FileIcon.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileIcon.kt
@@ -61,7 +61,7 @@ fun FileIcon(file: FileObject, iconTint: Color? = null, isExpanded: Boolean = fa
                 MaterialTheme.colorScheme.primary
             } else MaterialTheme.colorScheme.secondary
 
-    val useTint = currentIconPack.value?.info?.applyTint == true
+    val useTint = currentIconPack.value?.manifest?.applyTint == true
 
     if (iconPackFile != null) {
         AsyncImage(
@@ -104,7 +104,7 @@ fun FileNameIcon(fileName: String, isDirectory: Boolean, iconTint: Color? = null
                 MaterialTheme.colorScheme.primary
             } else MaterialTheme.colorScheme.secondary
 
-    val useTint = currentIconPack.value?.info?.applyTint == true
+    val useTint = currentIconPack.value?.manifest?.applyTint == true
 
     if (iconPackFile != null) {
         AsyncImage(

--- a/core/main/src/main/java/com/rk/icons/pack/IconPack.kt
+++ b/core/main/src/main/java/com/rk/icons/pack/IconPack.kt
@@ -11,7 +11,13 @@ typealias IconPackId = String
 typealias IconPackPath = String
 
 @Serializable
-data class IconPackInfo(val id: IconPackId, val name: String, val applyTint: Boolean = false, val icons: IconPackList)
+data class IconPackManifest(
+    val id: IconPackId,
+    val name: String,
+    val minAppVersion: Int? = null,
+    val applyTint: Boolean = false,
+    val icons: IconPackList,
+)
 
 @Serializable
 data class IconPackList(
@@ -25,7 +31,7 @@ data class IconPackList(
     val languageNames: Map<String, IconPackPath> = emptyMap(),
 )
 
-data class IconPack(val info: IconPackInfo, val installDir: File) {
+data class IconPack(val manifest: IconPackManifest, val installDir: File) {
     fun getIconFileForFile(file: FileObject, isExpanded: Boolean = false): File? {
         val fileName = file.getName()
         val isDirectory = file.isDirectory()
@@ -37,26 +43,27 @@ data class IconPack(val info: IconPackInfo, val installDir: File) {
             if (isDirectory) {
                 if (isExpanded) {
                     // First use folderNamesExpanded, then defaultFolderExpanded
-                    info.icons.folderNamesExpanded[fileName.lowercase()]
+                    manifest.icons.folderNamesExpanded[fileName.lowercase()]
                         ?.let { installDir.resolve(it) }
-                        ?.takeIf { it.exists() } ?: installDir.resolve(info.icons.defaultFolderExpanded)
+                        ?.takeIf { it.exists() } ?: installDir.resolve(manifest.icons.defaultFolderExpanded)
                 } else {
                     // First use folderNames, then defaultFolder
-                    info.icons.folderNames[fileName.lowercase()]?.let { installDir.resolve(it) }?.takeIf { it.exists() }
-                        ?: installDir.resolve(info.icons.defaultFolder)
+                    manifest.icons.folderNames[fileName.lowercase()]
+                        ?.let { installDir.resolve(it) }
+                        ?.takeIf { it.exists() } ?: installDir.resolve(manifest.icons.defaultFolder)
                 }
             } else {
                 // First use fileNames, then fileExtensions, then languageNames, then defaultFile
                 val ext = fileName.substringAfterLast(".", "")
 
-                info.icons.fileNames[fileName.lowercase()]?.let { installDir.resolve(it) }?.takeIf { it.exists() }
-                    ?: info.icons.fileExtensions[ext.lowercase()]
+                manifest.icons.fileNames[fileName.lowercase()]?.let { installDir.resolve(it) }?.takeIf { it.exists() }
+                    ?: manifest.icons.fileExtensions[ext.lowercase()]
                         ?.let { installDir.resolve(it) }
                         ?.takeIf { it.exists() }
-                    ?: info.icons.languageNames[FileTypeManager.fromExtension(ext).name.lowercase()]
+                    ?: manifest.icons.languageNames[FileTypeManager.fromExtension(ext).name.lowercase()]
                         ?.let { installDir.resolve(it) }
                         ?.takeIf { it.exists() }
-                    ?: installDir.resolve(info.icons.defaultFile)
+                    ?: installDir.resolve(manifest.icons.defaultFile)
             }
 
         // If no icon was working (even the fallback ones)
@@ -68,11 +75,13 @@ data class IconPack(val info: IconPackInfo, val installDir: File) {
     fun getIconFileForExt(fileExtension: String): File? {
         val path =
             // First use fileExtensions, then languageNames, then defaultFile
-            info.icons.fileExtensions[fileExtension.lowercase()]?.let { installDir.resolve(it) }?.takeIf { it.exists() }
-                ?: info.icons.languageNames[FileTypeManager.fromExtension(fileExtension).name.lowercase()]
+            manifest.icons.fileExtensions[fileExtension.lowercase()]
+                ?.let { installDir.resolve(it) }
+                ?.takeIf { it.exists() }
+                ?: manifest.icons.languageNames[FileTypeManager.fromExtension(fileExtension).name.lowercase()]
                     ?.let { installDir.resolve(it) }
                     ?.takeIf { it.exists() }
-                ?: installDir.resolve(info.icons.defaultFile)
+                ?: installDir.resolve(manifest.icons.defaultFile)
 
         // If no icon was working (even the fallback ones)
         if (!path.exists()) return null
@@ -86,9 +95,9 @@ data class IconPack(val info: IconPackInfo, val installDir: File) {
 
         val path =
             // First use fileExtensions, then languageNames, then defaultFile
-            extension?.let { info.icons.fileExtensions[it] }?.let { installDir.resolve(it) }?.takeIf { it.exists() }
-                ?: info.icons.languageNames[typeName]?.let { installDir.resolve(it) }?.takeIf { it.exists() }
-                ?: installDir.resolve(info.icons.defaultFile)
+            extension?.let { manifest.icons.fileExtensions[it] }?.let { installDir.resolve(it) }?.takeIf { it.exists() }
+                ?: manifest.icons.languageNames[typeName]?.let { installDir.resolve(it) }?.takeIf { it.exists() }
+                ?: installDir.resolve(manifest.icons.defaultFile)
 
         // If no icon was working (even the fallback ones)
         if (!path.exists()) return null

--- a/core/main/src/main/java/com/rk/icons/pack/IconPackManager.kt
+++ b/core/main/src/main/java/com/rk/icons/pack/IconPackManager.kt
@@ -3,6 +3,7 @@ package com.rk.icons.pack
 import android.app.Application
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.core.content.pm.PackageInfoCompat
 import com.rk.activities.settings.SettingsActivity
 import com.rk.file.child
 import com.rk.file.createDirIfNot
@@ -11,6 +12,7 @@ import com.rk.resources.getFilledString
 import com.rk.resources.getString
 import com.rk.resources.strings
 import com.rk.settings.Settings
+import com.rk.utils.application
 import com.rk.utils.dialog
 import java.io.File
 import java.util.zip.ZipFile
@@ -53,21 +55,40 @@ class IconPackManager(private val context: Application) {
         }
 
     private fun installIconPackFromDir(dir: File) {
-        val iconPackInfo = validateIconPack(dir) ?: return
+        val iconPackManifest = validateIconPack(dir) ?: return
 
-        val installDir = iconPackDir.child(iconPackInfo.id)
+        val packageName = application!!.packageName
+        val packageManager = application!!.packageManager
+        val currentVersionCode = PackageInfoCompat.getLongVersionCode(packageManager.getPackageInfo(packageName, 0))
+        if (iconPackManifest.minAppVersion != null && iconPackManifest.minAppVersion.toLong() > currentVersionCode) {
+            dialog(
+                context = SettingsActivity.instance,
+                title = strings.warning.getString(),
+                msg = strings.incompatible_theme_warning.getString(),
+                cancelString = strings.cancel,
+                okString = strings.continue_action,
+                onOk = { writeIconPackToDisk(iconPackManifest, dir) },
+            )
+            return
+        }
+
+        writeIconPackToDisk(iconPackManifest, dir)
+    }
+
+    private fun writeIconPackToDisk(iconPackManifest: IconPackManifest, dir: File) {
+        val installDir = iconPackDir.child(iconPackManifest.id)
         if (installDir.exists()) {
-            uninstallIconPack(iconPackInfo.id)
+            uninstallIconPack(iconPackManifest.id)
         }
 
         dir.copyRecursively(installDir, overwrite = true)
 
-        val iconPack = IconPack(iconPackInfo, installDir)
-        iconPacks[iconPackInfo.id] = iconPack
+        val iconPack = IconPack(iconPackManifest, installDir)
+        iconPacks[iconPackManifest.id] = iconPack
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    internal fun validateIconPack(dir: File): IconPackInfo? {
+    internal fun validateIconPack(dir: File): IconPackManifest? {
         val iconPackJson = dir.resolve("manifest.json")
         if (!iconPackJson.exists()) {
             dialog(
@@ -79,8 +100,8 @@ class IconPackManager(private val context: Application) {
 
             return null
         }
-        val iconPackInfo =
-            runCatching { json.decodeFromString<IconPackInfo>(iconPackJson.readText()) }
+        val iconPackManifest =
+            runCatching { json.decodeFromString<IconPackManifest>(iconPackJson.readText()) }
                 .getOrElse { e ->
                     if (e is MissingFieldException) {
                         val fields = e.missingFields.joinToString("\n") { "• $it" }
@@ -101,7 +122,7 @@ class IconPackManager(private val context: Application) {
                     return null
                 }
 
-        return iconPackInfo
+        return iconPackManifest
     }
 
     fun uninstallIconPack(iconPackId: IconPackId) {
@@ -118,10 +139,10 @@ class IconPackManager(private val context: Application) {
                     val manifestJson = dir.resolve("manifest.json")
                     if (manifestJson.exists()) {
                         runCatching {
-                            val iconPackInfo = json.decodeFromString<IconPackInfo>(manifestJson.readText())
-                            val installDir = iconPackDir.child(iconPackInfo.id)
-                            val iconPack = IconPack(iconPackInfo, installDir)
-                            iconPacks[iconPackInfo.id] = iconPack
+                            val iconPackManifest = json.decodeFromString<IconPackManifest>(manifestJson.readText())
+                            val installDir = iconPackDir.child(iconPackManifest.id)
+                            val iconPack = IconPack(iconPackManifest, installDir)
+                            iconPacks[iconPackManifest.id] = iconPack
                         }
                     }
                 }

--- a/core/main/src/main/java/com/rk/settings/theme/Theme.kt
+++ b/core/main/src/main/java/com/rk/settings/theme/Theme.kt
@@ -180,17 +180,17 @@ fun ThemeScreen(modifier: Modifier = Modifier) {
             )
 
             iconPackManager.iconPacks.forEach { (id, iconPack) ->
-                val iconPackInfo = iconPack.info
+                val iconPackManifest = iconPack.manifest
 
                 SettingsToggle(
-                    label = iconPackInfo.name,
+                    label = iconPackManifest.name,
                     description = null,
                     showSwitch = false,
                     default = false,
                     startWidget = {
                         RadioButton(
                             modifier = Modifier.padding(start = 16.dp),
-                            selected = currentIconPack.value?.info?.id == id,
+                            selected = currentIconPack.value?.manifest?.id == id,
                             onClick = null,
                         )
                     },
@@ -201,7 +201,7 @@ fun ThemeScreen(modifier: Modifier = Modifier) {
                     endWidget = {
                         IconButton(
                             onClick = {
-                                if (currentIconPack.value?.info?.id == id) {
+                                if (currentIconPack.value?.manifest?.id == id) {
                                     currentIconPack.value = null
                                     Settings.icon_pack = ""
                                 }

--- a/core/main/src/main/java/com/rk/theme/ThemeConfig.kt
+++ b/core/main/src/main/java/com/rk/theme/ThemeConfig.kt
@@ -104,7 +104,7 @@ data class ThemePalette(
 data class ThemeConfig(
     val id: String?,
     val name: String?,
-    val targetVersion: Int?,
+    val minAppVersion: Int?,
     val inheritBase: Boolean?,
     val light: ThemePalette?,
     val dark: ThemePalette?,

--- a/core/main/src/main/java/com/rk/theme/ThemeLoader.kt
+++ b/core/main/src/main/java/com/rk/theme/ThemeLoader.kt
@@ -66,20 +66,10 @@ suspend fun ThemeConfig.installTheme() =
             return@withContext
         }
 
-        if (targetVersion == null) {
-            dialog(
-                context = SettingsActivity.instance,
-                title = strings.theme_install_failed.getString(),
-                msg = strings.theme_version_missing.getString(),
-                cancelable = false,
-            )
-            return@withContext
-        }
-
         val packageName = application!!.packageName
         val packageManager = application!!.packageManager
         val currentVersionCode = PackageInfoCompat.getLongVersionCode(packageManager.getPackageInfo(packageName, 0))
-        if (targetVersion.toLong() != currentVersionCode) {
+        if (minAppVersion != null && minAppVersion.toLong() > currentVersionCode) {
             dialog(
                 context = SettingsActivity.instance,
                 title = strings.warning.getString(),


### PR DESCRIPTION
## Changes
- Rename `targetVersion` to `minAppVersion` in `ThemeConfig`.
- Rename `IconPackInfo` to `IconPackManifest` and update all references in `IconPackManager`, `FileIcon`, and settings UI.
- Rename `targetAppVersion` to `maxAppVersion` in `ExtensionManifest` and update `ExtensionManager` logic.
- Change extension version constraints (`minAppVersion`, `maxAppVersion`) to nullable types to represent no restriction.
- Implement app version compatibility checks and warning dialogs for Icon Pack installation.
- Update `ThemeLoader` to use `minAppVersion` for compatibility warnings instead of strict version equality.
- Refactor `IconPackManager` to extract `writeIconPackToDisk` for better readability.