### PR TITLE
feat: enhance terminal health checks

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainContentHost.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContentHost.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.MaterialTheme
@@ -41,8 +42,8 @@ import com.rk.settings.Settings
 import com.rk.tabs.editor.EditorTab
 import com.rk.theme.XedTheme
 import com.rk.utils.dialogRes
-import java.lang.ref.WeakReference
 import kotlinx.coroutines.launch
+import java.lang.ref.WeakReference
 
 var gitViewModel = WeakReference<GitViewModel?>(null)
 var fileTreeViewModel = WeakReference<FileTreeViewModel?>(null)
@@ -138,7 +139,10 @@ fun MainActivity.MainContentHost(
                     contentWindowInsets =
                         if (Settings.fullscreen) WindowInsets() else ScaffoldDefaults.contentWindowInsets,
                     snackbarHost = {
-                        SnackbarHost(hostState = snackbarHostState) { data ->
+                        SnackbarHost(
+                            hostState = snackbarHostState,
+                            modifier = Modifier.padding(bottom = snackbarBottomPadding),
+                        ) { data ->
                             Snackbar(
                                 snackbarData = data,
                                 containerColor = MaterialTheme.colorScheme.surfaceVariant,

--- a/core/main/src/main/java/com/rk/settings/terminal/SettingsTerminalScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/terminal/SettingsTerminalScreen.kt
@@ -51,14 +51,14 @@ import com.rk.utils.dpToPx
 import com.rk.utils.getTempDir
 import com.rk.utils.toast
 import com.termux.terminal.TerminalEmulator
-import java.io.File
-import java.io.FileOutputStream
-import java.lang.Runtime.getRuntime
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.lang.Runtime.getRuntime
 
 enum class TerminalCursorStyle(val value: String, val stringRes: Int) {
     BLOCK("block", strings.block),
@@ -102,12 +102,11 @@ fun SettingsTerminalScreen(overrideNavController: NavController? = null) {
                 showSwitch = true,
             )
 
-            SettingsItem(
-                label = "Terminal Health",
-                description = "Check if terminal is working",
-                sideEffect = { settingsNavController.get()?.navigate(SettingsRoutes.TerminalCheck.route) },
-                showSwitch = false,
-                default = false,
+            NextScreenCard(
+                label = stringResource(strings.terminal_health),
+                description = stringResource(strings.terminal_health_desc),
+                navController = overrideNavController ?: settingsNavController.get(),
+                route = SettingsRoutes.TerminalCheck,
             )
         }
 

--- a/core/main/src/main/java/com/rk/settings/terminal/TerminalCheckScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/terminal/TerminalCheckScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -23,15 +24,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.rk.components.InfoBlock
 import com.rk.components.compose.preferences.base.PreferenceGroup
 import com.rk.components.compose.preferences.base.PreferenceLayout
 import com.rk.components.compose.preferences.base.PreferenceTemplate
 import com.rk.icons.LucideCircleQuestionMark
-import kotlinx.coroutines.delay
+import com.rk.resources.strings
+import com.rk.theme.greenStatus
+import com.rk.utils.openUrl
 
 enum class CheckStatus {
     PENDING,
@@ -49,7 +54,8 @@ data class Check(
 )
 
 @Composable
-fun TerminalCheckScreen(modifier: Modifier = Modifier) {
+fun TerminalCheckScreen() {
+    val context = LocalContext.current
     val checks = terminalChecks()
 
     LaunchedEffect(Unit) {
@@ -60,18 +66,9 @@ fun TerminalCheckScreen(modifier: Modifier = Modifier) {
 
             val success =
                 try {
-                    val start = System.currentTimeMillis()
-
-                    val result =
-                        check.run { log ->
-                            // Append log to the current check's logs
-                            checks[i] = checks[i].copy(logs = checks[i].logs + log)
-                        }
-
-                    val end = System.currentTimeMillis()
-
-                    if ((end - start) < 1000) {
-                        delay(1000)
+                    val result = check.run { log ->
+                        // Append log to the current check's logs
+                        checks[i] = checks[i].copy(logs = checks[i].logs + log)
                     }
 
                     result
@@ -85,9 +82,20 @@ fun TerminalCheckScreen(modifier: Modifier = Modifier) {
         }
     }
 
-    PreferenceLayout(label = "Terminal Check", backArrowVisible = true) {
+    PreferenceLayout(label = stringResource(strings.terminal_health), backArrowVisible = true) {
+        if (isAffectedSamsungDevice()) {
+            InfoBlock(
+                icon = { Icon(imageVector = Icons.Outlined.Warning, contentDescription = null) },
+                text = stringResource(strings.samsung_proot_warning),
+                warning = true,
+                onClick = {
+                    context.openUrl("https://github.com/Xed-Editor/Xed-Editor/issues/639")
+                },
+            )
+        }
+
         checks.forEachIndexed { index, check ->
-            PreferenceGroup() {
+            PreferenceGroup {
                 PreferenceTemplate(
                     modifier = Modifier.clickable { checks[index] = check.copy(isExpanded = !check.isExpanded) },
                     title = { Text(text = check.label, style = MaterialTheme.typography.bodyLarge) },
@@ -119,7 +127,7 @@ fun TerminalCheckScreen(modifier: Modifier = Modifier) {
                         Column {
                             if (check.logs.isEmpty()) {
                                 Text(
-                                    text = "No logs available",
+                                    text = stringResource(strings.no_logs),
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
@@ -159,7 +167,7 @@ private fun StatusIcon(status: CheckStatus) {
             CheckStatus.PENDING -> {
                 Icon(
                     imageVector = LucideCircleQuestionMark,
-                    contentDescription = "Pending",
+                    contentDescription = stringResource(strings.pending),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f),
                     modifier = Modifier.size(20.dp),
                 )
@@ -168,7 +176,7 @@ private fun StatusIcon(status: CheckStatus) {
             CheckStatus.LOADING -> {
                 CircularProgressIndicator(
                     modifier = Modifier.size(16.dp),
-                    strokeWidth = 2.dp,
+                    strokeWidth = 4.dp,
                     color = MaterialTheme.colorScheme.primary,
                 )
             }
@@ -176,8 +184,8 @@ private fun StatusIcon(status: CheckStatus) {
             CheckStatus.SUCCESS -> {
                 Icon(
                     imageVector = Icons.Default.CheckCircle,
-                    contentDescription = "Success",
-                    tint = Color(0xFF4CAF50),
+                    contentDescription = stringResource(strings.success),
+                    tint = MaterialTheme.colorScheme.greenStatus,
                     modifier = Modifier.size(20.dp),
                 )
             }
@@ -185,7 +193,7 @@ private fun StatusIcon(status: CheckStatus) {
             CheckStatus.FAILED -> {
                 Icon(
                     imageVector = Icons.Default.Close,
-                    contentDescription = "Failed",
+                    contentDescription = stringResource(strings.failed),
                     tint = MaterialTheme.colorScheme.error,
                     modifier = Modifier.size(20.dp),
                 )

--- a/core/main/src/main/java/com/rk/settings/terminal/terminalChecks.kt
+++ b/core/main/src/main/java/com/rk/settings/terminal/terminalChecks.kt
@@ -1,22 +1,47 @@
 package com.rk.settings.terminal
 
+import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import com.rk.exec.*
-import com.rk.file.*
+import androidx.compose.ui.res.stringResource
+import com.rk.exec.isTerminalInstalled
+import com.rk.exec.readStderr
+import com.rk.exec.ubuntuProcess
+import com.rk.file.child
+import com.rk.file.sandboxDir
+import com.rk.file.sandboxHomeDir
+import com.rk.resources.strings
 import com.rk.utils.application
 import com.rk.utils.getTempDir
 import java.io.File
 
-// these checks are intended for trouble shooting terminal issues
+fun isAffectedSamsungDevice(): Boolean {
+    val model = Build.MODEL.uppercase()
+
+    return model.startsWith("SM-S911") || // S23
+        model.startsWith("SM-S936") || // S25+
+        model.startsWith("SM-F96") || // Fold7
+        model.startsWith("SM-A56") || // A56
+        model.startsWith("SM-A17") || // A17
+        model.startsWith("SM-A16") // A16
+}
+
+/** These checks are intended for troubleshooting terminal issues */
 @Composable
 inline fun terminalChecks(): SnapshotStateList<Check> {
+    val checkProot = stringResource(strings.check_proot)
+    val checkSystemShell = stringResource(strings.check_system_shell)
+    val checkStoragePermissions = stringResource(strings.check_storage_permissions)
+    val checkUbuntu = stringResource(strings.check_ubuntu)
+    val checkNetworkAccess = stringResource(strings.check_network_access)
+    val checkAbnormalities = stringResource(strings.check_abnormalities)
+
     return remember {
-        mutableStateListOf<Check>(
+        mutableStateListOf(
             Check(
-                label = "Check proot",
+                label = checkProot,
                 run = { printLog ->
                     val libproot = File(application!!.applicationInfo.nativeLibraryDir, "libproot.so")
                     val prootloader = File(application!!.applicationInfo.nativeLibraryDir, "libloader.so")
@@ -62,7 +87,7 @@ inline fun terminalChecks(): SnapshotStateList<Check> {
                 },
             ),
             Check(
-                label = "Check System shell",
+                label = checkSystemShell,
                 run = { printLog ->
                     val shell = File("/system/bin/sh")
                     printLog("$shell exists: ${shell.exists()}")
@@ -94,7 +119,7 @@ inline fun terminalChecks(): SnapshotStateList<Check> {
                 },
             ),
             Check(
-                label = "Check Storage & Permissions",
+                label = checkStoragePermissions,
                 run = { printLog ->
                     val filesDir = application!!.filesDir
                     val totalSpace = filesDir.totalSpace / (1024 * 1024)
@@ -116,7 +141,7 @@ inline fun terminalChecks(): SnapshotStateList<Check> {
                 },
             ),
             Check(
-                label = "Check Ubuntu",
+                label = checkUbuntu,
                 run = { printLog ->
                     if (!isTerminalInstalled()) {
                         printLog("Ubuntu not installed, skipping")
@@ -160,7 +185,7 @@ inline fun terminalChecks(): SnapshotStateList<Check> {
                 },
             ),
             Check(
-                label = "Check Network Access",
+                label = checkNetworkAccess,
                 run = { printLog ->
                     if (!isTerminalInstalled()) {
                         printLog("Ubuntu not installed, skipping network check.")
@@ -192,7 +217,7 @@ inline fun terminalChecks(): SnapshotStateList<Check> {
                 },
             ),
             Check(
-                label = "Check Abnormalities",
+                label = checkAbnormalities,
                 run = { printLog ->
                     if (!isTerminalInstalled()) {
                         printLog("Ubuntu not installed, skipping")

--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
@@ -55,13 +55,13 @@ import io.github.rosemoe.sora.lang.styling.inlayHint.ColorInlayHint
 import io.github.rosemoe.sora.text.CharPosition
 import io.github.rosemoe.sora.text.TextRange
 import io.github.rosemoe.sora.widget.component.TextActionItem
-import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.lang.ref.WeakReference
 
 @OptIn(DelicateCoroutinesApi::class, ExperimentalLayoutApi::class)
 @Composable
@@ -262,6 +262,12 @@ fun EditorTab.applyHighlightingAndConnectLSP() {
         val servers = builtin + extension + external
         if (servers.isEmpty()) return@launch
 
+        // Language servers fail with content URIs
+        if (file !is FileWrapper) {
+            logWarn("File ${file.getName()} is not a file wrapper. Skipping language server connection.")
+            return@launch
+        }
+
         // Create another language, as created identifiers cannot be modified retroactively
         val wrapperLanguage =
             editorState.textmateScope
@@ -347,7 +353,7 @@ private suspend fun EditorTab.findActiveLspServers(
             return@forEach
         }
 
-        if (InbuiltFeatures.terminal.state.value && !server.isInstalled(activity) && file is FileWrapper) {
+        if (InbuiltFeatures.terminal.state.value && !server.isInstalled(activity)) {
             logInfo("Server ${server.id} is not installed")
             promptLspInstall(activity, server)
             return@forEach

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -668,5 +668,16 @@
     <string name="formatter_lsp_desc">Use current language server</string>
     <string name="browse_extensions">Browse extensions</string>
     <string name="clipboard_keybindings">Clipboard keybindings</string>
-    <string name="clipboard_keybindings_desc">Enable copy and paste keybindings for hardware keyboards.</string>
+    <string name="clipboard_keybindings_desc">Enable copy and paste keybindings for hardware keyboards</string>
+    <string name="terminal_health">Terminal health</string>
+    <string name="terminal_health_desc">Run diagnostics to identify issues with the terminal environment</string>
+    <string name="no_logs">No logs available</string>
+    <string name="pending">Pending</string>
+    <string name="check_proot">Check PRoot</string>
+    <string name="check_system_shell">Check system shell</string>
+    <string name="check_storage_permissions">Check storage and permissions</string>
+    <string name="check_ubuntu">Check Ubuntu</string>
+    <string name="check_network_access">Check network access</string>
+    <string name="check_abnormalities">Check abnormalities</string>
+    <string name="samsung_proot_warning">Your Samsung device is affected by a known issue that causes the PRoot-based terminal installation to fail.</string>
 </resources>


### PR DESCRIPTION
## Changes
- Add a warning notification for specific Samsung devices known to have PRoot compatibility issues.
- Localize all strings in the Terminal Health screen and terminal settings.
- Remove artificial delay between terminal checks.
- Prevent language server initialization for non-file URIs (content URIs) to avoid crashes.
- Re-add bottom padding to `SnackbarHost` in `MainContentHost`.
- Refactor `terminalChecks` to use localized labels and include a utility to detect affected Samsung models.
- Improve `TerminalCheckScreen` UI by adjusting `CircularProgressIndicator` thickness and using theme-defined status colors.