### PR TITLE
feat: implement terminal degraded mode

### DIFF
--- a/core/main/src/main/assets/terminal/init.sh
+++ b/core/main/src/main/assets/terminal/init.sh
@@ -8,6 +8,10 @@ export PS1="\[\e[1;32m\]\u@\h\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\] \\$ "
 
 source "$LOCAL/bin/utils"
 
+if [ -f "$LOCAL/.sandbox_degraded" ]; then
+    warn "Running in degraded mode. Some features may not work"
+fi
+
 # Set timezone
 CONTAINER_TIMEZONE="UTC"  # or any timezone like "Asia/Kolkata"
 

--- a/core/main/src/main/assets/terminal/setup.sh
+++ b/core/main/src/main/assets/terminal/setup.sh
@@ -60,20 +60,21 @@ $PROOT $ARGS /system/bin/sh -c "$COMMAND"
 ret=$?
 set -e
 
+DEGRADED_MARKER="$LOCAL/.sandbox_degraded"
+
 if [ "$ret" -ne 0 ]; then
     warn "PRoot extraction failed (exit code $ret), falling back to direct extraction..."
 
-    mkdir -p "$LOCAL/sandbox" || exit 1
-
-    (
-        cd "$LOCAL/sandbox" &&
-        tar -xf "$TMP_DIR/sandbox.tar.gz"
-    )
+    set +e
+    /bin/sh -c "$COMMAND"
     ret=$?
+    set -e
 
     if [ "$ret" -ne 0 ]; then
-        error "Extraction failed (exit code $ret)"
-        exit "$ret"
+        warn "Extraction failed (exit code $ret), continuing in degraded mode"
+        warn "Sandbox may be incomplete and some features may not work"
+
+        touch "$DEGRADED_MARKER"
     fi
 fi
 

--- a/core/main/src/main/java/com/rk/activities/settings/SettingsNavHost.kt
+++ b/core/main/src/main/java/com/rk/activities/settings/SettingsNavHost.kt
@@ -57,6 +57,7 @@ fun SettingsNavHost(navController: NavHostController, activity: SettingsActivity
         composable(SettingsRoutes.Keybindings.route) { KeybindingsScreen() }
         composable(SettingsRoutes.TerminalSettings.route) { SettingsTerminalScreen() }
         composable(SettingsRoutes.TerminalExtraKeys.route) { TerminalExtraKeys() }
+        composable(SettingsRoutes.TerminalCheck.route) { TerminalCheckScreen() }
         composable(SettingsRoutes.About.route) { AboutScreen() }
         composable(SettingsRoutes.EditorFontScreen.route) { EditorFontScreen() }
         composable(SettingsRoutes.AppFontScreen.route) { AppFontScreen() }
@@ -120,6 +121,5 @@ fun SettingsNavHost(navController: NavHostController, activity: SettingsActivity
             ExtensionSettings(extension)
         }
         composable(SettingsRoutes.Git.route) { GitSettings() }
-        composable(SettingsRoutes.TerminalCheck.route) { TerminalCheckScreen() }
     }
 }

