### PR TITLE
feat: enhancements and numerous tiny issue fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         targetSdk = 28
 
         // versioning
-        versionCode = 91
+        versionCode = 92
         versionName = "3.2.9"
         vectorDrawables { useSupportLibrary = true }
     }

--- a/core/main/src/main/assets/terminal/universal_runner.sh
+++ b/core/main/src/main/assets/terminal/universal_runner.sh
@@ -2,7 +2,7 @@ set -e
 file="$1"
 
 if [ ! -f "$file" ]; then
-  echo "Error: File not found -> $file"
+  error "Error: File not found -> $file"
   exit 1
 fi
 
@@ -24,20 +24,28 @@ run_code() {
 
 install_package() {
   local packages="$1"
+
+  # If curl is requested, ensure ca-certificates is also installed
+  if echo "$packages" | grep -qw curl; then
+    if ! echo "$packages" | grep -qw ca-certificates; then
+      packages="$packages ca-certificates"
+    fi
+  fi
+
   info "Installing $packages..."
   apt update -y && apt upgrade -y
   apt install -y $packages
 }
 
 install_nodejs() {
-  echo "Installing Node.js LTS..."
+  info "Installing Node.js LTS..."
   install_package "curl"
   curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
   apt install -y nodejs
 }
 
 install_rust() {
-  echo "Installing Rust..."
+  info "Installing Rust..."
   install_package "curl"
   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
   source "$HOME/.cargo/env"
@@ -46,7 +54,7 @@ install_rust() {
 }
 
 install_dotnet() {
-  echo "Installing .NET SDK..."
+  info "Installing .NET SDK..."
   wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
   dpkg -i packages-microsoft-prod.deb
   rm packages-microsoft-prod.deb
@@ -56,7 +64,7 @@ install_dotnet() {
 
 install_kotlin() {
     install_package "unzip curl"
-    echo "Fetching latest Kotlin compiler..."
+    info "Fetching latest Kotlin compiler..."
     url=$(curl -s https://api.github.com/repos/JetBrains/kotlin/releases/latest \
         | grep "browser_download_url" \
         | grep "kotlin-compiler-.*zip" \
@@ -64,21 +72,21 @@ install_kotlin() {
         | cut -d '"' -f 4)
 
     if [ -z "$url" ]; then
-        echo "Error: Could not find Kotlin compiler download URL."
+        error "Error: Could not find Kotlin compiler download URL."
         return 1
     fi
 
-    echo "Downloading from: $url"
+    info "Downloading from: $url"
     curl -L -o /tmp/kotlin.zip "$url"
 
-    echo "Extracting to /opt/kotlinc ..."
+    info "Extracting to /opt/kotlinc ..."
     mkdir -p /opt/kotlinc
     unzip -qo /tmp/kotlin.zip -d /opt
 
     ln -sf /opt/kotlinc/bin/kotlinc /usr/local/bin/kotlinc
     ln -sf /opt/kotlinc/bin/kotlin /usr/local/bin/kotlin
 
-    echo "Kotlin installed at /opt/kotlinc"
+    info "Kotlin installed at /opt/kotlinc"
 }
 
 case "$file" in
@@ -102,7 +110,7 @@ case "$file" in
     fi
 
     if ! command_exists tsc; then
-      echo "Installing TypeScript compiler..."
+      info "Installing TypeScript compiler..."
       npm install -g typescript
     fi
 
@@ -132,11 +140,11 @@ case "$file" in
 
   *.kt)
     if ! command_exists java; then
-      echo "Installing Java..."
+      info "Installing Java..."
       install_package "default-jdk"
     fi
     if ! command_exists kotlinc; then
-      echo "Installing Kotlin..."
+      info "Installing Kotlin..."
       install_kotlin
     fi
     kotlinc "$file" -include-runtime -d temp.jar && java -jar temp.jar
@@ -263,14 +271,14 @@ case "$file" in
 
   *.elm)
     if ! command_exists elm; then
-      echo "Installing Elm..."
+      info "Installing Elm..."
       if ! command_exists node; then
         install_nodejs
       fi
       npm install -g elm
     fi
     elm make "$file" --output=temp.html
-    echo "Elm compiled to temp.html - transfer to browser to view"
+    info "Elm compiled to temp.html - transfer to browser to view"
     ;;
 
   *.fsx|*.fs)

--- a/core/main/src/main/java/com/rk/commands/editor/ReplaceCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/ReplaceCommand.kt
@@ -1,6 +1,7 @@
 package com.rk.commands.editor
 
 import android.view.KeyEvent
+import androidx.compose.ui.text.TextRange
 import com.rk.commands.EditorActionContext
 import com.rk.commands.EditorCommand
 import com.rk.commands.KeyCombination
@@ -16,7 +17,9 @@ class ReplaceCommand : EditorCommand() {
 
     override fun action(editorActionContext: EditorActionContext) {
         editorActionContext.editorTab.editorState.apply {
-            editorActionContext.editor.getSelectedText()?.let { searchKeyword = it }
+            editorActionContext.editor.getSelectedText()?.let {
+                searchKeyword = searchKeyword.copy(text = it, selection = TextRange(it.length))
+            }
             isSearching = true
             isReplaceShown = true
         }

--- a/core/main/src/main/java/com/rk/commands/editor/SearchCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/SearchCommand.kt
@@ -1,6 +1,7 @@
 package com.rk.commands.editor
 
 import android.view.KeyEvent
+import androidx.compose.ui.text.TextRange
 import com.rk.commands.EditorActionContext
 import com.rk.commands.EditorCommand
 import com.rk.commands.KeyCombination
@@ -16,7 +17,9 @@ class SearchCommand : EditorCommand() {
 
     override fun action(editorActionContext: EditorActionContext) {
         editorActionContext.editorTab.editorState.apply {
-            editorActionContext.editor.getSelectedText()?.let { searchKeyword = it }
+            editorActionContext.editor.getSelectedText()?.let {
+                searchKeyword = searchKeyword.copy(text = it, selection = TextRange(it.length))
+            }
             isSearching = true
             isReplaceShown = false
         }

--- a/core/main/src/main/java/com/rk/components/GlobalToolbarActions.kt
+++ b/core/main/src/main/java/com/rk/components/GlobalToolbarActions.kt
@@ -81,6 +81,7 @@ fun GlobalToolbarActions(viewModel: MainViewModel, drawerViewModel: DrawerViewMo
 
     if (fileSearchDialog && drawerViewModel.currentDrawerTab is FileTreeTab) {
         FileSearchDialog(
+            mainViewModel = viewModel,
             searchViewModel = searchViewModel.get()!!,
             projectFile = (drawerViewModel.currentDrawerTab as FileTreeTab).root,
             onFinish = { fileSearchDialog = false },

--- a/core/main/src/main/java/com/rk/components/StyledTextFeild.kt
+++ b/core/main/src/main/java/com/rk/components/StyledTextFeild.kt
@@ -1,14 +1,13 @@
 package com.rk.components
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -17,9 +16,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+
+private fun TextFieldColors.textColor(enabled: Boolean, isError: Boolean, focused: Boolean): Color =
+    when {
+        !enabled -> disabledTextColor
+        isError -> errorTextColor
+        focused -> focusedTextColor
+        else -> unfocusedTextColor
+    }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,29 +55,25 @@ fun StyledTextField(
     minLines: Int = 1,
     interactionSource: MutableInteractionSource? = null,
     shape: Shape = TextFieldDefaults.shape,
-    colors: TextFieldColors =
-        TextFieldDefaults.colors(
-            cursorColor = MaterialTheme.colorScheme.onSurface,
-            focusedIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent,
-            disabledIndicatorColor = Color.Transparent,
-            selectionColors =
-                TextSelectionColors(
-                    handleColor = MaterialTheme.colorScheme.primary,
-                    backgroundColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.4f),
-                ),
-        ),
+    colors: TextFieldColors = TextFieldDefaults.colors(),
 ) {
     val finalInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
 
+    val textColor =
+        textStyle.color.takeOrElse {
+            val focused = finalInteractionSource.collectIsFocusedAsState().value
+            colors.textColor(enabled, isError, focused)
+        }
+    val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+
     BasicTextField(
-        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+        cursorBrush = SolidColor(if (isError) colors.errorCursorColor else colors.cursorColor),
         value = value,
         onValueChange = onValueChange,
         modifier = modifier,
         enabled = enabled,
         readOnly = readOnly,
-        textStyle = TextStyle(color = MaterialTheme.colorScheme.onSurface),
+        textStyle = mergedTextStyle,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         visualTransformation = visualTransformation,
@@ -85,7 +90,81 @@ fun StyledTextField(
             enabled = enabled,
             isError = isError,
             interactionSource = finalInteractionSource,
-            contentPadding = PaddingValues(top = 8.dp, start = 8.dp, end = 8.dp),
+            contentPadding = PaddingValues(top = 8.dp, start = 16.dp, end = 16.dp),
+            placeholder = placeholder,
+            leadingIcon = leadingIcon,
+            trailingIcon = trailingIcon,
+            prefix = prefix,
+            suffix = suffix,
+            supportingText = supportingText,
+            label = label,
+            shape = shape,
+            colors = colors,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StyledTextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = LocalTextStyle.current,
+    label: @Composable (() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    minLines: Int = 1,
+    interactionSource: MutableInteractionSource? = null,
+    shape: Shape = TextFieldDefaults.shape,
+    colors: TextFieldColors = TextFieldDefaults.colors(),
+) {
+    val finalInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+
+    val textColor =
+        textStyle.color.takeOrElse {
+            val focused = finalInteractionSource.collectIsFocusedAsState().value
+            colors.textColor(enabled, isError, focused)
+        }
+    val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+
+    BasicTextField(
+        cursorBrush = SolidColor(if (isError) colors.errorCursorColor else colors.cursorColor),
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        readOnly = readOnly,
+        textStyle = mergedTextStyle,
+        keyboardOptions = keyboardOptions,
+        keyboardActions = keyboardActions,
+        visualTransformation = visualTransformation,
+        interactionSource = finalInteractionSource,
+        singleLine = singleLine,
+        maxLines = maxLines,
+        minLines = minLines,
+    ) { innerTextField ->
+        TextFieldDefaults.DecorationBox(
+            value = value.text,
+            visualTransformation = visualTransformation,
+            innerTextField = innerTextField,
+            singleLine = singleLine,
+            enabled = enabled,
+            isError = isError,
+            interactionSource = finalInteractionSource,
+            contentPadding = PaddingValues(top = 8.dp, start = 16.dp, end = 16.dp),
             placeholder = placeholder,
             leadingIcon = leadingIcon,
             trailingIcon = trailingIcon,

--- a/core/main/src/main/java/com/rk/drawer/DrawerPersistence.kt
+++ b/core/main/src/main/java/com/rk/drawer/DrawerPersistence.kt
@@ -65,7 +65,7 @@ object DrawerPersistence {
                     if (expandedNodeFile.exists() && expandedNodeFile.canRead()) {
                         fileTreeViewModel
                             .get()
-                            ?.setExpandedNodes(expandedNodeFile.readObject() as Map<FileObject, Boolean>)
+                            ?.setExpandedNodes(expandedNodeFile.readObject() as Map<FileObject, Set<FileObject>>)
                     }
                 }
                 .onFailure {

--- a/core/main/src/main/java/com/rk/editor/Editor.kt
+++ b/core/main/src/main/java/com/rk/editor/Editor.kt
@@ -47,6 +47,7 @@ class Editor : CodeEditor {
         val editorSurface: Int,
         val surfaceContainer: Int,
         val highSurfaceContainer: Int,
+        val highestSurfaceContainer: Int,
         val onSurface: Int,
         val colorPrimary: Int,
         val selectionBg: Int,
@@ -68,6 +69,7 @@ class Editor : CodeEditor {
         val surfaceColor = if (isDarkMode) colorScheme.surfaceDim else colorScheme.surface
         val surfaceContainer = colorScheme.surfaceContainer
         val highSurfaceContainer = colorScheme.surfaceContainerHigh
+        val highestSurfaceContainer = colorScheme.surfaceContainerHighest
         val onSurfaceColor = colorScheme.onSurface
         val colorPrimary = colorScheme.primary
         val divider = colorScheme.outlineVariant
@@ -84,6 +86,7 @@ class Editor : CodeEditor {
             editorSurface = surfaceColor.toArgb(),
             surfaceContainer = surfaceContainer.toArgb(),
             highSurfaceContainer = highSurfaceContainer.toArgb(),
+            highestSurfaceContainer = highestSurfaceContainer.toArgb(),
             onSurface = onSurfaceColor.toArgb(),
             colorPrimary = colorPrimary.toArgb(),
             selectionBg = selectionBackground.toArgb(),
@@ -100,6 +103,7 @@ class Editor : CodeEditor {
         editorSurface: Int,
         surfaceContainer: Int,
         highSurfaceContainer: Int,
+        highestSurfaceContainer: Int,
         onSurface: Int,
         colorPrimary: Int,
         selectionBg: Int,
@@ -115,6 +119,7 @@ class Editor : CodeEditor {
                 editorSurface,
                 surfaceContainer,
                 highSurfaceContainer,
+                highestSurfaceContainer,
                 onSurface,
                 colorPrimary,
                 selectionBg,

--- a/core/main/src/main/java/com/rk/editor/XedColorScheme.kt
+++ b/core/main/src/main/java/com/rk/editor/XedColorScheme.kt
@@ -44,6 +44,7 @@ class XedColorScheme(
                 editorSurface,
                 surfaceContainer,
                 highSurfaceContainer,
+                highestSurfaceContainer,
                 onSurface,
                 colorPrimary,
                 selectionBg,
@@ -70,12 +71,17 @@ class XedColorScheme(
                 SIGNATURE_BACKGROUND,
                 HOVER_BACKGROUND,
                 LINE_NUMBER_PANEL,
+                TEXT_INLAY_HINT_BACKGROUND,
             )
 
             setColors(setAlpha(surfaceContainer, 0.4f), MINIMAP_BACKGROUND)
             setColors(setAlpha(highSurfaceContainer, 0.6f), MINIMAP_VIEWPORT, MINIMAP_VIEWPORT_BORDER)
 
-            setColors(highSurfaceContainer, COMPLETION_WND_ITEM_CURRENT)
+            setColors(highSurfaceContainer, COMPLETION_WND_ITEM_CURRENT, TEXT_HIGHLIGHT_BACKGROUND)
+
+            setColors(highestSurfaceContainer, SNIPPET_BACKGROUND_EDITING, TEXT_HIGHLIGHT_STRONG_BACKGROUND)
+            setColors(setAlpha(highestSurfaceContainer, 0.8f), SNIPPET_BACKGROUND_RELATED)
+            setColors(setAlpha(highestSurfaceContainer, 0.6f), SNIPPET_BACKGROUND_INACTIVE)
 
             setColors(
                 onSurface,
@@ -89,6 +95,7 @@ class XedColorScheme(
                 LINE_NUMBER,
                 LINE_NUMBER_CURRENT,
                 LINE_NUMBER_PANEL_TEXT,
+                TEXT_INLAY_HINT_FOREGROUND,
             )
 
             setColors(handleColor, SELECTION_HANDLE)

--- a/core/main/src/main/java/com/rk/exec/TerminalUtils.kt
+++ b/core/main/src/main/java/com/rk/exec/TerminalUtils.kt
@@ -1,8 +1,7 @@
 package com.rk.exec
 
-import android.content.Context
+import android.app.Activity
 import android.content.Intent
-import com.rk.activities.main.MainActivity
 import com.rk.activities.terminal.Terminal
 import com.rk.file.child
 import com.rk.file.localDir
@@ -28,9 +27,9 @@ suspend fun isTerminalWorking(): Boolean =
         return@withContext process.waitFor() == 0
     }
 
-fun launchTerminal(context: Context, terminalCommand: TerminalCommand) {
-    showTerminalNotice(activity = MainActivity.instance!!) {
+fun launchTerminal(activity: Activity, terminalCommand: TerminalCommand) {
+    showTerminalNotice(activity = activity) {
         pendingCommand = terminalCommand
-        context.startActivity(Intent(context, Terminal::class.java))
+        activity.startActivity(Intent(activity, Terminal::class.java))
     }
 }

--- a/core/main/src/main/java/com/rk/filetree/FileTree.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTree.kt
@@ -72,8 +72,8 @@ fun FileTree(
 ) {
     // Auto-expand root node on first composition
     LaunchedEffect(rootNode.file) {
-        if (!viewModel.isNodeExpanded(rootNode.file)) {
-            viewModel.toggleNodeExpansion(rootNode.file)
+        if (!viewModel.isNodeExpanded(rootNode.file, rootNode.file)) {
+            viewModel.toggleNodeExpansion(rootNode.file, rootNode.file)
             viewModel.loadChildrenForNode(rootNode)
         }
     }

--- a/core/main/src/main/java/com/rk/filetree/FileTreeNodeItem.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeNodeItem.kt
@@ -55,7 +55,7 @@ fun FileTreeNodeItem(
     val isHidden = node.file.getName().startsWith(".")
     if (isHidden && !Settings.show_hidden_files_drawer) return
 
-    val isExpanded = viewModel.isNodeExpanded(node.file)
+    val isExpanded = viewModel.isNodeExpanded(root, node.file)
     val horizontalPadding = (depth * 16).dp
 
     val isLoading = viewModel.isNodeLoading(node.file)
@@ -101,7 +101,7 @@ fun FileTreeNodeItem(
     LaunchedEffect(children, Settings.compact_folders_drawer) {
         displayedChildren =
             if (Settings.compact_folders_drawer && children.size == 1 && children[0].isDirectory) {
-                val collapsedNode = viewModel.collapseNode(node)
+                val collapsedNode = viewModel.collapseNode(root, node)
                 viewModel.getNodeChildren(collapsedNode)
             } else children
         displayName =
@@ -123,7 +123,7 @@ fun FileTreeNodeItem(
                             }
 
                             if (node.isDirectory) {
-                                viewModel.toggleNodeExpansion(node.file)
+                                viewModel.toggleNodeExpansion(root, node.file)
                                 return@combinedClickable
                             }
 

--- a/core/main/src/main/java/com/rk/filetree/FileTreeViewModel.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeViewModel.kt
@@ -14,6 +14,7 @@ import com.rk.activities.main.searchViewModel
 import com.rk.file.FileObject
 import com.rk.search.GlobExcluder
 import com.rk.settings.Settings
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -133,18 +134,19 @@ class FileTreeViewModel : ViewModel() {
     private val selectedFiles = mutableStateMapOf<FileObject, List<FileObject>>()
     private val focusedFile = mutableStateMapOf<FileObject, FileObject>()
     private val fileListCache = mutableStateMapOf<FileObject, List<FileTreeNode>>()
-    private val expandedNodes = mutableStateMapOf<FileObject, Boolean>()
+    private val expandedNodes = mutableStateMapOf<FileObject, Set<FileObject>>()
     private val collapsedNameCache = mutableStateMapOf<FileObject, String>()
     private var fileOperationsCount by mutableIntStateOf(0)
 
     private val excluder by derivedStateOf { GlobExcluder(Settings.excluded_files_drawer) }
 
-    fun getExpandedNodes(): Map<FileObject, Boolean> {
-        return mutableMapOf<FileObject, Boolean>().apply { expandedNodes.forEach { set(it.key, it.value) } }
+    fun getExpandedNodes(): Map<FileObject, Set<FileObject>> {
+        // Convert to java `Set` to make serialization possible
+        return expandedNodes.mapValues { (_, value) -> HashSet(value) }
     }
 
-    fun setExpandedNodes(map: Map<FileObject, Boolean>) {
-        map.forEach { expandedNodes[it.key] = it.value }
+    fun setExpandedNodes(map: Map<FileObject, Set<FileObject>>) {
+        map.forEach { (key, value) -> expandedNodes[key] = expandedNodes[key]?.plus(value) ?: value }
     }
 
     fun toggleSelection(projectRoot: FileObject, fileObject: FileObject) {
@@ -215,7 +217,8 @@ class FileTreeViewModel : ViewModel() {
     // Track loading states to avoid showing spinners incorrectly
     private val _loadingStates = mutableStateMapOf<FileObject, Boolean>()
 
-    fun isNodeExpanded(fileObject: FileObject): Boolean = expandedNodes[fileObject] == true
+    fun isNodeExpanded(projectRoot: FileObject, fileObject: FileObject): Boolean =
+        expandedNodes[projectRoot]?.contains(fileObject) ?: false
 
     fun isNodeLoading(fileObject: FileObject): Boolean = _loadingStates[fileObject] == true
 
@@ -241,12 +244,27 @@ class FileTreeViewModel : ViewModel() {
         return diagnosedNodes[fileObject] ?: -1
     }
 
-    fun toggleNodeExpansion(fileObject: FileObject) {
-        val wasExpanded = expandedNodes[fileObject] == true
-        expandedNodes[fileObject] = !wasExpanded
+    fun toggleNodeExpansion(projectRoot: FileObject, fileObject: FileObject) {
+        val wasExpanded = isNodeExpanded(projectRoot, fileObject)
+        if (wasExpanded) {
+            collapseFile(projectRoot, fileObject)
+        } else {
+            expandFile(projectRoot, fileObject)
+        }
+    }
+
+    private fun collapseFile(projectRoot: FileObject, fileObject: FileObject) {
+        expandedNodes[projectRoot] = expandedNodes[projectRoot]?.minus(fileObject) ?: emptySet()
+        if (expandedNodes[projectRoot]?.isEmpty() == true) {
+            expandedNodes.remove(projectRoot)
+        }
+    }
+
+    private fun expandFile(projectRoot: FileObject, fileObject: FileObject) {
+        expandedNodes[projectRoot] = expandedNodes[projectRoot]?.plus(fileObject) ?: setOf(fileObject)
 
         // If we're expanding and haven't loaded yet, trigger a load
-        if (!wasExpanded && !fileListCache.containsKey(fileObject)) {
+        if (!fileListCache.containsKey(fileObject)) {
             _loadingStates[fileObject] = true
         }
     }
@@ -255,13 +273,11 @@ class FileTreeViewModel : ViewModel() {
         return collapsedNameCache[node.file] ?: node.name
     }
 
-    suspend fun collapseNode(node: FileTreeNode): FileTreeNode {
+    suspend fun collapseNode(projectFile: FileObject, node: FileTreeNode): FileTreeNode {
         var currentNode = node
         var collapsedName = node.name
         while (true) {
-            if (!isNodeExpanded(currentNode.file)) {
-                toggleNodeExpansion(currentNode.file)
-            }
+            expandFile(projectFile, currentNode.file)
             loadChildrenForNodeSynchronous(currentNode)
             val children = getNodeChildren(currentNode)
             if (children.size != 1) {
@@ -302,11 +318,8 @@ class FileTreeViewModel : ViewModel() {
 
                 fileListCache[file] = sortedFiles
 
-                viewModelScope.launch {
-                    delay(300)
-                    _loadingStates[file] = false
-                }
-            } catch (e: Exception) {
+                viewModelScope.launch { clearLoadingState(file) }
+            } catch (_: Exception) {
                 _loadingStates[file] = false
             }
         }
@@ -317,22 +330,23 @@ class FileTreeViewModel : ViewModel() {
     suspend fun goToFolder(projectFile: FileObject, fileObject: FileObject) {
         focusedFile[projectFile] = fileObject
         viewModelScope.launch {
-            delay(1000)
+            delay(1000.milliseconds)
             focusedFile.remove(projectFile)
         }
 
         var currentFile: FileObject? = fileObject
         while (currentFile != null && currentFile != projectFile) {
-            expandedNodes[currentFile] = true
+            expandFile(projectFile, currentFile)
 
             // If we're expanding and haven't loaded yet, trigger a load
-            if (!fileListCache.containsKey(fileObject)) {
+            if (!fileListCache.containsKey(currentFile)) {
                 _loadingStates[currentFile] = true
             }
 
             currentFile = currentFile.getParentFile()
         }
-        expandedNodes[projectFile] = true
+
+        expandFile(projectFile, projectFile)
     }
 
     suspend fun refreshEverything() =
@@ -367,10 +381,7 @@ class FileTreeViewModel : ViewModel() {
                 val sortedFiles = sortAndFilterFiles(fileList)
 
                 fileListCache[node.file] = sortedFiles
-                viewModelScope.launch {
-                    delay(300)
-                    _loadingStates[node.file] = false
-                }
+                viewModelScope.launch { clearLoadingState(node.file) }
             } catch (_: Exception) {
                 _loadingStates[node.file] = false
             }
@@ -401,13 +412,16 @@ class FileTreeViewModel : ViewModel() {
             val sortedFiles = sortAndFilterFiles(fileList)
 
             fileListCache[node.file] = sortedFiles
-            viewModelScope.launch {
-                delay(300)
-                _loadingStates[node.file] = false
-            }
+            viewModelScope.launch { clearLoadingState(node.file) }
         } catch (_: Exception) {
             _loadingStates[node.file] = false
         }
+    }
+
+    private suspend fun clearLoadingState(file: FileObject) {
+        // Use delay to avoid flickering
+        delay(300.milliseconds)
+        _loadingStates[file] = false
     }
 
     private suspend fun calculateFileSizes(fileObjects: List<FileObject>): Map<FileObject, Long> {

--- a/core/main/src/main/java/com/rk/search/CodeSearchDialog.kt
+++ b/core/main/src/main/java/com/rk/search/CodeSearchDialog.kt
@@ -68,6 +68,7 @@ import com.rk.resources.drawables
 import com.rk.resources.fillPlaceholders
 import com.rk.resources.strings
 import com.rk.settings.Settings
+import com.rk.tabs.editor.EditorTab
 import com.rk.utils.rememberNumberFormatter
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.launch
@@ -84,7 +85,11 @@ fun CodeSearchDialog(
     val context = LocalContext.current
     val viewportHeight = with(LocalDensity.current) { LocalWindowInfo.current.containerSize.height.toDp() }
 
-    val textFieldSearchState = rememberTextFieldState(searchViewModel.codeSearchQuery)
+    val editorTab = mainViewModel.currentTab as? EditorTab
+    val textFieldSearchState =
+        rememberTextFieldState(
+            editorTab?.editorState?.editor?.get()?.getSelectedText() ?: searchViewModel.codeSearchQuery
+        )
     LaunchedEffect(textFieldSearchState.text) { searchViewModel.codeSearchQuery = textFieldSearchState.text.toString() }
 
     val textFieldReplaceState = rememberTextFieldState(searchViewModel.codeReplaceQuery)

--- a/core/main/src/main/java/com/rk/search/EditorSearch.kt
+++ b/core/main/src/main/java/com/rk/search/EditorSearch.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -45,6 +44,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import com.rk.components.StyledTextField
 import com.rk.resources.strings
 import com.rk.tabs.editor.CodeEditorState
 import io.github.rosemoe.sora.event.PublishSearchResultEvent
@@ -139,7 +139,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                             )
                         }
 
-                        TextField(
+                        StyledTextField(
                             modifier =
                                 Modifier.weight(1f)
                                     .height(42.dp)
@@ -147,7 +147,6 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                                     .focusRequester(focusRequester),
                             shape = RoundedCornerShape(8.dp),
                             maxLines = 1,
-                            // Show error state with red text color
                             textStyle =
                                 LocalTextStyle.current.copy(
                                     color =
@@ -259,7 +258,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                         Row(Modifier.fillMaxWidth()) {
                             Spacer(Modifier.width(48.dp))
 
-                            TextField(
+                            StyledTextField(
                                 modifier = Modifier.weight(1f).padding(horizontal = 8.dp).height(42.dp),
                                 value = editorState.replaceKeyword,
                                 onValueChange = { editorState.replaceKeyword = it },

--- a/core/main/src/main/java/com/rk/search/EditorSearch.kt
+++ b/core/main/src/main/java/com/rk/search/EditorSearch.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.unit.dp
 import com.rk.components.StyledTextField
 import com.rk.resources.strings
 import com.rk.tabs.editor.CodeEditorState
+import com.rk.utils.logError
+import com.rk.utils.toast
 import io.github.rosemoe.sora.event.PublishSearchResultEvent
 import io.github.rosemoe.sora.event.SelectionChangeEvent
 import io.github.rosemoe.sora.widget.EditorSearcher
@@ -63,6 +65,12 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
     var searchMatchesCount by remember { mutableIntStateOf(0) }
     var searchCurrentIndex by remember { mutableIntStateOf(0) }
 
+    fun stopEditorSearch() {
+        hasSearchError = false
+        isSearchingInternal = false
+        editor.get()?.searcher?.stopSearch()
+    }
+
     // Search execution logic
     fun tryCommitSearch() {
         val query = editorState.searchKeyword.text
@@ -78,9 +86,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                 isSearchingInternal = false
             }
         } else {
-            editor.get()?.searcher?.stopSearch()
-            hasSearchError = false
-            isSearchingInternal = false
+            stopEditorSearch()
         }
     }
 
@@ -97,6 +103,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
 
     // Execute search when keyword changes
     LaunchedEffect(
+        editorState.editor.get(),
         editorState.isSearching,
         editorState.searchKeyword,
         editorState.ignoreCase,
@@ -243,9 +250,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                         IconButton(
                             onClick = {
                                 editorState.isSearching = false
-                                editor.get()?.searcher?.stopSearch()
-                                hasSearchError = false
-                                isSearchingInternal = false
+                                stopEditorSearch()
                             }
                         ) {
                             Icon(imageVector = Icons.Outlined.Close, null)
@@ -280,27 +285,59 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                     horizontalArrangement = Arrangement.Start,
                     modifier = Modifier.weight(1f).horizontalScroll(rememberScrollState()).padding(horizontal = 8.dp),
                 ) {
-                    TextButton(enabled = isSearchingInternal, onClick = { editor.get()?.searcher?.gotoPrevious() }) {
+                    TextButton(
+                        enabled = isSearchingInternal,
+                        onClick = {
+                            runCatching { editor.get()?.searcher?.gotoPrevious() }
+                                .onFailure {
+                                    logError(it)
+                                    toast(strings.unknown_err)
+                                }
+                        },
+                    ) {
                         Text(stringResource(strings.go_prev).uppercase())
                     }
 
                     Spacer(Modifier.height(10.dp))
 
-                    TextButton(enabled = isSearchingInternal, onClick = { editor.get()?.searcher?.gotoNext() }) {
+                    TextButton(
+                        enabled = isSearchingInternal,
+                        onClick = {
+                            runCatching { editor.get()?.searcher?.gotoNext() }
+                                .onFailure {
+                                    logError(it)
+                                    toast(strings.unknown_err)
+                                }
+                        },
+                    ) {
                         Text(stringResource(strings.go_next).uppercase())
                     }
 
                     if (editorState.isReplaceShown && editorState.editable) {
                         TextButton(
                             enabled = isSearchingInternal,
-                            onClick = { editor.get()?.searcher?.replaceCurrentMatch(editorState.replaceKeyword.text) },
+                            onClick = {
+                                runCatching {
+                                        editor.get()?.searcher?.replaceCurrentMatch(editorState.replaceKeyword.text)
+                                    }
+                                    .onFailure {
+                                        logError(it)
+                                        toast(strings.unknown_err)
+                                    }
+                            },
                         ) {
                             Text(stringResource(strings.replace).uppercase())
                         }
 
                         TextButton(
                             enabled = isSearchingInternal,
-                            onClick = { editor.get()?.searcher?.replaceAll(editorState.replaceKeyword.text) },
+                            onClick = {
+                                runCatching { editor.get()?.searcher?.replaceAll(editorState.replaceKeyword.text) }
+                                    .onFailure {
+                                        logError(it)
+                                        toast(strings.unknown_err)
+                                    }
+                            },
                         ) {
                             Text(stringResource(strings.replace_all).uppercase())
                         }
@@ -316,9 +353,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
 
         BackHandler {
             editorState.isSearching = false
-            editor.get()?.searcher?.stopSearch()
-            hasSearchError = false
-            isSearchingInternal = false
+            stopEditorSearch()
         }
     }
 }

--- a/core/main/src/main/java/com/rk/search/EditorSearch.kt
+++ b/core/main/src/main/java/com/rk/search/EditorSearch.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -44,7 +45,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
-import com.rk.components.StyledTextField
 import com.rk.resources.strings
 import com.rk.tabs.editor.CodeEditorState
 import io.github.rosemoe.sora.event.PublishSearchResultEvent
@@ -65,7 +65,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
 
     // Search execution logic
     fun tryCommitSearch() {
-        val query = editorState.searchKeyword
+        val query = editorState.searchKeyword.text
         if (query.isNotEmpty()) {
             try {
                 val searchOptions =
@@ -139,7 +139,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                             )
                         }
 
-                        StyledTextField(
+                        TextField(
                             modifier =
                                 Modifier.weight(1f)
                                     .height(42.dp)
@@ -245,6 +245,8 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                             onClick = {
                                 editorState.isSearching = false
                                 editor.get()?.searcher?.stopSearch()
+                                hasSearchError = false
+                                isSearchingInternal = false
                             }
                         ) {
                             Icon(imageVector = Icons.Outlined.Close, null)
@@ -257,7 +259,7 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                         Row(Modifier.fillMaxWidth()) {
                             Spacer(Modifier.width(48.dp))
 
-                            StyledTextField(
+                            TextField(
                                 modifier = Modifier.weight(1f).padding(horizontal = 8.dp).height(42.dp),
                                 value = editorState.replaceKeyword,
                                 onValueChange = { editorState.replaceKeyword = it },
@@ -292,14 +294,14 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
                     if (editorState.isReplaceShown && editorState.editable) {
                         TextButton(
                             enabled = isSearchingInternal,
-                            onClick = { editor.get()?.searcher?.replaceCurrentMatch(editorState.replaceKeyword) },
+                            onClick = { editor.get()?.searcher?.replaceCurrentMatch(editorState.replaceKeyword.text) },
                         ) {
                             Text(stringResource(strings.replace).uppercase())
                         }
 
                         TextButton(
                             enabled = isSearchingInternal,
-                            onClick = { editor.get()?.searcher?.replaceAll(editorState.replaceKeyword) },
+                            onClick = { editor.get()?.searcher?.replaceAll(editorState.replaceKeyword.text) },
                         ) {
                             Text(stringResource(strings.replace_all).uppercase())
                         }
@@ -316,6 +318,8 @@ fun EditorSearchPanel(editorState: CodeEditorState, modifier: Modifier = Modifie
         BackHandler {
             editorState.isSearching = false
             editor.get()?.searcher?.stopSearch()
+            hasSearchError = false
+            isSearchingInternal = false
         }
     }
 }

--- a/core/main/src/main/java/com/rk/search/FileSearchDialog.kt
+++ b/core/main/src/main/java/com/rk/search/FileSearchDialog.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.rk.activities.main.MainViewModel
 import com.rk.components.XedDialog
 import com.rk.components.compose.utils.addIf
 import com.rk.file.FileObject
@@ -47,12 +48,14 @@ import com.rk.filetree.FileIcon
 import com.rk.filetree.getAppropriateName
 import com.rk.resources.fillPlaceholders
 import com.rk.resources.strings
+import com.rk.tabs.editor.EditorTab
 import com.rk.utils.getGitColor
 import com.rk.utils.rememberNumberFormatter
 import java.io.File
 
 @Composable
 fun FileSearchDialog(
+    mainViewModel: MainViewModel,
     searchViewModel: SearchViewModel,
     projectFile: FileObject,
     onFinish: () -> Unit,
@@ -61,7 +64,12 @@ fun FileSearchDialog(
     val focusRequester = remember { FocusRequester() }
     val context = LocalContext.current
 
-    val textFieldState = rememberTextFieldState(searchViewModel.fileSearchQuery)
+    val editorTab = mainViewModel.currentTab as? EditorTab
+    val textFieldState =
+        rememberTextFieldState(
+            editorTab?.editorState?.editor?.get()?.getSelectedText() ?: searchViewModel.fileSearchQuery
+        )
+
     LaunchedEffect(textFieldState.text) { searchViewModel.fileSearchQuery = textFieldState.text.toString() }
 
     LaunchedEffect(searchViewModel.isIndexing(projectFile), searchViewModel.fileSearchQuery) {

--- a/core/main/src/main/java/com/rk/settings/debugOptions/AppLogs.kt
+++ b/core/main/src/main/java/com/rk/settings/debugOptions/AppLogs.kt
@@ -34,7 +34,7 @@ fun AppLogs() {
 private fun buildLogs(logLevel: LogLevel): String {
     val entries =
         LogCollector.logs
-            .filter { it.level.ordinal >= logLevel.ordinal }
+            .filter { it.level.ordinal <= logLevel.ordinal }
             .joinToString("\n") { "[${it.level.name.uppercase()}] ${it.message}" }
 
     val packageInfo = with(application!!) { packageManager.getPackageInfo(packageName, 0) }

--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorState.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.TextFieldValue
 import com.rk.color.ColorFormat
 import com.rk.editor.Editor
 import com.rk.runner.Runner
@@ -38,8 +39,8 @@ data class CodeEditorState(val initialContent: Content? = null) {
     var searchRegex by mutableStateOf(false)
     var searchWholeWord by mutableStateOf(false)
     var showOptionsMenu by mutableStateOf(false)
-    var searchKeyword by mutableStateOf("")
-    var replaceKeyword by mutableStateOf("")
+    var searchKeyword by mutableStateOf(TextFieldValue(""))
+    var replaceKeyword by mutableStateOf(TextFieldValue(""))
 
     var showFindingsDialog by mutableStateOf(false)
     var findingsItems by mutableStateOf(listOf<CodeItem>())

--- a/core/main/src/main/java/com/rk/utils/Log.kt
+++ b/core/main/src/main/java/com/rk/utils/Log.kt
@@ -1,6 +1,8 @@
 package com.rk.utils
 
 import android.util.Log
+import com.rk.resources.getString
+import com.rk.resources.strings
 import com.rk.settings.debugOptions.LogCollector
 
 fun Any.logDebug(msg: String) {
@@ -23,7 +25,7 @@ fun Any.logError(msg: String) {
     LogCollector.reportError(msg)
 }
 
-fun Any.logError(throwable: Throwable, msg: String) {
+fun Any.logError(throwable: Throwable, msg: String = strings.unknown_error.getString()) {
     Log.e(this::class.java.simpleName, msg, throwable)
     LogCollector.reportError("$msg: \n${throwable.stackTraceToString()}")
 }


### PR DESCRIPTION
This PR closes #1420, closes #1285, closes #1415

## Changes
- Fix theming for inlay hints, snippet backgrounds and document highlights
- Improve universal runner logging
- Fix ca-certificates missing when using curl in universal runner
- Bump version code to 92 in order to update universal runner script
- Fix cursor placement issue in editor search
- Automatically use selected text in global code and file search
- Separate expansion logic by project
- Use default Material Design 3 text fields for editor search
- Properly update states in editor search
- Add `TextFieldValue` overload for `StyledTextField`
- Implement dynamic text color and cursor brush handling based on focus, error, and enabled states (clone of default Material Design 3 behavior)
- Update `StyledTextField` to use `DecorationBox` for better support of icons, labels, and placeholders
- Adjust `StyledTextField` horizontal padding to 16.dp
- Replace standard `TextField` with `StyledTextField` in `EditorSearch`
- Fix log level filtering logic in `AppLogs`
- Resolve pattern not set crash