### PR TITLE
fix: fix type casting crash and DividerColumn layout crash

### DIFF
--- a/core/components/src/main/java/com/rk/components/compose/preferences/base/DividerColumn.kt
+++ b/core/components/src/main/java/com/rk/components/compose/preferences/base/DividerColumn.kt
@@ -61,8 +61,10 @@ fun DividerColumn(
             }
 
         val width = constraints.maxWidth
-        val dividersHeight = thicknessPx.roundToInt() * (placeables.size - 1)
-        val height = placeables.sumOf { it.height } + dividersHeight
+        val childCount = measurables.size
+        val dividersHeight = if (childCount <= 1) 0 else thicknessPx.roundToInt() * (childCount - 1)
+        val contentHeight = placeables.sumOf { it.height }
+        val height = (contentHeight + dividersHeight).coerceAtLeast(0)
 
         layout(width, height) {
             val dividerPositions = mutableListOf<Int>()

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionActionButtons.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionActionButtons.kt
@@ -22,8 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.rk.extension.Extension
-import com.rk.extension.UpdatableExtension
 import com.rk.icons.Download
 import com.rk.icons.XedIcons
 import com.rk.resources.drawables
@@ -41,12 +39,11 @@ enum class InstallState {
 
 @Composable
 fun SmallExtensionActionButton(
-    extension: Extension,
     installState: InstallState,
     scope: CoroutineScope,
-    onInstallClick: suspend (Extension) -> Unit,
-    onUninstallClick: suspend (Extension) -> Unit,
-    onUpdateClick: suspend (UpdatableExtension) -> Unit,
+    onInstallClick: suspend () -> Unit,
+    onUninstallClick: suspend () -> Unit,
+    onUpdateClick: suspend () -> Unit,
     modifier: Modifier = Modifier,
     outdatedWarning: Boolean = false,
 ) {
@@ -62,7 +59,7 @@ fun SmallExtensionActionButton(
 
     when (installState) {
         InstallState.Idle -> {
-            IconButton(modifier = modifier, onClick = { scope.launch { onInstallClick(extension) } }) {
+            IconButton(modifier = modifier, onClick = { scope.launch { onInstallClick() } }) {
                 Icon(XedIcons.Download, contentDescription = null)
             }
         }
@@ -76,7 +73,7 @@ fun SmallExtensionActionButton(
         InstallState.Installed -> {
             IconButton(
                 modifier = modifier,
-                onClick = { scope.launch { onUninstallClick(extension) } },
+                onClick = { scope.launch { onUninstallClick() } },
                 colors = IconButtonDefaults.iconButtonColors(contentColor = MaterialTheme.colorScheme.error),
             ) {
                 Icon(Icons.Outlined.Delete, contentDescription = stringResource(strings.delete))
@@ -84,10 +81,9 @@ fun SmallExtensionActionButton(
         }
 
         InstallState.Updatable -> {
-            val updatableExtension = extension as UpdatableExtension
             IconButton(
                 modifier = modifier,
-                onClick = { scope.launch { onUpdateClick(updatableExtension) } },
+                onClick = { scope.launch { onUpdateClick() } },
                 colors = IconButtonDefaults.iconButtonColors(contentColor = MaterialTheme.colorScheme.primary),
             ) {
                 Icon(painterResource(drawables.update), contentDescription = stringResource(strings.update))
@@ -104,18 +100,17 @@ fun SmallExtensionActionButton(
 
 @Composable
 fun ExtensionActionButtons(
-    extension: Extension,
     installState: InstallState,
     scope: CoroutineScope,
-    onInstallClick: suspend (Extension) -> Unit,
-    onUninstallClick: suspend (Extension) -> Unit,
-    onUpdateClick: suspend (UpdatableExtension) -> Unit,
+    onInstallClick: suspend () -> Unit,
+    onUninstallClick: suspend () -> Unit,
+    onUpdateClick: suspend () -> Unit,
     modifier: Modifier = Modifier,
     outdatedWarning: Boolean = false,
 ) {
     when (installState) {
         InstallState.Idle -> {
-            InstallButton(scope, onInstallClick, extension, modifier, outdatedWarning)
+            InstallButton(scope, onInstallClick, modifier, outdatedWarning)
         }
 
         InstallState.Installing -> {
@@ -123,13 +118,13 @@ fun ExtensionActionButtons(
         }
 
         InstallState.Installed -> {
-            UninstallButton(scope, onUninstallClick, extension, modifier)
+            UninstallButton(scope, onUninstallClick, modifier)
         }
 
         InstallState.Updatable -> {
             Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                UpdateButton(extension, scope, onUpdateClick, Modifier.weight(1f), outdatedWarning)
-                UninstallButton(scope, onUninstallClick, extension, Modifier.weight(1f))
+                UpdateButton(scope, onUpdateClick, Modifier.weight(1f), outdatedWarning)
+                UninstallButton(scope, onUninstallClick, Modifier.weight(1f))
             }
         }
 
@@ -142,12 +137,11 @@ fun ExtensionActionButtons(
 @Composable
 private fun InstallButton(
     scope: CoroutineScope,
-    onInstallClick: suspend (Extension) -> Unit,
-    extension: Extension,
+    onInstallClick: suspend () -> Unit,
     modifier: Modifier = Modifier,
     outdatedWarning: Boolean = false,
 ) {
-    Button(modifier = modifier, enabled = !outdatedWarning, onClick = { scope.launch { onInstallClick(extension) } }) {
+    Button(modifier = modifier, enabled = !outdatedWarning, onClick = { scope.launch { onInstallClick() } }) {
         Icon(XedIcons.Download, contentDescription = null, Modifier.size(18.dp))
         Spacer(Modifier.width(6.dp))
         Text(stringResource(strings.install))
@@ -170,13 +164,12 @@ private fun InstallingButton(modifier: Modifier = Modifier) {
 @Composable
 private fun UninstallButton(
     scope: CoroutineScope,
-    onUninstallClick: suspend (Extension) -> Unit,
-    extension: Extension,
+    onUninstallClick: suspend () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Button(
         modifier = modifier,
-        onClick = { scope.launch { onUninstallClick(extension) } },
+        onClick = { scope.launch { onUninstallClick() } },
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.error,
@@ -191,17 +184,15 @@ private fun UninstallButton(
 
 @Composable
 private fun UpdateButton(
-    extension: Extension,
     scope: CoroutineScope,
-    onUpdateClick: suspend (UpdatableExtension) -> Unit,
+    onUpdateClick: suspend () -> Unit,
     modifier: Modifier = Modifier,
     outdatedWarning: Boolean = false,
 ) {
-    val updatableExtension = extension as UpdatableExtension
     Button(
         modifier = modifier,
         enabled = !outdatedWarning,
-        onClick = { scope.launch { onUpdateClick(updatableExtension) } },
+        onClick = { scope.launch { onUpdateClick() } },
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.secondary,

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionCard.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionCard.kt
@@ -34,9 +34,9 @@ fun ExtensionCard(
     extension: Extension,
     modifier: Modifier = Modifier,
     installState: InstallState = InstallState.Idle,
-    onInstallClick: suspend (Extension) -> Unit,
-    onUninstallClick: suspend (Extension) -> Unit,
-    onUpdateClick: suspend (UpdatableExtension) -> Unit,
+    onInstallClick: suspend () -> Unit,
+    onUninstallClick: suspend () -> Unit,
+    onUpdateClick: suspend () -> Unit,
     onClick: (Extension) -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
@@ -96,7 +96,6 @@ fun ExtensionCard(
         },
         endWidget = {
             SmallExtensionActionButton(
-                extension = extension,
                 installState = installState,
                 scope = scope,
                 onInstallClick = onInstallClick,

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
@@ -254,12 +254,14 @@ private fun AboutSection(
     ExtensionActionButtons(
         outdatedWarning = outdatedClient || outdatedExtension,
         modifier = Modifier.fillMaxWidth(),
-        extension = extension,
         installState = installState,
         scope = scope,
-        onInstallClick = { runExtensionInstallAction(it, updateInstallState, scope, context, activity) },
-        onUninstallClick = { runExtensionUninstallAction(it, updateInstallState, scope, activity) },
-        onUpdateClick = { runExtensionUpdateAction(it, updateInstallState, scope, context, activity) },
+        onInstallClick = { runExtensionInstallAction(extension, updateInstallState, scope, context, activity) },
+        onUninstallClick = { runExtensionUninstallAction(extension, updateInstallState, scope, activity) },
+        onUpdateClick = {
+            if (extension !is UpdatableExtension) return@ExtensionActionButtons
+            runExtensionUpdateAction(extension, updateInstallState, scope, context, activity)
+        },
     )
 
     if (outdatedClient || outdatedExtension) {

--- a/core/main/src/main/java/com/rk/settings/extension/ExtensionScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/extension/ExtensionScreen.kt
@@ -230,13 +230,14 @@ fun ExtensionScreen(navController: NavController) {
                             extension = extension,
                             installState = installState,
                             onInstallClick = {
-                                runExtensionInstallAction(it, { installState = it }, scope, context, activity)
+                                runExtensionInstallAction(extension, { installState = it }, scope, context, activity)
                             },
                             onUninstallClick = {
-                                runExtensionUninstallAction(it, { installState = it }, scope, activity)
+                                runExtensionUninstallAction(extension, { installState = it }, scope, activity)
                             },
                             onUpdateClick = {
-                                runExtensionUpdateAction(it, { installState = it }, scope, context, activity)
+                                if (extension !is UpdatableExtension) return@ExtensionCard
+                                runExtensionUpdateAction(extension, { installState = it }, scope, context, activity)
                             },
                             onClick = { navController.navigate("${SettingsRoutes.ExtensionDetail.route}/${it.id}") },
                         )


### PR DESCRIPTION
- Simplify extension action components by removing redundant `extension` parameters and transition to parameterless callbacks.
- Add type safety checks for `UpdatableExtension` before executing update actions in `ExtensionScreen` and `ExtensionDetail`.
- Fix height calculation in `DividerColumn` to correctly handle cases with zero or one child components.