--- a/core/main/src/main/java/com/rk/activities/settings/SettingsRoutes.kt
+++ b/core/main/src/main/java/com/rk/activities/settings/SettingsRoutes.kt
@@ -13,6 +13,8 @@ sealed class SettingsRoutes(val route: String) {
 
     data object TerminalExtraKeys : SettingsRoutes("terminal_extra_keys")
 
+    data object TerminalCheck : SettingsRoutes("terminal_check")
+
     data object About : SettingsRoutes("about")
 
     data object EditorFontScreen : SettingsRoutes("editor_font_screen")
@@ -60,6 +62,4 @@ sealed class SettingsRoutes(val route: String) {
     data object LspServerLogs : SettingsRoutes("lsp_server_logs")
 
     data object Git : SettingsRoutes("git")
-
-    data object TerminalCheck : SettingsRoutes("terminal_check")
 }

--- a/core/main/src/main/java/com/rk/editor/Formatters.kt
+++ b/core/main/src/main/java/com/rk/editor/Formatters.kt
@@ -5,6 +5,7 @@ import com.rk.file.FileObject
 import com.rk.icons.Icon
 import com.rk.settings.Preference
 import com.rk.settings.Settings
+import com.rk.settings.app.InbuiltFeatures
 import io.github.rosemoe.sora.lang.format.Formatter
 
 abstract class FormatterProvider {
@@ -88,7 +89,7 @@ object Formatters {
     }
 
     fun isLspFormatterEnabled(): Boolean {
-        return Preference.getBoolean("formatter_$LSP_FORMATTER_ID", true)
+        return Preference.getBoolean("formatter_$LSP_FORMATTER_ID", true) && InbuiltFeatures.terminal.state.value
     }
 
     fun setLspFormatterEnabled(enabled: Boolean) {

--- a/core/main/src/main/java/com/rk/settings/editor/FormatterSettings.kt
+++ b/core/main/src/main/java/com/rk/settings/editor/FormatterSettings.kt
@@ -246,7 +246,7 @@ fun DraggableLspFormatter(modifier: Modifier = Modifier) {
         checked = it
     }
 
-    val enabled = false
+    val enabled = false // -> set to InbuiltFeatures.terminal.state.value
 
     Surface(shape = MaterialTheme.shapes.large, tonalElevation = 1.dp, modifier = modifier) {
         PreferenceTemplate(

--- a/core/main/src/main/java/com/rk/settings/terminal/TerminalCheckScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/terminal/TerminalCheckScreen.kt
@@ -94,6 +94,14 @@ fun TerminalCheckScreen() {
             )
         }
 
+        if (isTerminalDegraded(context)) {
+            InfoBlock(
+                icon = { Icon(imageVector = Icons.Outlined.Warning, contentDescription = null) },
+                text = stringResource(strings.terminal_degraded_warning),
+                warning = true,
+            )
+        }
+
         checks.forEachIndexed { index, check ->
             PreferenceGroup {
                 PreferenceTemplate(

--- a/core/main/src/main/java/com/rk/settings/terminal/terminalChecks.kt
+++ b/core/main/src/main/java/com/rk/settings/terminal/terminalChecks.kt
@@ -1,5 +1,6 @@
 package com.rk.settings.terminal
 
+import android.content.Context
 import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
@@ -10,6 +11,7 @@ import com.rk.exec.isTerminalInstalled
 import com.rk.exec.readStderr
 import com.rk.exec.ubuntuProcess
 import com.rk.file.child
+import com.rk.file.localDir
 import com.rk.file.sandboxDir
 import com.rk.file.sandboxHomeDir
 import com.rk.resources.strings
@@ -21,11 +23,16 @@ fun isAffectedSamsungDevice(): Boolean {
     val model = Build.MODEL.uppercase()
 
     return model.startsWith("SM-S911") || // S23
+        model.startsWith("SM-S721") || // S24 FE
         model.startsWith("SM-S936") || // S25+
         model.startsWith("SM-F96") || // Fold7
         model.startsWith("SM-A56") || // A56
         model.startsWith("SM-A17") || // A17
         model.startsWith("SM-A16") // A16
+}
+
+fun isTerminalDegraded(context: Context): Boolean {
+    return localDir(context).child(".sandbox_degraded").exists()
 }
 
 /** These checks are intended for troubleshooting terminal issues */

--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
@@ -268,6 +268,11 @@ fun EditorTab.applyHighlightingAndConnectLSP() {
             return@launch
         }
 
+        if (!InbuiltFeatures.terminal.state.value) {
+            logWarn("Terminal is not enabled. Skipping language server connection.")
+            return@launch
+        }
+
         // Create another language, as created identifiers cannot be modified retroactively
         val wrapperLanguage =
             editorState.textmateScope
@@ -353,7 +358,7 @@ private suspend fun EditorTab.findActiveLspServers(
             return@forEach
         }
 
-        if (InbuiltFeatures.terminal.state.value && !server.isInstalled(activity)) {
+        if (!server.isInstalled(activity)) {
             logInfo("Server ${server.id} is not installed")
             promptLspInstall(activity, server)
             return@forEach

--- a/core/main/src/main/java/com/rk/terminal/TerminalScreen.kt
+++ b/core/main/src/main/java/com/rk/terminal/TerminalScreen.kt
@@ -79,6 +79,7 @@ import com.rk.settings.editor.DEFAULT_TERMINAL_FONT_PATH
 import com.rk.settings.editor.TerminalFontScreen
 import com.rk.settings.terminal.DEFAULT_TERMINAL_EXTRA_KEYS
 import com.rk.settings.terminal.SettingsTerminalScreen
+import com.rk.settings.terminal.TerminalCheckScreen
 import com.rk.settings.terminal.TerminalExtraKeys
 import com.rk.terminal.virtualkeys.VirtualKeysConstants
 import com.rk.terminal.virtualkeys.VirtualKeysInfo
@@ -91,9 +92,9 @@ import com.rk.utils.toast
 import com.termux.terminal.TerminalColors
 import com.termux.terminal.TextStyle
 import com.termux.view.TerminalView
+import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
 import java.util.Properties
-import kotlinx.coroutines.launch
 
 var terminalView = WeakReference<TerminalView?>(null)
 var virtualKeysView = WeakReference<VirtualKeysView?>(null)
@@ -115,6 +116,7 @@ fun TerminalScreen(modifier: Modifier = Modifier, terminalActivity: Terminal) {
         composable(SettingsRoutes.TerminalSettings.route) { SettingsTerminalScreen(navController) }
         composable(SettingsRoutes.TerminalFontScreen.route) { TerminalFontScreen() }
         composable(SettingsRoutes.TerminalExtraKeys.route) { TerminalExtraKeys() }
+        composable(SettingsRoutes.TerminalCheck.route) { TerminalCheckScreen() }
     }
 }
 
@@ -394,7 +396,7 @@ private fun TerminalDrawer(drawerWidth: Dp, terminalActivity: Terminal, navContr
                         Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(strings.add_session))
                     }
 
-                    IconButton(onClick = { navController.navigate("terminal_settings") }) {
+                    IconButton(onClick = { navController.navigate(SettingsRoutes.TerminalSettings.route) }) {
                         Icon(
                             imageVector = Icons.Outlined.Settings,
                             contentDescription = stringResource(strings.settings),
@@ -462,7 +464,7 @@ fun Terminal.changeSession(sessionId: String) {
     terminalView.apply {
         post {
             keepScreenOn = true
-            setFocusableInTouchMode(true)
+            isFocusableInTouchMode = true
             requestFocus()
         }
     }

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -278,7 +278,7 @@
     <string name="support">Support</string>
     <string name="support_desc">Support development</string>
     <string name="translate">Translate</string>
-    <string name="terminal_feature">Terminal and runners</string>
+    <string name="terminal_feature">Terminal, runners and language servers</string>
     <string name="folder_name">Folder name</string>
     <string name="invalid_characters">Invalid characters</string>
     <string name="properties">Properties</string>
@@ -680,4 +680,5 @@
     <string name="check_network_access">Check network access</string>
     <string name="check_abnormalities">Check abnormalities</string>
     <string name="samsung_proot_warning">Your Samsung device is affected by a known issue that causes the PRoot-based terminal installation to fail.</string>
+    <string name="terminal_degraded_warning">The terminal is currently running in a degraded mode due to a known compatibility issue caused by a malfunction in the PRoot environment on certain devices. Some features may be limited or behave differently.</string>
 </resources>


### PR DESCRIPTION
## Changes
- Add support for a "degraded mode" fallback when PRoot extraction fails during terminal setup.
- Display warning notifications in the terminal shell and settings screen when running in degraded mode.
- Update the terminal compatibility check to include additional Samsung device models (S24 FE, S25+, etc.).
- Link Language Server Protocol (LSP) and formatter availability to the terminal feature toggle state.
- Ensure language server installation and connection are skipped if the terminal feature is disabled.
- Refactor terminal-related navigation routes for consistency.