### PR TITLE
feat: enhance extension progress UI and add compose tooling

### DIFF
--- a/core/main/build.gradle.kts
+++ b/core/main/build.gradle.kts
@@ -10,32 +10,47 @@ plugins {
 
 val isGitRepo = generateSequence(rootProject.projectDir) { it.parentFile }.any { File(it, ".git").exists() }
 
-val gitCommitHash: Provider<String> = if (isGitRepo) {
-    providers.exec {
-        commandLine("git", "rev-parse", "--short=8", "HEAD")
-        isIgnoreExitValue = true
-    }.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
-} else {
-    providers.provider { "unknown" }
-}
+val gitCommitHash: Provider<String> =
+    if (isGitRepo) {
+        providers
+            .exec {
+                commandLine("git", "rev-parse", "--short=8", "HEAD")
+                isIgnoreExitValue = true
+            }
+            .standardOutput
+            .asText
+            .map { it.trim().ifEmpty { "unknown" } }
+    } else {
+        providers.provider { "unknown" }
+    }
 
-val fullGitCommitHash: Provider<String> = if (isGitRepo) {
-    providers.exec {
-        commandLine("git", "rev-parse", "HEAD")
-        isIgnoreExitValue = true
-    }.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
-} else {
-    providers.provider { "unknown" }
-}
+val fullGitCommitHash: Provider<String> =
+    if (isGitRepo) {
+        providers
+            .exec {
+                commandLine("git", "rev-parse", "HEAD")
+                isIgnoreExitValue = true
+            }
+            .standardOutput
+            .asText
+            .map { it.trim().ifEmpty { "unknown" } }
+    } else {
+        providers.provider { "unknown" }
+    }
 
-val gitCommitDate: Provider<String> = if (isGitRepo) {
-    providers.exec {
-        commandLine("git", "show", "-s", "--format=%cI", "HEAD")
-        isIgnoreExitValue = true
-    }.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
-} else {
-    providers.provider { "unknown" }
-}
+val gitCommitDate: Provider<String> =
+    if (isGitRepo) {
+        providers
+            .exec {
+                commandLine("git", "show", "-s", "--format=%cI", "HEAD")
+                isIgnoreExitValue = true
+            }
+            .standardOutput
+            .asText
+            .map { it.trim().ifEmpty { "unknown" } }
+    } else {
+        providers.provider { "unknown" }
+    }
 
 android {
     namespace = "com.rk.xededitor"
@@ -109,6 +124,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.core)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.utilcode)
     implementation(libs.coil.compose)
@@ -178,4 +195,3 @@ abstract class GenerateSupportedLocales : DefaultTask() {
         logger.lifecycle("✅ Generated ${outFile.path}")
     }
 }
-

--- a/core/main/src/main/java/com/rk/activities/settings/SettingsNavHost.kt
+++ b/core/main/src/main/java/com/rk/activities/settings/SettingsNavHost.kt
@@ -6,8 +6,8 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
-import com.rk.App
 import com.rk.animations.NavigationAnimationTransitions
+import com.rk.feature.SettingsRegistry
 import com.rk.lsp.LspRegistry
 import com.rk.settings.SettingsScreen
 import com.rk.settings.about.AboutScreen
@@ -30,7 +30,6 @@ import com.rk.settings.lsp.LspServerLogs
 import com.rk.settings.lsp.LspSettings
 import com.rk.settings.support.Support
 import com.rk.settings.theme.ThemeScreen
