### PR TITLE
feat: integrate semantic versioning for update logic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         targetSdk = 28
 
         // versioning
-        versionCode = 89
+        versionCode = 90
         versionName = "3.2.9"
         vectorDrawables { useSupportLibrary = true }
     }

--- a/core/main/build.gradle.kts
+++ b/core/main/build.gradle.kts
@@ -111,6 +111,7 @@ dependencies {
     implementation(libs.ec4j.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.jgit)
+    implementation(libs.semver)
     debugImplementation(libs.leakcanary)
     // implementation("androidx.compose.material:material-icons-extended:1.7.8")
 

--- a/core/main/src/main/java/com/rk/exec/NpmUtils.kt
+++ b/core/main/src/main/java/com/rk/exec/NpmUtils.kt
@@ -1,5 +1,6 @@
 package com.rk.exec
 
+import io.github.z4kn4fein.semver.toVersionOrNull
 import org.json.JSONObject
 
 object NpmUtils {
@@ -26,8 +27,8 @@ object NpmUtils {
     }
 
     suspend fun hasUpdate(packageName: String): Boolean {
-        val currentVersion = getInstalledVersion(packageName) ?: return false
-        val latestVersion = getLatestVersion(packageName) ?: return false
-        return currentVersion != latestVersion
+        val currentVersion = getInstalledVersion(packageName)?.toVersionOrNull(false) ?: return false
+        val latestVersion = getLatestVersion(packageName)?.toVersionOrNull(false) ?: return false
+        return currentVersion < latestVersion
     }
 }

--- a/core/main/src/main/java/com/rk/exec/PipxUtils.kt
+++ b/core/main/src/main/java/com/rk/exec/PipxUtils.kt
@@ -1,5 +1,6 @@
 package com.rk.exec
 
+import io.github.z4kn4fein.semver.toVersionOrNull
 import org.json.JSONObject
 
 object PipxUtils {
@@ -45,7 +46,10 @@ object PipxUtils {
                 val obj = JSONObject(result.output)
                 val latest = obj.getString("latest")
                 val installed = obj.getString("installed_version")
-                installed != latest
+
+                val latestVersion = latest.toVersionOrNull(false) ?: return false
+                val installedVersion = installed.toVersionOrNull(false) ?: return false
+                installedVersion < latestVersion
             }
             .getOrDefault(false)
     }

--- a/core/main/src/main/java/com/rk/extension/Extension.kt
+++ b/core/main/src/main/java/com/rk/extension/Extension.kt
@@ -3,6 +3,7 @@ package com.rk.extension
 import android.content.Context
 import android.content.pm.PackageManager
 import dalvik.system.PathClassLoader
+import io.github.z4kn4fein.semver.toVersionOrNull
 import java.io.File
 import java.util.Date
 import kotlinx.coroutines.Dispatchers
@@ -201,19 +202,23 @@ data class UpdatableExtension(val installed: LocalExtension, val store: StoreExt
         get() = installed.hasSettings
 
     override val iconUrl
-        get() = store.iconUrl
+        get() = if (isUpdatable()) store.iconUrl else installed.iconUrl
 
     override val readmeUrl
-        get() = store.readmeUrl
+        get() = if (isUpdatable()) store.readmeUrl else installed.readmeUrl
 
     override val changelogUrl
-        get() = store.changelogUrl
+        get() = if (isUpdatable()) store.changelogUrl else installed.changelogUrl
 
     override suspend fun getStats() = store.getStats()
 
     override suspend fun getReviews() = store.getReviews()
 
-    fun isUpdatable() = installed.version != store.version
+    fun isUpdatable(): Boolean {
+        val installedVersion = installed.version.toVersionOrNull() ?: return false
+        val storeVersion = store.version.toVersionOrNull() ?: return false
+        return installedVersion < storeVersion
+    }
 }
 
 fun LocalExtension.classLoader(parent: ClassLoader?) = PathClassLoader(apkFile.absolutePath, parent)

--- a/core/main/src/main/java/com/rk/extension/ExtensionManager.kt
+++ b/core/main/src/main/java/com/rk/extension/ExtensionManager.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.core.content.pm.PackageInfoCompat
 import com.rk.file.child
+import com.rk.resources.getString
+import com.rk.resources.strings
 import com.rk.utils.errorDialog
 import java.io.File
 import java.util.zip.ZipFile
@@ -189,7 +191,8 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
                 val extension =
                     localExtensions[extensionId] ?: return@withContext Result.failure(Exception("Extension not found"))
 
-                loadedExtensions[extension]?.api?.onUninstalled()
+                runCatching { loadedExtensions[extension]?.api?.onUninstalled() }
+                    .onFailure { errorDialog(title = strings.ext_cleanup_failed.getString(), throwable = it) }
                 loadedExtensions[extension]?.scope?.cancel()
 
                 val extensionDir = File(extension.installPath)

--- a/core/main/src/main/java/com/rk/lsp/servers/XML.kt
+++ b/core/main/src/main/java/com/rk/lsp/servers/XML.kt
@@ -8,6 +8,8 @@ import com.rk.file.localBinDir
 import com.rk.file.sandboxHomeDir
 import com.rk.lsp.LspConnectionConfig
 import com.rk.lsp.ScriptedLspServer
+import io.github.z4kn4fein.semver.toVersion
+import io.github.z4kn4fein.semver.toVersionOrNull
 
 object XML : ScriptedLspServer() {
     override val id = "xml"
@@ -32,8 +34,9 @@ object XML : ScriptedLspServer() {
 
     override suspend fun isUpdatable(context: Context): Boolean {
         val versionFile = sandboxHomeDir().child(".lsp/lemminx/version.txt")
-        val currentVersion = runCatching { versionFile.readText().trim() }.getOrNull()
-        return currentVersion != LATEST_VERSION
+        val currentVersionText = runCatching { versionFile.readText().trim() }.getOrNull()
+        val currentVersion = currentVersionText?.toVersionOrNull() ?: return false
+        return currentVersion < LATEST_VERSION.toVersion()
     }
 
     override fun getConnectionConfig(): LspConnectionConfig {

--- a/core/main/src/main/java/com/rk/utils/dialogs.kt
+++ b/core/main/src/main/java/com/rk/utils/dialogs.kt
@@ -51,7 +51,11 @@ fun errorDialog(@StringRes msgRes: Int) {
     runOnUiThread { errorDialog(msg = msgRes.getString()) }
 }
 
-fun errorDialog(activity: Activity? = MainActivity.instance, throwable: Throwable) {
+fun errorDialog(
+    activity: Activity? = MainActivity.instance,
+    throwable: Throwable,
+    title: String = strings.error.getString(),
+) {
     runOnUiThread {
         if (throwable.message.toString().contains("Job was cancelled")) {
             Log.w("ERROR_DIALOG", throwable.message.toString())
@@ -65,7 +69,7 @@ fun errorDialog(activity: Activity? = MainActivity.instance, throwable: Throwabl
             }
         }
 
-        errorDialog(activity = activity, msg = message.toString())
+        errorDialog(activity = activity, title = title, msg = message.toString())
     }
 }
 

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -656,4 +656,5 @@
     <string name="sort_lines_ascending">Sort lines ascending</string>
     <string name="sort_lines_descending">Sort lines descending</string>
     <string name="choose_runner">Choose runner</string>
+    <string name="ext_cleanup_failed">Extension cleanup failed</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ monarchJson = "1.0.2"
 regexOnig = "1.0.3"
 regexRe2j = "1.0.2"
 gson = "2.13.2"
+semver = "3.1.0"
 leakcanary = "2.14"
 motionCompose = "2.0.1"
 
@@ -173,6 +174,7 @@ anrwatchdog = { module = "com.github.anrwatchdog:anrwatchdog", version.ref = "an
 pine-core = { module = "top.canyie.pine:core", version.ref = "coreVersion" }
 utilcode = { module = "com.blankj:utilcodex", version.ref = "utilcode" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+semver = { module = "io.github.z4kn4fein:semver", version.ref = "semver" }
 
 # Tree-sitter / editor
 tree-sitter = { module = "com.itsaky.androidide.treesitter:android-tree-sitter", version.ref = "tsBinding" }

--- a/plugin-sdk/gradle/libs.versions.toml
+++ b/plugin-sdk/gradle/libs.versions.toml
@@ -1,5 +1,12 @@
 [versions]
+
+# kotlin, agp and r8 must be compatible with each other aftr update
 agp = "8.13.1"
+kotlin = "2.3.0"
+ksp = "2.3.0"
+kotlinReflect = "2.3.0"
+r8 = "8.13.19"
+
 annotation = "1.9.1"
 anrwatchdog = "1.4.0"
 appcompat = "1.7.1"
@@ -9,13 +16,11 @@ coreVersion = "0.3.0"
 desugar_jdk_libs = "2.1.5"
 documentfile = "1.1.0"
 glide = "5.0.5"
-kotlinReflect = "2.3.20"
 material = "1.13.0"
 constraintlayout = "2.2.1"
 materialIconsCore = "1.7.8"
 nanohttpd = "2.3.1"
 navigation = "2.9.6"
-kotlin = "2.3.20"
 coreKtx = "1.17.0"
 activity = "1.12.0"
 okhttp = "5.3.2"
@@ -29,6 +34,7 @@ composeBom = "2025.11.01"
 coil = "2.7.0"
 ktfmt = "0.25.0"
 jgit = "6.2.0.202206071550-r"
+
 tsBinding = "4.3.2"
 lsp4j = "1.0.0"
 uiautomator = "2.3.0"
@@ -41,7 +47,7 @@ androidsvgAar = "1.4"
 ec4jCore = "1.2.0"
 kotlinxSerializationJson = "1.10.0"
 room = "2.8.4"
-ksp = "2.3.6"
+
 publish = "0.36.0"
 collection = "1.5.0"
 jcodings = "1.0.64"
@@ -60,6 +66,7 @@ monarchJson = "1.0.2"
 regexOnig = "1.0.3"
 regexRe2j = "1.0.2"
 gson = "2.13.2"
+semver = "3.1.0"
 leakcanary = "2.14"
 motionCompose = "2.0.1"
 
@@ -140,6 +147,7 @@ androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "junit
 androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
 androidx-runner = { module = "androidx.test:runner", version.ref = "runner" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
+r8 = { module = "com.android.tools:r8", version.ref = "r8" }
 tests-robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 tests-google-truth = { module = "com.google.truth:truth", version.ref = "truth" }
 leakcanary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanary" }
@@ -166,6 +174,7 @@ anrwatchdog = { module = "com.github.anrwatchdog:anrwatchdog", version.ref = "an
 pine-core = { module = "top.canyie.pine:core", version.ref = "coreVersion" }
 utilcode = { module = "com.blankj:utilcodex", version.ref = "utilcode" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+semver = { module = "io.github.z4kn4fein:semver", version.ref = "semver" }
 
 # Tree-sitter / editor
 tree-sitter = { module = "com.itsaky.androidide.treesitter:android-tree-sitter", version.ref = "tsBinding" }


### PR DESCRIPTION
* Added `io.github.z4kn4fein:semver` dependency to handle version comparisons.
* Refactored update checks in `XML` LSP server, `PipxUtils`, `NpmUtils`, and `Extension` to use semantic versioning (`<`) instead of string inequality (`!=`).
* Updated `UpdatableExtension` to prefer store-provided metadata (icon, readme, changelog) when an update is available.
* Enhanced `errorDialog` utility to support custom titles.
* Added error handling and localized string for extension uninstallation cleanup failures.
* Updated and organized dependency versions in `plugin-sdk`, including Kotlin, AGP, KSP, and R8.
* Bump version code to `90`.