### PR TITLE
refactor: use `Activity` instead of `Context` in LSP/Runner APIs

### DIFF
--- a/core/main/src/main/java/com/rk/activities/terminal/Terminal.kt
+++ b/core/main/src/main/java/com/rk/activities/terminal/Terminal.kt
@@ -47,7 +47,6 @@ import com.rk.XedConstants
 import com.rk.exec.isTerminalInstalled
 import com.rk.file.child
 import com.rk.file.localBinDir
-import com.rk.file.localLibDir
 import com.rk.file.sandboxDir
 import com.rk.resources.getString
 import com.rk.resources.strings

--- a/core/main/src/main/java/com/rk/exec/ubuntuProcess.kt
+++ b/core/main/src/main/java/com/rk/exec/ubuntuProcess.kt
@@ -1,7 +1,6 @@
 package com.rk.exec
 
 import android.annotation.SuppressLint
-import android.os.Build
 import android.util.Log
 import com.rk.file.child
 import com.rk.file.localBinDir
@@ -171,7 +170,7 @@ suspend fun ubuntuProcess(
                 "/bin:/sbin:/usr/bin:/usr/sbin:/usr/games:/usr/local/bin:/usr/local/sbin:${localBinDir()}:${System.getenv("PATH")}"
 
             val loader32 = "${application!!.applicationInfo.nativeLibraryDir}/libloader32.so"
-            if (File(loader32).exists()){
+            if (File(loader32).exists()) {
                 env["LOADER32"] = loader32
             }
 

--- a/core/main/src/main/java/com/rk/lsp/LspServer.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspServer.kt
@@ -23,16 +23,15 @@ abstract class ScriptedLspServer : LspServer() {
     abstract val installScript: File
     abstract val installId: String
 
-    override fun install(context: Context) = launchInstaller(context)
+    override fun install(activity: Activity) = launchInstaller(activity)
 
-    override fun uninstall(context: Context) = launchInstaller(context, "--uninstall")
+    override fun uninstall(activity: Activity) = launchInstaller(activity, "--uninstall")
 
-    override fun update(context: Context) = launchInstaller(context, "--update")
+    override fun update(activity: Activity) = launchInstaller(activity, "--update")
 
-    protected fun launchInstaller(context: Context, vararg flags: String) {
+    protected fun launchInstaller(activity: Activity, vararg flags: String) {
         launchTerminal(
-            //TODO
-            activity = context as Activity,
+            activity = activity,
             terminalCommand =
                 TerminalCommand(
                     exe = "/bin/bash",
@@ -97,13 +96,13 @@ abstract class LspServer {
 
     abstract suspend fun isInstalled(context: Context): Boolean
 
-    abstract fun install(context: Context)
+    abstract fun install(activity: Activity)
 
-    abstract fun uninstall(context: Context)
+    abstract fun uninstall(activity: Activity)
 
     abstract suspend fun isUpdatable(context: Context): Boolean
 
-    abstract fun update(context: Context)
+    abstract fun update(activity: Activity)
 
     abstract fun getConnectionConfig(): LspConnectionConfig
 

--- a/core/main/src/main/java/com/rk/lsp/servers/ExternalProcessServer.kt
+++ b/core/main/src/main/java/com/rk/lsp/servers/ExternalProcessServer.kt
@@ -1,5 +1,6 @@
 package com.rk.lsp.servers
 
+import android.app.Activity
 import android.content.Context
 import com.rk.file.FileTypeManager
 import com.rk.lsp.LspConnectionConfig
@@ -19,13 +20,13 @@ data class ExternalProcessServer(
 
     override suspend fun isInstalled(context: Context) = true
 
-    override fun install(context: Context) {}
+    override fun install(activity: Activity) {}
 
-    override fun uninstall(context: Context) {}
+    override fun uninstall(activity: Activity) {}
 
     override suspend fun isUpdatable(context: Context) = false
 
-    override fun update(context: Context) {}
+    override fun update(activity: Activity) {}
 
     override fun getConnectionConfig(): LspConnectionConfig {
         return LspConnectionConfig.Process(

--- a/core/main/src/main/java/com/rk/lsp/servers/ExternalSocketServer.kt
+++ b/core/main/src/main/java/com/rk/lsp/servers/ExternalSocketServer.kt
@@ -1,5 +1,6 @@
 package com.rk.lsp.servers
 
+import android.app.Activity
 import android.content.Context
 import com.rk.file.FileTypeManager
 import com.rk.lsp.LspConnectionConfig
@@ -21,13 +22,13 @@ data class ExternalSocketServer(
 
     override suspend fun isInstalled(context: Context) = true
 
-    override fun install(context: Context) {}
+    override fun install(activity: Activity) {}
 
-    override fun uninstall(context: Context) {}
+    override fun uninstall(activity: Activity) {}
 
     override suspend fun isUpdatable(context: Context) = false
 
-    override fun update(context: Context) {}
+    override fun update(activity: Activity) {}
 
     override fun getConnectionConfig(): LspConnectionConfig {
         return LspConnectionConfig.Socket(host = host, port = port)

--- a/core/main/src/main/java/com/rk/runner/RunnerManager.kt
+++ b/core/main/src/main/java/com/rk/runner/RunnerManager.kt
@@ -22,7 +22,7 @@ abstract class Runner {
 
     abstract fun matcher(fileObject: FileObject): Boolean
 
-    abstract suspend fun run(context: Context, fileObject: FileObject)
+    abstract suspend fun run(activity: Activity, fileObject: FileObject)
 
     abstract suspend fun isRunning(): Boolean
 

--- a/core/main/src/main/java/com/rk/runner/ShellBasedRunners.kt
+++ b/core/main/src/main/java/com/rk/runner/ShellBasedRunners.kt
@@ -76,11 +76,10 @@ data class ShellBasedRunner(override val label: String, val regex: String) : Run
         return Regex(regex).matches(fileObject.getName())
     }
 
-    override suspend fun run(context: Context, fileObject: FileObject) {
+    override suspend fun run(activity: Activity, fileObject: FileObject) {
         val script = runnerDir().child("${label}.sh").createFileIfNot()
         launchTerminal(
-            //TODO
-            activity = context as Activity,
+            activity = activity,
             TerminalCommand(
                 exe = "/bin/bash",
                 args = arrayOf(script.absolutePath, fileObject.getAbsolutePath()),

--- a/core/main/src/main/java/com/rk/runner/runners/UniversalRunner.kt
+++ b/core/main/src/main/java/com/rk/runner/runners/UniversalRunner.kt
@@ -34,7 +34,7 @@ object UniversalRunner : Runner() {
     }
 
     @SuppressLint("SdCardPath")
-    override suspend fun run(context: Context, fileObject: FileObject) {
+    override suspend fun run(activity: Activity, fileObject: FileObject) {
         setupAssetFile("universal_runner")
 
         if (fileObject !is FileWrapper) {
@@ -53,18 +53,17 @@ object UniversalRunner : Runner() {
                 msg = strings.sdcard_filetype.getString(),
                 okRes = strings.continue_action,
                 onCancel = {},
-                onOk = { DefaultScope.launch { launchUniversalRunner(context, fileObject) } },
+                onOk = { DefaultScope.launch { launchUniversalRunner(activity, fileObject) } },
             )
             return
         }
 
-        launchUniversalRunner(context, fileObject)
+        launchUniversalRunner(activity, fileObject)
     }
 
-    suspend fun launchUniversalRunner(context: Context, fileObject: FileObject) {
+    suspend fun launchUniversalRunner(activity: Activity, fileObject: FileObject) {
         launchTerminal(
-            //TODO
-            activity = context as Activity,
+            activity = activity,
             terminalCommand =
                 TerminalCommand(
                     sandbox = true,

--- a/core/main/src/main/java/com/rk/runner/runners/web/html/HtmlRunner.kt
+++ b/core/main/src/main/java/com/rk/runner/runners/web/html/HtmlRunner.kt
@@ -1,5 +1,6 @@
 package com.rk.runner.runners.web.html
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.browser.customtabs.CustomTabsIntent
@@ -33,12 +34,12 @@ object HtmlRunner : Runner() {
 
     override val onConfigure: () -> Unit = { settingsNavController.get()?.navigate(SettingsRoutes.HtmlRunner.route) }
 
-    override suspend fun run(context: Context, fileObject: FileObject) {
+    override suspend fun run(activity: Activity, fileObject: FileObject) {
         stop()
 
         val port = Settings.http_server_port
         try {
-            httpServer = HttpServer(context, port, fileObject.getParentFile() ?: fileObject)
+            httpServer = HttpServer(activity, port, fileObject.getParentFile() ?: fileObject)
         } catch (_: BindException) {
             toast(strings.http_server_port_error.getFilledString(port))
             return
@@ -50,14 +51,14 @@ object HtmlRunner : Runner() {
         val url = "$address/${fileObject.getName()}"
         if (Settings.launch_in_browser) {
             val intent = Intent(Intent.ACTION_VIEW, url.toUri())
-            context.startActivity(intent)
+            activity.startActivity(intent)
             return
         }
         CustomTabsIntent.Builder()
             .setShowTitle(true)
             .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
             .build()
-            .launchUrl(context, url.toUri())
+            .launchUrl(activity, url.toUri())
     }
 
     override fun getIcon(context: Context): Icon? {

--- a/core/main/src/main/java/com/rk/runner/runners/web/markdown/MarkdownRunner.kt
+++ b/core/main/src/main/java/com/rk/runner/runners/web/markdown/MarkdownRunner.kt
@@ -1,5 +1,6 @@
 package com.rk.runner.runners.web.markdown
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import com.rk.file.BuiltinFileType
@@ -25,10 +26,10 @@ object MarkdownRunner : Runner() {
         return Regex(".*\\.($markdownExtensions)$").matches(fileObject.getName())
     }
 
-    override suspend fun run(context: Context, fileObject: FileObject) {
-        val intent = Intent(context, MDViewer::class.java)
+    override suspend fun run(activity: Activity, fileObject: FileObject) {
+        val intent = Intent(activity, MDViewer::class.java)
         toPreviewFile = fileObject
-        context.startActivity(intent)
+        activity.startActivity(intent)
     }
 
     override fun getIcon(context: Context): Icon? {

--- a/core/main/src/main/java/com/rk/settings/lsp/LspServerDetail.kt
+++ b/core/main/src/main/java/com/rk/settings/lsp/LspServerDetail.kt
@@ -1,5 +1,6 @@
 package com.rk.settings.lsp
 
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -73,6 +74,7 @@ enum class LspInstallationAction {
 fun LspServerDetail(navController: NavHostController, server: LspServer) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
+    val activity = LocalActivity.current
 
     var refreshKey by remember { mutableIntStateOf(0) }
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -98,7 +100,7 @@ fun LspServerDetail(navController: NavHostController, server: LspServer) {
         if (!server.canBeUninstalled) return
 
         FilledTonalButton(
-            onClick = { server.uninstall(context) },
+            onClick = { activity?.let { server.uninstall(it) } },
             colors =
                 ButtonDefaults.filledTonalButtonColors()
                     .copy(
@@ -114,7 +116,7 @@ fun LspServerDetail(navController: NavHostController, server: LspServer) {
 
     @Composable
     fun UpdateButton() {
-        FilledTonalButton(onClick = { server.update(context) }) {
+        FilledTonalButton(onClick = { activity?.let { server.update(it) } }) {
             Icon(painter = painterResource(drawables.update), contentDescription = stringResource(strings.update))
             Spacer(Modifier.width(12.dp))
             Text(stringResource(strings.update))
@@ -123,7 +125,7 @@ fun LspServerDetail(navController: NavHostController, server: LspServer) {
 
     @Composable
     fun DownloadButton() {
-        FilledTonalButton(onClick = { server.install(context) }) {
+        FilledTonalButton(onClick = { activity?.let { server.install(it) } }) {
             Icon(painter = painterResource(drawables.download), contentDescription = stringResource(strings.download))
             Spacer(Modifier.width(12.dp))
             Text(stringResource(strings.install))

--- a/core/main/src/main/java/com/rk/settings/lsp/LspSettings.kt
+++ b/core/main/src/main/java/com/rk/settings/lsp/LspSettings.kt
@@ -1,6 +1,7 @@
 package com.rk.settings.lsp
 
 import android.content.Context
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -228,10 +229,11 @@ private fun LspServerItem(
         },
         endWidget = {
             val status by rememberLspInstallStatus(context, server, refreshKey)
+            val activity = LocalActivity.current
 
             when (status) {
                 LspInstallationAction.INSTALL -> {
-                    IconButton(onClick = { server.install(context) }) {
+                    IconButton(onClick = { activity?.let { server.install(it) } }) {
                         Icon(
                             painter = painterResource(drawables.download),
                             contentDescription = stringResource(strings.download),
@@ -240,7 +242,7 @@ private fun LspServerItem(
                 }
 
                 LspInstallationAction.UPDATE -> {
-                    IconButton(onClick = { server.update(context) }) {
+                    IconButton(onClick = { activity?.let { server.update(it) } }) {
                         Icon(
                             painter = painterResource(drawables.update),
                             contentDescription = stringResource(strings.update),

--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
@@ -1,6 +1,6 @@
 package com.rk.tabs.editor
 
-import android.content.Context
+import android.app.Activity
 import android.content.Intent
 import android.view.KeyEvent
 import android.view.View
@@ -255,8 +255,9 @@ fun EditorTab.applyHighlightingAndConnectLSP() {
         val editorConfigProps = editorState.editorConfigLoaded?.await()
         editorConfigProps?.let { withContext(Dispatchers.Main) { editor.applySettings(it) } }
 
-        val builtin = getBuiltinServers(editor.context)
-        val extension = getExtensionServers(editor.context)
+        val activity = editor.context as? Activity ?: return@launch
+        val builtin = getBuiltinServers(activity)
+        val extension = getExtensionServers(activity)
         val external = getExternalServers()
         val servers = builtin + extension + external
         if (servers.isEmpty()) return@launch
@@ -294,48 +295,51 @@ fun EditorTab.applyHighlightingAndConnectLSP() {
     }
 }
 
-private suspend fun EditorTab.getBuiltinServers(context: Context): List<LspServer> {
+private suspend fun EditorTab.getBuiltinServers(activity: Activity): List<LspServer> {
     val servers = LspRegistry.builtInServer.filter { it.isSupported(file) }
-    return findActiveLspServers(servers, context)
+    return findActiveLspServers(servers, activity)
 }
 
-private fun EditorTab.promptLspInstall(context: Context, server: LspServer) {
+private fun EditorTab.promptLspInstall(activity: Activity, server: LspServer) {
     scope.launch {
         val snackbarHost = snackbarHostStateRef.get() ?: return@launch
         val result =
             snackbarHost.showSnackbar(
-                message = strings.ask_lsp_install.getFilledString(server.languageName, context),
+                message = strings.ask_lsp_install.getFilledString(server.languageName, activity),
                 actionLabel = strings.install.getString(),
                 withDismissAction = true,
                 duration = SnackbarDuration.Short,
             )
         if (result == SnackbarResult.ActionPerformed) {
-            server.install(context)
+            server.install(activity)
         }
     }
 }
 
-private fun EditorTab.promptLspUpdate(context: Context, server: LspServer) {
+private fun EditorTab.promptLspUpdate(activity: Activity, server: LspServer) {
     scope.launch {
         val snackbarHost = snackbarHostStateRef.get() ?: return@launch
         val result =
             snackbarHost.showSnackbar(
-                message = strings.ask_lsp_update.getFilledString(server.languageName, context),
+                message = strings.ask_lsp_update.getFilledString(server.languageName, activity),
                 actionLabel = strings.update.getString(),
                 duration = SnackbarDuration.Long,
             )
         if (result == SnackbarResult.ActionPerformed) {
-            server.update(context)
+            server.update(activity)
         }
     }
 }
 
-private suspend fun EditorTab.getExtensionServers(context: Context): List<LspServer> {
+private suspend fun EditorTab.getExtensionServers(activity: Activity): List<LspServer> {
     val servers = LspRegistry.extensionServers.filter { server -> server.isSupported(file) }
-    return findActiveLspServers(servers, context)
+    return findActiveLspServers(servers, activity)
 }
 
-private suspend fun EditorTab.findActiveLspServers(servers: List<LspServer>, context: Context): MutableList<LspServer> {
+private suspend fun EditorTab.findActiveLspServers(
+    servers: List<LspServer>,
+    activity: Activity,
+): MutableList<LspServer> {
     val matchedServers = mutableListOf<LspServer>()
 
     servers.forEach { server ->
@@ -343,16 +347,16 @@ private suspend fun EditorTab.findActiveLspServers(servers: List<LspServer>, con
             return@forEach
         }
 
-        if (InbuiltFeatures.terminal.state.value && !server.isInstalled(context) && file is FileWrapper) {
+        if (InbuiltFeatures.terminal.state.value && !server.isInstalled(activity) && file is FileWrapper) {
             logInfo("Server ${server.id} is not installed")
-            promptLspInstall(context, server)
+            promptLspInstall(activity, server)
             return@forEach
         }
 
         scope.launch(Dispatchers.IO) {
-            if (server.isUpdatable(context)) {
+            if (server.isUpdatable(activity)) {
                 logInfo("Server ${server.id} is updatable")
-                promptLspUpdate(context, server)
+                promptLspUpdate(activity, server)
             }
         }
 

--- a/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
@@ -1,6 +1,7 @@
 package com.rk.tabs.editor
 
 import android.content.Context
+import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
@@ -557,12 +558,14 @@ private fun EditorTab.RunnerSheet(context: Context) {
 
             Column {
                 editorState.runnersToShow.forEach { runner ->
+                    val activity = LocalActivity.current
+
                     AddDialogItem(
                         icon = runner.getIcon(context) ?: Icon.ResourceIcon(drawableRes = drawables.run),
                         title = runner.label,
                     ) {
                         DefaultScope.launch {
-                            runner.run(context, file)
+                            activity?.let { runner.run(it, file) }
                             editorState.showRunnerDialog = false
                             editorState.runnersToShow = emptyList()
                         }

--- a/core/main/src/main/java/com/rk/terminal/MkSession.kt
+++ b/core/main/src/main/java/com/rk/terminal/MkSession.kt
@@ -1,6 +1,5 @@
 package com.rk.terminal
 
-import android.os.Build
 import com.rk.activities.main.MainActivity
 import com.rk.activities.terminal.Terminal
 import com.rk.exec.pendingCommand
@@ -83,7 +82,7 @@ object MkSession {
                 )
 
             val loader32 = "${application!!.applicationInfo.nativeLibraryDir}/libloader32.so"
-            if (File(loader32).exists()){
+            if (File(loader32).exists()) {
                 env.add("LOADER32=$loader32")
             }
 


### PR DESCRIPTION
## Changes
- Update `LspServer` and `RunnerManager` method signatures to require `Activity`
- Remove unsafe `context as Activity` casts in `launchInstaller` and `launchTerminal`
- Update Compose UI components to resolve the current activity via `LocalActivity`
- Adjust `EditorTab` and `CodeEditorCompose` to pass `Activity` to LSP and runner implementations
- Clean up formatting and unused imports in modified files