### PR TITLE
feat: improve LSP log page with enhanced categories

### DIFF
--- a/core/main/src/main/java/com/rk/lsp/LspConnector.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspConnector.kt
@@ -262,18 +262,24 @@ class LspConnector(
                 get() =
                     object : EventHandler.EventListener {
                         override fun onEventException(eventListener: AsyncEventListener, exception: Exception) {
-                            instance.addLog(LspLogEntry(MessageType.Error, "Event ${eventListener.eventName} failed"))
+                            instance.addLog(
+                                LspLogEntry(
+                                    MessageSource.Client,
+                                    MessageType.Error,
+                                    "Event ${eventListener.eventName} failed",
+                                )
+                            )
                             exception.localizedMessage?.let { message ->
-                                instance.addLog(LspLogEntry(MessageType.Error, message))
+                                instance.addLog(LspLogEntry(MessageSource.Client, MessageType.Error, message))
                             }
                         }
 
                         override fun onHandlerException(exception: Exception) {
                             exception.cause?.localizedMessage?.let { message ->
-                                instance.addLog(LspLogEntry(MessageType.Error, message))
+                                instance.addLog(LspLogEntry(MessageSource.Client, MessageType.Error, message))
                             }
                             exception.localizedMessage?.let { message ->
-                                instance.addLog(LspLogEntry(MessageType.Error, message))
+                                instance.addLog(LspLogEntry(MessageSource.Client, MessageType.Error, message))
                             }
                         }
 
@@ -322,7 +328,7 @@ class LspConnector(
                                     is ServerStatus.STOPPED ->
                                         "Disconnected from LSP server (reason: ${newStatus.reason})\n"
                                 }
-                            instance.addLog(LspLogEntry(MessageType.Info, statusMessage))
+                            instance.addLog(LspLogEntry(MessageSource.Client, MessageType.Info, statusMessage))
 
                             if (
                                 oldStatus is ServerStatus.STOPPED &&

--- a/core/main/src/main/java/com/rk/lsp/LspServerInstance.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspServerInstance.kt
@@ -21,8 +21,6 @@ import com.rk.file.FileObject
 import com.rk.icons.Error
 import com.rk.icons.XedIcons
 import com.rk.resources.strings
-import com.rk.settings.debugOptions.LogEntry
-import com.rk.settings.debugOptions.LogLevel
 import com.rk.tabs.editor.EditorTab
 import com.rk.tabs.editor.applyHighlightingAndConnectLSP
 import com.rk.theme.greenStatus
@@ -44,20 +42,19 @@ enum class LspConnectionStatus {
     TIMEOUT,
 }
 
-private fun MessageType.toLogLevel() =
-    when (this) {
-        MessageType.Error -> LogLevel.ERROR
-        MessageType.Warning -> LogLevel.WARN
-        MessageType.Info -> LogLevel.INFO
-        MessageType.Log -> LogLevel.DEBUG
-        MessageType.Debug -> LogLevel.DEBUG
-    }
-
-data class LspLogEntry(val level: MessageType, val message: String, val timestamp: Long = System.currentTimeMillis()) {
-    fun toLogEntry(): LogEntry {
-        return LogEntry(level = level.toLogLevel(), message = message, timestamp = timestamp)
-    }
+enum class MessageSource {
+    RPC,
+    LSP,
+    Runtime,
+    Client,
 }
+
+data class LspLogEntry(
+    val source: MessageSource,
+    val type: MessageType?,
+    val message: String,
+    val timestamp: Long = System.currentTimeMillis(),
+)
 
 data class LspServerInstance(val server: LspServer, internal val lspProject: LspProject, val projectRoot: FileObject) {
     val id = "${server.id}_${projectRoot.getAbsolutePath().hashCode()}"
@@ -68,17 +65,15 @@ data class LspServerInstance(val server: LspServer, internal val lspProject: Lsp
     var hasError by mutableStateOf(false)
 
     fun addLog(messageParams: MessageParams) {
-        logs.add(LspLogEntry(level = messageParams.type, message = messageParams.message))
+        logs.add(LspLogEntry(type = messageParams.type, message = messageParams.message, source = MessageSource.LSP))
     }
 
     fun addLog(lspLogEntry: LspLogEntry) {
-        if (lspLogEntry.level == MessageType.Error) hasError = true
+        if (lspLogEntry.type == MessageType.Error) hasError = true
         logs.add(lspLogEntry)
     }
 
     fun getLspLogs() = logs.toList()
-
-    fun getLogs() = getLspLogs().map { it.toLogEntry() }
 
     fun getWrapper(): LanguageServerWrapper? {
         return server.supportedExtensions.firstOrNull()?.let {
@@ -86,7 +81,7 @@ data class LspServerInstance(val server: LspServer, internal val lspProject: Lsp
         }
             ?: run {
                 hasError = true
-                addLog(LspLogEntry(MessageType.Error, "Language server instance not found..."))
+                addLog(LspLogEntry(MessageSource.Client, MessageType.Error, "Language server instance not found..."))
                 return null
             }
     }
@@ -94,7 +89,7 @@ data class LspServerInstance(val server: LspServer, internal val lspProject: Lsp
     /** Stops this language server instance */
     suspend fun stop() {
         withContext(Dispatchers.IO) {
-            addLog(LspLogEntry(MessageType.Info, "User stopped language server instance..."))
+            addLog(LspLogEntry(MessageSource.Client, MessageType.Info, "User stopped language server instance..."))
             val wrapper = getWrapper() ?: return@withContext
             DefinitionPrevention.register(lspProject, server)
             try {
@@ -108,7 +103,7 @@ data class LspServerInstance(val server: LspServer, internal val lspProject: Lsp
     /** Restarts this language server instance */
     suspend fun restart() {
         withContext(Dispatchers.IO) {
-            addLog(LspLogEntry(MessageType.Info, "User restarted language server instance..."))
+            addLog(LspLogEntry(MessageSource.Client, MessageType.Info, "User restarted language server instance..."))
             val wrapper = getWrapper() ?: return@withContext
             try {
                 wrapper.restartAndReconnect()
@@ -125,7 +120,7 @@ data class LspServerInstance(val server: LspServer, internal val lspProject: Lsp
      */
     suspend fun start(): List<EditorTab> {
         return withContext(Dispatchers.IO) {
-            addLog(LspLogEntry(MessageType.Info, "User started language server instance..."))
+            addLog(LspLogEntry(MessageSource.Client, MessageType.Info, "User started language server instance..."))
             val wrapper = getWrapper() ?: return@withContext emptyList()
             hasError = false
             DefinitionPrevention.unregister(lspProject, server)

--- a/core/main/src/main/java/com/rk/lsp/ProcessConnection.kt
+++ b/core/main/src/main/java/com/rk/lsp/ProcessConnection.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.eclipse.lsp4j.MessageType
 
 class ProcessConnection(private val cmd: Array<String>, instance: LspServerInstance) :
     BaseLspConnectionProvider(instance) {
@@ -37,19 +36,19 @@ class ProcessConnection(private val cmd: Array<String>, instance: LspServerInsta
         loggingInput =
             LoggingInputStream(process!!.inputStream) { json ->
                 Log.d("ProcessConnection", "[stdout] $json")
-                instance.addLog(LspLogEntry(MessageType.Log, "→ $json"))
+                instance.addLog(LspLogEntry(MessageSource.RPC, null, "→ $json"))
             }
         loggingOutput =
             LoggingOutputStream(process!!.outputStream) { json ->
                 Log.d("ProcessConnection", "[stdin] $json")
-                instance.addLog(LspLogEntry(MessageType.Log, "← $json"))
+                instance.addLog(LspLogEntry(MessageSource.RPC, null, "← $json"))
             }
 
         scope!!.launch {
             runCatching {
                 process!!.errorStream.bufferedReader().forEachLine { line ->
                     Log.e("ProcessConnection", "[stderr] $line")
-                    instance.addLog(LspLogEntry(MessageType.Error, line))
+                    instance.addLog(LspLogEntry(MessageSource.Runtime, null, line))
                 }
             }
         }

--- a/core/main/src/main/java/com/rk/lsp/SocketConnection.kt
+++ b/core/main/src/main/java/com/rk/lsp/SocketConnection.kt
@@ -35,12 +35,12 @@ class SocketConnection(private val port: Int, private val host: String? = null, 
         loggingInput =
             LoggingInputStream(socket!!.getInputStream()) { json ->
                 Log.d("SocketConnection", "[stdout] $json")
-                instance.addLog(LspLogEntry(MessageType.Log, "→ $json"))
+                instance.addLog(LspLogEntry(MessageSource.RPC, MessageType.Log, "→ $json"))
             }
         loggingOutput =
             LoggingOutputStream(socket!!.getOutputStream()) { json ->
                 Log.d("SocketConnection", "[stdin] $json")
-                instance.addLog(LspLogEntry(MessageType.Log, "← $json"))
+                instance.addLog(LspLogEntry(MessageSource.RPC, MessageType.Log, "← $json"))
             }
     }
 

--- a/core/main/src/main/java/com/rk/settings/debugOptions/AppLogs.kt
+++ b/core/main/src/main/java/com/rk/settings/debugOptions/AppLogs.kt
@@ -1,11 +1,25 @@
 package com.rk.settings.debugOptions
 
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.core.content.pm.PackageInfoCompat
+import com.rk.components.StyledTextField
 import com.rk.utils.application
 import com.rk.xededitor.BuildConfig
 
@@ -14,7 +28,7 @@ fun AppLogs() {
     var logLevel by remember { mutableStateOf(LogLevel.INFO) }
     val logText = buildLogs(logLevel)
 
-    LogScreen(logText, "App Logs Report", "app_logs", logLevel, { logLevel = it })
+    LogScreen(logText, "App Logs Report", "app_logs") { LogLevelDropdown(logLevel, { logLevel = it }) }
 }
 
 private fun buildLogs(logLevel: LogLevel): String {
@@ -28,12 +42,47 @@ private fun buildLogs(logLevel: LogLevel): String {
     val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo)
 
     return buildString {
-        append("[DEBUG] App version: ").append(versionName).appendLine()
-        append("[DEBUG] Version code: ").append(versionCode).appendLine()
-        append("[DEBUG] Commit hash: ").append(BuildConfig.GIT_COMMIT_HASH.substring(0, 8)).appendLine()
+        append("[REPORT] App version: ").append(versionName).appendLine()
+        append("[REPORT] Version code: ").append(versionCode).appendLine()
+        append("[REPORT] Commit hash: ").append(BuildConfig.GIT_COMMIT_HASH.substring(0, 8)).appendLine()
 
         appendLine()
 
         append(entries)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RowScope.LogLevelDropdown(logLevel: LogLevel, onLogLevelChange: (LogLevel) -> Unit) {
+    var dropdownMenuExpanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = dropdownMenuExpanded,
+        onExpandedChange = { dropdownMenuExpanded = !dropdownMenuExpanded },
+        modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
+    ) {
+        StyledTextField(
+            value = logLevel.label,
+            onValueChange = {},
+            shape = RoundedCornerShape(8.dp),
+            maxLines = 1,
+            readOnly = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = dropdownMenuExpanded) },
+            modifier =
+                Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth().height(42.dp),
+        )
+
+        ExposedDropdownMenu(expanded = dropdownMenuExpanded, onDismissRequest = { dropdownMenuExpanded = false }) {
+            LogLevel.entries.forEach { level ->
+                DropdownMenuItem(
+                    text = { Text(text = level.label) },
+                    onClick = {
+                        onLogLevelChange(level)
+                        dropdownMenuExpanded = false
+                    },
+                )
+            }
+        }
     }
 }

--- a/core/main/src/main/java/com/rk/settings/debugOptions/LogCollector.kt
+++ b/core/main/src/main/java/com/rk/settings/debugOptions/LogCollector.kt
@@ -4,11 +4,11 @@ import androidx.compose.runtime.mutableStateListOf
 import com.rk.resources.getString
 import com.rk.resources.strings
 
-enum class LogLevel(val label: String) {
-    DEBUG(strings.debug.getString()),
-    INFO(strings.info.getString()),
-    WARN(strings.warning.getString()),
-    ERROR(strings.error.getString()),
+enum class LogLevel(val label: String, val value: Int) {
+    ERROR(strings.error.getString(), 1),
+    WARN(strings.warning.getString(), 2),
+    INFO(strings.info.getString(), 3),
+    DEBUG(strings.debug.getString(), 5),
 }
 
 data class LogEntry(val level: LogLevel, val message: String, val timestamp: Long = System.currentTimeMillis())

--- a/core/main/src/main/java/com/rk/settings/debugOptions/LogScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/debugOptions/LogScreen.kt
@@ -5,20 +5,14 @@ import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuAnchorType
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -29,11 +23,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -42,7 +33,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
 import com.rk.activities.settings.SettingsActivity
-import com.rk.components.StyledTextField
 import com.rk.crashhandler.CrashHandler.logErrorOrExit
 import com.rk.editor.Editor
 import com.rk.file.BuiltinFileType
@@ -61,19 +51,11 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LogScreen(
-    logText: String,
-    issueTitle: String,
-    copyLabel: String,
-    logLevel: LogLevel,
-    onLogLevelChange: (LogLevel) -> Unit,
-    actionButtons: @Composable (() -> Unit)? = null,
-) {
+fun LogScreen(logText: String, issueTitle: String, copyLabel: String, toolbarButtons: @Composable RowScope.() -> Unit) {
     val scope = rememberCoroutineScope()
     val backDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 
     val editorState = remember { CodeEditorState() }
-    var dropdownMenuExpanded by remember { mutableStateOf(false) }
 
     XedTheme {
         Scaffold(
@@ -119,43 +101,7 @@ fun LogScreen(
                                 )
                             }
 
-                            ExposedDropdownMenuBox(
-                                expanded = dropdownMenuExpanded,
-                                onExpandedChange = { dropdownMenuExpanded = !dropdownMenuExpanded },
-                                modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
-                            ) {
-                                StyledTextField(
-                                    value = logLevel.label,
-                                    onValueChange = {},
-                                    shape = RoundedCornerShape(8.dp),
-                                    maxLines = 1,
-                                    readOnly = true,
-                                    trailingIcon = {
-                                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = dropdownMenuExpanded)
-                                    },
-                                    modifier =
-                                        Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
-                                            .fillMaxWidth()
-                                            .height(42.dp),
-                                )
-
-                                ExposedDropdownMenu(
-                                    expanded = dropdownMenuExpanded,
-                                    onDismissRequest = { dropdownMenuExpanded = false },
-                                ) {
-                                    LogLevel.entries.forEach { level ->
-                                        DropdownMenuItem(
-                                            text = { Text(text = level.label) },
-                                            onClick = {
-                                                onLogLevelChange(level)
-                                                dropdownMenuExpanded = false
-                                            },
-                                        )
-                                    }
-                                }
-                            }
-
-                            actionButtons?.invoke()
+                            toolbarButtons()
                         }
 
                         HorizontalDivider()

--- a/core/main/src/main/java/com/rk/settings/lsp/LspServerLogs.kt
+++ b/core/main/src/main/java/com/rk/settings/lsp/LspServerLogs.kt
@@ -1,40 +1,114 @@
 package com.rk.settings.lsp
 
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.core.content.pm.PackageInfoCompat
+import com.rk.components.StyledTextField
 import com.rk.lsp.LspConnectionStatus
 import com.rk.lsp.LspRegistry
 import com.rk.lsp.LspServer
 import com.rk.lsp.LspServerInstance
+import com.rk.lsp.MessageSource
 import com.rk.resources.drawables
 import com.rk.resources.getString
 import com.rk.resources.strings
-import com.rk.settings.debugOptions.LogLevel
 import com.rk.settings.debugOptions.LogScreen
 import com.rk.utils.application
 import com.rk.xededitor.BuildConfig
 import kotlinx.coroutines.launch
+import org.eclipse.lsp4j.MessageType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LspServerLogs(server: LspServer, id: String) {
     val scope = rememberCoroutineScope()
-    var logLevel by remember { mutableStateOf(LogLevel.INFO) }
+    var messageType by remember { mutableStateOf(MessageType.Info) }
+
+    val messageSources = remember { mutableStateSetOf(MessageSource.LSP, MessageSource.Runtime, MessageSource.Client) }
+    var sourceDropdownExpanded by remember { mutableStateOf(false) }
 
     val instance = server.instances.find { it.id == id }
-    val logText = instance?.let { buildLogs(server, it, logLevel) } ?: strings.instance_not_found.getString()
+    val logText =
+        instance?.let { buildLogs(server, it, messageType, messageSources) } ?: strings.instance_not_found.getString()
 
-    LogScreen(logText, "Language Server Error Report", "server_logs", logLevel, { logLevel = it }) {
+    LogScreen(logText, "Language Server Error Report", "server_logs") {
+        var dropdownMenuExpanded by remember { mutableStateOf(false) }
+
+        ExposedDropdownMenuBox(
+            expanded = dropdownMenuExpanded,
+            onExpandedChange = { dropdownMenuExpanded = !dropdownMenuExpanded },
+            modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
+        ) {
+            StyledTextField(
+                value = messageType.name + " (LSP)",
+                onValueChange = {},
+                shape = RoundedCornerShape(8.dp),
+                maxLines = 1,
+                readOnly = true,
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = dropdownMenuExpanded) },
+                modifier =
+                    Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth().height(42.dp),
+            )
+
+            ExposedDropdownMenu(expanded = dropdownMenuExpanded, onDismissRequest = { dropdownMenuExpanded = false }) {
+                MessageType.entries.forEach { type ->
+                    DropdownMenuItem(
+                        text = { Text(text = type.name) },
+                        onClick = {
+                            messageType = type
+                            dropdownMenuExpanded = false
+                        },
+                    )
+                }
+            }
+        }
+
+        IconButton(onClick = { sourceDropdownExpanded = !sourceDropdownExpanded }) {
+            Icon(
+                painter = painterResource(drawables.filter),
+                contentDescription = stringResource(strings.filter_options),
+            )
+
+            DropdownMenu(expanded = sourceDropdownExpanded, onDismissRequest = { sourceDropdownExpanded = false }) {
+                MessageSource.entries.forEach { source ->
+                    DropdownMenuItem(
+                        text = { Text(text = source.name) },
+                        leadingIcon = { Checkbox(checked = messageSources.contains(source), onCheckedChange = null) },
+                        onClick = {
+                            if (messageSources.contains(source)) {
+                                messageSources.remove(source)
+                            } else {
+                                messageSources.add(source)
+                            }
+                        },
+                    )
+                }
+            }
+        }
+
         val isRunning =
             instance?.status != LspConnectionStatus.NOT_RUNNING &&
                 instance?.status != LspConnectionStatus.CRASHED &&
@@ -55,29 +129,39 @@ fun LspServerLogs(server: LspServer, id: String) {
     }
 }
 
-private fun buildLogs(server: LspServer, instance: LspServerInstance, logLevel: LogLevel): String {
+private fun buildLogs(
+    server: LspServer,
+    instance: LspServerInstance,
+    messageType: MessageType,
+    messageSources: Set<MessageSource>,
+): String {
     val entries =
         instance
-            .getLogs()
-            .filter { it.level.ordinal >= logLevel.ordinal }
-            .joinToString("\n") { "[${it.level.name.uppercase()}] ${it.message}" }
+            .getLspLogs()
+            .filter { messageSources.contains(it.source) }
+            .filter { it.type == null || it.type.value <= messageType.value }
+            .joinToString("\n") {
+                val sourceString = it.source.name.uppercase().let { source -> "[$source]" }
+                val levelString = it.type?.name?.uppercase() ?: ""
+                "$sourceString $levelString ${it.message}"
+            }
 
     val packageInfo = with(application!!) { packageManager.getPackageInfo(packageName, 0) }
     val versionName = packageInfo.versionName
     val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo)
 
     return buildString {
-        append("[DEBUG] App version: ").append(versionName).appendLine()
-        append("[DEBUG] Version code: ").append(versionCode).appendLine()
-        append("[DEBUG] Commit hash: ").append(BuildConfig.GIT_COMMIT_HASH.substring(0, 8)).appendLine()
+        append("[REPORT] App version: ").append(versionName).appendLine()
+        append("[REPORT] Version code: ").append(versionCode).appendLine()
+        append("[REPORT] Commit hash: ").append(BuildConfig.GIT_COMMIT_HASH.substring(0, 8)).appendLine()
 
         appendLine()
 
-        append("[DEBUG] Server name: ").append(server.serverName).appendLine()
-        append("[DEBUG] Server id: ").append(server.id).appendLine()
-        append("[DEBUG] Server status: ").append(instance.status.name).appendLine()
-        append("[DEBUG] Supported extensions: ").append(server.supportedExtensions).appendLine()
-        append("[DEBUG] Is built-in: ").append(LspRegistry.builtInServer.contains(server)).appendLine()
+        append("[REPORT] Server name: ").append(server.serverName).appendLine()
+        append("[REPORT] Server id: ").append(server.id).appendLine()
+        append("[REPORT] Server status: ").append(instance.status.name).appendLine()
+        append("[REPORT] Supported extensions: ").append(server.supportedExtensions).appendLine()
+        append("[REPORT] Is built-in: ").append(LspRegistry.builtInServer.contains(server)).appendLine()
 
         appendLine()
 


### PR DESCRIPTION
This PR closes #1412

## Changes
- Introduce `MessageSource` enum (RPC, LSP, Runtime, Client) to better categorize logs.
- Update `LspLogEntry` to include source metadata and allow optional `MessageType`.
- Enhance the LSP logs UI with a new filter for message sources and a log level selector.
- Generalize the `LogScreen` component to support custom toolbar actions via `toolbarButtons`.
- Add numeric values to `LogLevel` and use them for filtering logic.
- Update log report headers to use a `[REPORT]` prefix instead of `[DEBUG]`.
- Update `SocketConnection`, `ProcessConnection`, and `LspConnector` to provide appropriate message sources.