-import com.rk.feature.SettingsRegistry
 
 @Composable
 fun SettingsNavHost(navController: NavHostController, activity: SettingsActivity) {
@@ -90,9 +89,10 @@ fun SettingsNavHost(navController: NavHostController, activity: SettingsActivity
             LspServerLogs(server, instanceId)
         }
         composable(SettingsRoutes.Themes.route) { ThemeScreen() }
+
         SettingsRegistry.routes.forEach { customRoute ->
-            composable(customRoute.route) {
-                customRoute.content(navController)
+            composable(customRoute.route, arguments = customRoute.arguments) { backStackEntry ->
+                customRoute.content(navController, backStackEntry)
             }
         }
     }

--- a/core/main/src/main/java/com/rk/feature/FeatureRegistry.kt
+++ b/core/main/src/main/java/com/rk/feature/FeatureRegistry.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import com.rk.resources.drawables
 import com.rk.resources.getString
@@ -98,7 +100,8 @@ data class SettingsCategory(
 
 data class SettingsRoute(
     val route: String,
-    val content: @Composable (NavController) -> Unit,
+    val arguments: List<NamedNavArgument> = emptyList(),
+    val content: @Composable (NavController, NavBackStackEntry) -> Unit,
 )
 
 object SettingsRegistry {

--- a/features/extensions/build.gradle.kts
+++ b/features/extensions/build.gradle.kts
@@ -30,15 +30,15 @@ dependencies {
     implementation(project(":core:main"))
     implementation(project(":core:components"))
     implementation(project(":core:resources"))
-    
+
     // Editor modules for Markdown rendering
     implementation(project(":editor"))
     implementation(project(":editor-lsp"))
-    
+
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.semver)
-    
+
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
@@ -46,11 +46,13 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.compose.material.icons.core)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
 
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
     implementation(libs.gson)
-    
+
     // Image loading
     implementation(libs.coil.compose)
     implementation(libs.coil.svg)

--- a/features/extensions/src/main/java/com/rk/ExtensionFeature.kt
+++ b/features/extensions/src/main/java/com/rk/ExtensionFeature.kt
@@ -55,22 +55,20 @@ class ExtensionFeature : Feature {
 
         // Register settings routes
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.Extensions.route) { navController ->
+            SettingsRoute(SettingsRoutes.Extensions.route) { navController, _ ->
                 ExtensionScreen(navController = navController)
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute("${SettingsRoutes.ExtensionDetail.route}/{extensionId}") { navController ->
-                val it = navController.currentBackStackEntry
-                val extensionId = it?.arguments?.getString("extensionId")
+            SettingsRoute("${SettingsRoutes.ExtensionDetail.route}/{extensionId}") { navController, backStackEntry ->
+                val extensionId = backStackEntry.arguments?.getString("extensionId")
                 val extension = extensionId?.let { extensionManager.getExtension(it) }
                 ExtensionDetail(extension, navController)
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute("${SettingsRoutes.ExtensionSettings.route}/{extensionId}") { navController ->
-                val it = navController.currentBackStackEntry
-                val extensionId = it?.arguments?.getString("extensionId")
+            SettingsRoute("${SettingsRoutes.ExtensionSettings.route}/{extensionId}") { _, backStackEntry ->
+                val extensionId = backStackEntry.arguments?.getString("extensionId")
                 val extension = extensionId?.let { extensionManager.getExtension(it) }
                 ExtensionSettings(extension)
             }

--- a/features/extensions/src/main/java/com/rk/extension/model/Extension.kt
+++ b/features/extensions/src/main/java/com/rk/extension/model/Extension.kt
@@ -94,7 +94,7 @@ data class StoreExtension(private val entry: ExtensionEntry) : Extension {
         get() = null
 
     override val size
-        get() = null
+        get() = null // TODO
 
     override val createdAt
         get() = entry.createdAt

--- a/features/extensions/src/main/java/com/rk/settings/extension/ExtensionActionButtons.kt
+++ b/features/extensions/src/main/java/com/rk/settings/extension/ExtensionActionButtons.kt
@@ -1,8 +1,12 @@
 package com.rk.settings.extension
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -18,7 +22,11 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -107,7 +115,7 @@ fun ExtensionActionButtons(
     onUpdateClick: suspend () -> Unit,
     modifier: Modifier = Modifier,
     outdatedWarning: Boolean = false,
-    progress: Float? = null,
+    progress: Float,
 ) {
     when (installState) {
         InstallState.Idle -> {
@@ -150,20 +158,46 @@ private fun InstallButton(
 }
 
 @Composable
-private fun InstallingButton(modifier: Modifier = Modifier, progress: Float? = null) {
-    Button(modifier = modifier, onClick = {}, enabled = false) {
-        CircularProgressIndicator(
-            modifier = Modifier.size(16.dp),
-            strokeWidth = 2.dp,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Spacer(Modifier.width(6.dp))
-        val text = if (progress != null && progress >= 0f) {
-            "${stringResource(strings.installing)} (${(progress * 100).toInt()}%)"
-        } else {
-            stringResource(strings.installing)
+private fun InstallingButton(modifier: Modifier = Modifier, progress: Float) {
+    val shape = ButtonDefaults.shape
+
+    Button(
+        modifier = modifier,
+        onClick = {},
+        enabled = false,
+        contentPadding = PaddingValues(0.dp),
+        shape = shape,
+    ) {
+        val primaryContainer = MaterialTheme.colorScheme.primaryContainer
+        Box(
+            modifier =
+                Modifier.heightIn(min = ButtonDefaults.MinHeight).fillMaxWidth().clip(shape).drawBehind {
+                    drawRect(
+                        color = primaryContainer,
+                        size =
+                            Size(
+                                width = size.width * progress.coerceIn(0f, 1f),
+                                height = size.height,
+                            ),
+                    )
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
+                )
+
+                Spacer(Modifier.width(8.dp))
+
+                Text("${stringResource(strings.installing)} (${(progress * 100).toInt()}%)")
+            }
         }
-        Text(text)
     }
 }
 
@@ -216,19 +250,48 @@ private fun UpdateButton(
 }
 
 @Composable
-private fun UpdatingButton(modifier: Modifier = Modifier, progress: Float? = null) {
-    Button(modifier = modifier, onClick = {}, enabled = false) {
-        CircularProgressIndicator(
-            modifier = Modifier.size(16.dp),
-            strokeWidth = 2.dp,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Spacer(Modifier.width(6.dp))
-        val text = if (progress != null && progress >= 0f) {
-            "${stringResource(strings.updating)} (${(progress * 100).toInt()}%)"
-        } else {
-            stringResource(strings.updating)
+private fun UpdatingButton(
+    modifier: Modifier = Modifier,
+    progress: Float,
+) {
+    val shape = ButtonDefaults.shape
+
+    Button(
+        modifier = modifier,
+        onClick = {},
+        enabled = false,
+        contentPadding = PaddingValues(0.dp),
+        shape = shape,
+    ) {
+        val primaryContainer = MaterialTheme.colorScheme.primaryContainer
+        Box(
+            modifier =
+                Modifier.heightIn(min = ButtonDefaults.MinHeight).fillMaxWidth().clip(shape).drawBehind {
+                    drawRect(
+                        color = primaryContainer,
+                        size =
+                            Size(
+                                width = size.width * progress.coerceIn(0f, 1f),
+                                height = size.height,
+                            ),
+                    )
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
+                )
+
+                Spacer(Modifier.width(8.dp))
+
+                Text("${stringResource(strings.updating)} (${(progress * 100).toInt()}%)")
+            }
         }
-        Text(text)
     }
 }

--- a/features/extensions/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
+++ b/features/extensions/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
@@ -123,11 +123,7 @@ fun ExtensionDetail(extension: Extension?, navController: NavController) {
             val installState =
                 remember(extension, localInstallState, ExtensionRegistry.activeInstalls[extension.id]) {
                     val active = ExtensionRegistry.activeInstalls[extension.id]
-                    if (active != null) {
-                        active
-                    } else {
-                        localInstallState
-                    }
+                    active ?: localInstallState
                 }
 
             Column(modifier = Modifier.padding(horizontal = 16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/features/extensions/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
+++ b/features/extensions/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LeadingIconTab
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.Text
@@ -271,28 +270,12 @@ private fun AboutSection(
     val outdatedClient = minAppVersion != null && xedVersionCode < minAppVersion
     val outdatedExtension = maxAppVersion != null && xedVersionCode > maxAppVersion
 
-    val progress = ExtensionRegistry.downloadProgress[extension.id]
-    if (progress != null) {
-        if (progress >= 0f) {
-            LinearProgressIndicator(
-                progress = { progress },
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.primary,
-            )
-        } else {
-            LinearProgressIndicator(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.primary,
-            )
-        }
-    }
-
     ExtensionActionButtons(
         outdatedWarning = outdatedClient || outdatedExtension,
         modifier = Modifier.fillMaxWidth(),
         installState = installState,
         scope = scope,
-        progress = progress,
+        progress = ExtensionRegistry.downloadProgress[extension.id] ?: 0f,
         onInstallClick = {
             checkExtensionWarningAndRun(activity) {
                 runExtensionInstallAction(extension, updateInstallState, context, activity)

--- a/features/git/src/main/java/com/rk/git/GitFeature.kt
+++ b/features/git/src/main/java/com/rk/git/GitFeature.kt
@@ -61,7 +61,7 @@ class GitFeature : Feature {
 
         // Register Git settings route
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.Git.route) {
+            SettingsRoute(SettingsRoutes.Git.route) { _, _ ->
                 GitSettings()
             }
         )

--- a/features/runner/src/main/java/com/rk/runner/RunnerFeature.kt
+++ b/features/runner/src/main/java/com/rk/runner/RunnerFeature.kt
@@ -34,12 +34,12 @@ class RunnerFeature : Feature {
 
         // Register settings routes
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.Runners.route) { navController ->
+            SettingsRoute(SettingsRoutes.Runners.route) { navController, _ ->
                 RunnerSettings(navController = navController)
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.HtmlRunner.route) {
+            SettingsRoute(SettingsRoutes.HtmlRunner.route) { _, _ ->
                 HtmlRunnerSettings()
             }
         )

--- a/features/terminal/src/main/java/com/rk/TerminalFeature.kt
+++ b/features/terminal/src/main/java/com/rk/TerminalFeature.kt
@@ -101,22 +101,22 @@ class TerminalFeature : Feature {
 
         // Register settings routes
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.TerminalSettings.route) {
+            SettingsRoute(SettingsRoutes.TerminalSettings.route) { _, _ ->
                 SettingsTerminalScreen()
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.TerminalExtraKeys.route) {
+            SettingsRoute(SettingsRoutes.TerminalExtraKeys.route) { _, _ ->
                 TerminalExtraKeys()
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.TerminalCheck.route) {
+            SettingsRoute(SettingsRoutes.TerminalCheck.route) { _, _ ->
                 TerminalCheckScreen()
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.TerminalFontScreen.route) {
+            SettingsRoute(SettingsRoutes.TerminalFontScreen.route) { _, _ ->
                 TerminalFontScreen()
             }
         )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,6 +117,8 @@ androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "composeRuntime" }
 androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "materialIconsCore" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 
 # Networking / IO
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
- Implement in-button progress visualization for extension installation and updates using `drawBehind`.
- Remove standalone `LinearProgressIndicator` from `ExtensionDetail`.
- Add `androidx.compose.ui:ui-tooling` and `ui-tooling-preview` dependencies.
- Reformat Git commit hash generation logic in `core/main/build.gradle.kts`.