### PR TITLE
feat: add terminal clipboard keybindings for hardware keyboards

### DIFF
--- a/core/main/src/main/java/com/rk/settings/Settings.kt
+++ b/core/main/src/main/java/com/rk/settings/Settings.kt
@@ -104,6 +104,7 @@ object Settings {
     var show_minimap by CachedPreference("show_minimap", false)
     var auto_closing_bracket by CachedPreference("auto_closing_bracket", true)
     var confirm_exit by CachedPreference("confirm_exit", true)
+    var terminal_clipboard_keybindings by CachedPreference("terminal_clipboard_keybindings", true)
 
     // Int settings
     var tab_size by CachedPreference("tab_size", 4)

--- a/core/main/src/main/java/com/rk/settings/terminal/SettingsTerminalScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/terminal/SettingsTerminalScreen.kt
@@ -347,6 +347,13 @@ fun SettingsTerminalScreen(overrideNavController: NavController? = null) {
                 route = SettingsRoutes.TerminalExtraKeys,
             )
 
+            SettingsItem(
+                label = stringResource(strings.clipboard_keybindings),
+                description = stringResource(strings.clipboard_keybindings_desc),
+                default = Settings.terminal_clipboard_keybindings,
+                sideEffect = { Settings.terminal_clipboard_keybindings = it },
+            )
+
             ValueSlider(
                 label = stringResource(strings.scrollback_buffer),
                 description = stringResource(strings.scrollback_buffer_desc),
@@ -371,7 +378,6 @@ fun SettingsTerminalScreen(overrideNavController: NavController? = null) {
                 description = stringResource(strings.project_as_wk_desc),
                 default = Settings.project_as_pwd,
                 sideEffect = { Settings.project_as_pwd = it },
-                showSwitch = true,
             )
 
             var exposeHomeDirState by remember { mutableStateOf(Settings.expose_home_dir) }

--- a/core/main/src/main/java/com/rk/terminal/TerminalBackEnd.kt
+++ b/core/main/src/main/java/com/rk/terminal/TerminalBackEnd.kt
@@ -29,8 +29,9 @@ class TerminalBackEnd : TerminalViewClient, TerminalSessionClient {
 
     override fun onPasteTextFromClipboard(session: TerminalSession?) {
         val clip = ClipboardUtils.getText().toString()
-        if (clip.trim { it <= ' ' }.isNotEmpty() && terminalView.get()?.mEmulator != null) {
-            terminalView.get()?.mEmulator?.paste(clip)
+        val emulator = terminalView.get()?.mEmulator ?: return
+        if (clip.isNotBlank()) {
+            emulator.paste(clip)
         }
     }
 
@@ -101,6 +102,10 @@ class TerminalBackEnd : TerminalViewClient, TerminalSessionClient {
         return true
     }
 
+    override fun shouldSupportClipboardKeybindings(): Boolean {
+        return Settings.terminal_clipboard_keybindings
+    }
+
     override fun isTerminalViewSelected(): Boolean {
         return true
     }
@@ -110,13 +115,12 @@ class TerminalBackEnd : TerminalViewClient, TerminalSessionClient {
     override fun onKeyDown(keyCode: Int, e: KeyEvent, session: TerminalSession): Boolean {
         if (keyCode == KeyEvent.KEYCODE_ENTER && !session.isRunning) {
             val activity = Terminal.instance ?: return false
-            activity.sessionBinder
-                ?.get()
-                ?.terminateSession(activity.sessionBinder?.get()!!.getService().currentSession.value)
-            if (activity.sessionBinder?.get()!!.getService().sessionList.isEmpty()) {
+            val sessionBinder = activity.sessionBinder?.get() ?: return false
+            sessionBinder.terminateSession(sessionBinder.getService().currentSession.value)
+            if (sessionBinder.getService().sessionList.isEmpty()) {
                 activity.finish()
             } else {
-                activity.changeSession(activity.sessionBinder?.get()!!.getService().sessionList.first())
+                activity.changeSession(sessionBinder.getService().sessionList.first())
             }
             return true
         }

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -660,4 +660,6 @@
     <string name="uninstall_ext_dialog">Uninstall extension?</string>
     <string name="uninstall_ext_dialog_desc">Are you sure you want to uninstall the extension \'%s\'?</string>
     <string name="invalid_terminal_extra_keys">Invalid format for terminal extra keys. Default keys will be loaded.</string>
+    <string name="clipboard_keybindings">Clipboard keybindings</string>
+    <string name="clipboard_keybindings_desc">Enable copy and paste keybindings for hardware keyboards.</string>
 </resources>

--- a/terminal-view/src/main/java/com/termux/view/TerminalView.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalView.java
@@ -770,7 +770,29 @@ public final class TerminalView extends View {
         if (TERMINAL_VIEW_KEY_LOGGING_ENABLED)
             mClient.logInfo(LOG_TAG, "onKeyDown(keyCode=" + keyCode + ", isSystem()=" + event.isSystem() + ", event=" + event + ")");
         if (mEmulator == null) return true;
-        if (isSelectingText()) {
+
+        // Xed-Editor addition
+        if (mClient.shouldSupportClipboardKeybindings()) {
+            final boolean controlDown = event.isCtrlPressed();
+
+            // Copy
+            if (controlDown && keyCode == KeyEvent.KEYCODE_C && isSelectingText()) {
+                String selectedText = getSelectedText();
+                if (selectedText != null) {
+                    mTermSession.onCopyTextToClipboard(selectedText);
+                    stopTextSelectionMode();
+                }
+                return true;
+            }
+
+            // Paste
+            if (controlDown && keyCode == KeyEvent.KEYCODE_V) {
+                mTermSession.onPasteTextFromClipboard();
+                return true;
+            }
+        }
+
+        if (isSelectingText() && !mClient.shouldSupportClipboardKeybindings()) {
             stopTextSelectionMode();
         }
 

--- a/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalViewClient.java
@@ -34,6 +34,8 @@ public interface TerminalViewClient {
 
     boolean shouldUseCtrlSpaceWorkaround();
 
+    boolean shouldSupportClipboardKeybindings();
+
     boolean isTerminalViewSelected();
 
 


### PR DESCRIPTION
This PR closes #626

## Changes
- Implement Ctrl+C (copy) and Ctrl+V (paste) support in `TerminalView` when text is selected.
- Add `terminal_clipboard_keybindings` setting to toggle keyboard shortcut support.
- Update `TerminalViewClient` and `TerminalBackEnd` to support the new clipboard configuration.
- Refactor `TerminalBackEnd` for cleaner session termination and improved clipboard text handling.
- Add string resources and UI toggle in terminal settings for the new feature.