### PR TITLE
refactor: add event system and improve extensible registries

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainContentHost.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContentHost.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import com.rk.components.DialogRegistry
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
@@ -31,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.rk.components.DialogRegistry
 import com.rk.components.ResponsiveDrawer
 import com.rk.drawer.DrawerContent
 import com.rk.drawer.DrawerPersistence
@@ -207,7 +207,7 @@ fun MainActivity.MainContentHost(
                 sheetContent = sheetContent,
             )
 
-            DialogRegistry.dialogs.forEach { dialog ->
+            DialogRegistry.getDialogs().forEach { dialog ->
                 dialog()
             }
         }

--- a/core/main/src/main/java/com/rk/activities/main/TabManager.kt
+++ b/core/main/src/main/java/com/rk/activities/main/TabManager.kt
@@ -4,7 +4,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.setValue
+import com.rk.DefaultScope
+import com.rk.events.EditorTabEvent
+import com.rk.events.Events
+import com.rk.events.TabEvent
 import com.rk.tabs.base.Tab
+import com.rk.tabs.editor.EditorTab
+import kotlinx.coroutines.launch
 
 class TabManager {
     private val _tabs = mutableStateListOf<Tab>()
@@ -28,6 +34,13 @@ class TabManager {
         _tabs.add(tab)
         tab.onTabAdded()
 
+        DefaultScope.launch {
+            Events.publish(TabEvent.Opened(tab))
+            if (tab is EditorTab) {
+                Events.publish(EditorTabEvent.Opened(tab))
+            }
+        }
+
         if (switchToTab) {
             setCurrentTab(_tabs.lastIndex)
         }
@@ -36,8 +49,16 @@ class TabManager {
     fun removeTab(index: Int) {
         if (index !in _tabs.indices) return
 
-        _tabs[index].onTabRemoved()
+        val tab = _tabs[index]
+        tab.onTabRemoved()
         _tabs.removeAt(index)
+
+        DefaultScope.launch {
+            Events.publish(TabEvent.Closed(tab))
+            if (tab is EditorTab) {
+                Events.publish(EditorTabEvent.Closed(tab))
+            }
+        }
 
         setCurrentTab(
             when {
@@ -55,6 +76,13 @@ class TabManager {
 
         val item = _tabs.removeAt(from)
         _tabs.add(to, item)
+
+        DefaultScope.launch {
+            Events.publish(TabEvent.Reordered(item, from, to))
+            if (item is EditorTab) {
+                Events.publish(EditorTabEvent.Reordered(item, from, to))
+            }
+        }
 
         setCurrentTab(
             when (currentTabIndex) {
@@ -74,6 +102,14 @@ class TabManager {
         currentTab?.onTabUnselected()
         currentTabIndex = index
         currentTab?.onTabSelected()
+
+        val tab = currentTab ?: return
+        DefaultScope.launch {
+            Events.publish(TabEvent.Selected(tab))
+            if (tab is EditorTab) {
+                Events.publish(EditorTabEvent.Selected(tab))
+            }
+        }
     }
 
     fun removeOtherTabs() {

--- a/core/main/src/main/java/com/rk/activities/settings/SettingsNavHost.kt
+++ b/core/main/src/main/java/com/rk/activities/settings/SettingsNavHost.kt
@@ -7,8 +7,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.rk.animations.NavigationAnimationTransitions
-import com.rk.feature.SettingsRegistry
 import com.rk.lsp.LspRegistry
+import com.rk.settings.SettingsRegistry
 import com.rk.settings.SettingsScreen
 import com.rk.settings.about.AboutScreen
 import com.rk.settings.app.SettingsAppScreen

--- a/core/main/src/main/java/com/rk/commands/editor/RefreshCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/RefreshCommand.kt
@@ -1,14 +1,19 @@
 package com.rk.commands.editor
 
 import android.view.KeyEvent
+import com.rk.DefaultScope
 import com.rk.commands.EditorActionContext
 import com.rk.commands.EditorCommand
 import com.rk.commands.KeyCombination
+import com.rk.events.EditorTabEvent
+import com.rk.events.Events
 import com.rk.icons.Icon
 import com.rk.resources.drawables
 import com.rk.resources.getString
 import com.rk.resources.strings
+import com.rk.tabs.editor.EditorTab
 import com.rk.utils.dialogRes
+import kotlinx.coroutines.launch
 
 class RefreshCommand : EditorCommand() {
     override val id: String = "editor.refresh"
@@ -24,10 +29,20 @@ class RefreshCommand : EditorCommand() {
                 msg = strings.ask_refresh.getString(),
                 okRes = strings.refresh,
                 onCancel = {},
-                onOk = { currentTab.refresh() },
+                onOk = {
+                    currentTab.refresh()
+                    publishEvent(currentTab)
+                },
             )
         } else {
             currentTab.refresh()
+            publishEvent(currentTab)
+        }
+    }
+
+    private fun publishEvent(currentTab: EditorTab) {
+        DefaultScope.launch {
+            Events.publish(EditorTabEvent.Refreshed(currentTab))
         }
     }
 

--- a/core/main/src/main/java/com/rk/components/DialogRegistry.kt
+++ b/core/main/src/main/java/com/rk/components/DialogRegistry.kt
@@ -1,8 +1,23 @@
 package com.rk.components
 
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.Composable
 
+data class DialogProvider(val content: @Composable () -> Unit)
+
 object DialogRegistry {
-    val dialogs = mutableStateListOf<@Composable () -> Unit>()
+
+    private val providers = mutableListOf<DialogProvider>()
+
+    fun register(provider: DialogProvider) {
+        providers += provider
+    }
+
+    fun unregister(provider: DialogProvider) {
+        providers -= provider
+    }
+
+    @Composable
+    fun getDialogs(): List<@Composable () -> Unit> {
+        return providers.map { { it.content() } }
+    }
 }

--- a/core/main/src/main/java/com/rk/components/PropertiesDialog.kt
+++ b/core/main/src/main/java/com/rk/components/PropertiesDialog.kt
@@ -36,20 +36,20 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.rk.file.FileObject
-import com.rk.file.FilePropertiesRegistry
 import com.rk.file.FileOperations
+import com.rk.file.FilePropertiesRegistry
 import com.rk.file.FileWrapper
 import com.rk.resources.fillPlaceholders
 import com.rk.resources.getString
 import com.rk.resources.strings
 import com.rk.utils.formatFileSize
 import com.rk.utils.rememberNumberFormatter
-import java.text.DateFormat
-import java.util.Date
-import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
 
 data class ContentProgress(val totalSize: Long, val totalItems: Long)
 
@@ -165,14 +165,12 @@ fun AdvancedProperties(file: FileObject) {
     InfoRow(stringResource(strings.permissions), getPseudoPermissions(file))
     InfoRow(stringResource(strings.wrapper_type), file.javaClass.simpleName)
 
-    FilePropertiesRegistry.providers.forEach { provider ->
-        provider.getProperties(file).forEach { property ->
-            InfoRow(
-                label = property.label,
-                value = property.value,
-                customTextColor = property.valueColor
-            )
-        }
+    FilePropertiesRegistry.getProperties(file).forEach { property ->
+        InfoRow(
+            label = property.label,
+            value = property.value,
+            customTextColor = property.valueColor,
+        )
     }
 
     if (file is FileWrapper && file.isFile()) {
@@ -180,15 +178,17 @@ fun AdvancedProperties(file: FileObject) {
         InfoRow(label = stringResource(strings.file_type), fileInfo)
 
         LaunchedEffect(file) {
-            val result = withContext(Dispatchers.IO) {
-                runCatching {
-                    val process = ProcessBuilder("file", file.getAbsolutePath()).start()
-                    val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
-                    val error = process.errorStream.bufferedReader().use { it.readText() }.trim()
-                    val code = process.waitFor()
-                    Triple(code, output, error)
-                }.getOrElse { Triple(-1, "", it.message.orEmpty()) }
-            }
+            val result =
+                withContext(Dispatchers.IO) {
+                    runCatching {
+                        val process = ProcessBuilder("file", file.getAbsolutePath()).start()
+                        val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
+                        val error = process.errorStream.bufferedReader().use { it.readText() }.trim()
+                        val code = process.waitFor()
+                        Triple(code, output, error)
+                    }
+                        .getOrElse { Triple(-1, "", it.message.orEmpty()) }
+                }
 
             fileInfo =
                 if (result.first == 0) {

--- a/core/main/src/main/java/com/rk/drawer/AddProjectSheet.kt
+++ b/core/main/src/main/java/com/rk/drawer/AddProjectSheet.kt
@@ -21,14 +21,13 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.rk.activities.main.MainActivity
 import com.rk.components.AddDialogItem
+import com.rk.feature.FeatureRegistry
 import com.rk.file.FileObject
 import com.rk.file.FileWrapper
-import com.rk.file.sandboxHomeDir
 import com.rk.icons.Icon
 import com.rk.resources.drawables
 import com.rk.resources.strings
 import com.rk.settings.Settings
-import com.rk.feature.FeatureRegistry
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -126,14 +125,13 @@ fun AddProjectSheet(
             AddProjectRegistry.options.forEach { option ->
                 AddDialogItem(
                     icon = option.icon,
-                    title = stringResource(option.titleRes),
-                    description = stringResource(option.descriptionRes),
+                    title = option.title,
+                    description = option.description,
                     onClick = {
                         option.onClick { onDismiss() }
                     },
                 )
             }
-
         }
     }
 }

--- a/core/main/src/main/java/com/rk/drawer/DrawerRegistries.kt
+++ b/core/main/src/main/java/com/rk/drawer/DrawerRegistries.kt
@@ -1,23 +1,48 @@
 package com.rk.drawer
 
-import android.app.Activity
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModelStoreOwner
 import com.rk.icons.Icon
 
-
 object ServiceTabRegistry {
-    val providers = mutableStateListOf<(androidx.lifecycle.ViewModelStoreOwner) -> DrawerTab>()
+
+    private val providers = mutableListOf<ServiceTabProvider>()
+
+    fun register(provider: ServiceTabProvider) {
+        providers += provider
+    }
+
+    fun unregister(provider: ServiceTabProvider) {
+        providers -= provider
+    }
+
+    internal fun createAll(owner: ViewModelStoreOwner): List<DrawerTab> {
+        return providers.map { it.create(owner) }
+    }
+}
+
+fun interface ServiceTabProvider {
+    fun create(owner: ViewModelStoreOwner): DrawerTab
 }
 
 data class AddProjectOption(
     val icon: Icon,
-    val titleRes: Int,
-    val descriptionRes: Int,
-    val onClick: (onDismiss: () -> Unit) -> Unit
+    val title: String,
+    val description: String,
+    val onClick: (onDismiss: () -> Unit) -> Unit,
 )
 
 object AddProjectRegistry {
-    val options = mutableStateListOf<AddProjectOption>()
-}
 
+    private val _options = mutableListOf<AddProjectOption>()
+
+    val options
+        get() = _options.toList()
+
+    fun register(option: AddProjectOption) {
+        _options += option
+    }
+
+    fun unregister(option: AddProjectOption) {
+        _options -= option
+    }
+}

--- a/core/main/src/main/java/com/rk/drawer/DrawerViewModel.kt
+++ b/core/main/src/main/java/com/rk/drawer/DrawerViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewModelScope
 import com.rk.file.FileObject
 import com.rk.filetree.FileTreeTab
@@ -36,11 +37,9 @@ class DrawerViewModel : ViewModel() {
     val currentServiceTab: DrawerTab?
         get() = _serviceTabs.getOrNull(currentServiceTabIndex)
 
-    internal fun setupBuiltinServices(owner: androidx.lifecycle.ViewModelStoreOwner) {
+    internal fun setupBuiltinServices(owner: ViewModelStoreOwner) {
         _serviceTabs.clear()
-        ServiceTabRegistry.providers.forEach { provider ->
-            _serviceTabs.add(provider(owner))
-        }
+        _serviceTabs.addAll(ServiceTabRegistry.createAll(owner))
         currentServiceTabIndex = -1
     }
 

--- a/core/main/src/main/java/com/rk/drawer/DrawerViewModel.kt
+++ b/core/main/src/main/java/com/rk/drawer/DrawerViewModel.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewModelScope
+import com.rk.events.DrawerEvent
+import com.rk.events.Events
 import com.rk.file.FileObject
 import com.rk.filetree.FileTreeTab
 import kotlinx.coroutines.Dispatchers
@@ -41,6 +43,7 @@ class DrawerViewModel : ViewModel() {
         _serviceTabs.clear()
         _serviceTabs.addAll(ServiceTabRegistry.createAll(owner))
         currentServiceTabIndex = -1
+        viewModelScope.launch { Events.publish(DrawerEvent.ServicesInitialized(serviceTabs)) }
     }
 
     fun addFileTreeTab(fileObject: FileObject, save: Boolean = false) {
@@ -60,6 +63,8 @@ class DrawerViewModel : ViewModel() {
 
         _drawerTabs.add(tab)
         selectDrawerTab(_drawerTabs.lastIndex)
+
+        viewModelScope.launch { Events.publish(DrawerEvent.TabAdded(tab)) }
 
         if (save) persistAsync()
     }
@@ -83,8 +88,11 @@ class DrawerViewModel : ViewModel() {
 
         val isActive = currentDrawerTabIndex == index
 
-        _drawerTabs[index].onRemoved()
+        val tab = _drawerTabs[index]
+        tab.onRemoved()
         _drawerTabs.removeAt(index)
+
+        viewModelScope.launch { Events.publish(DrawerEvent.TabRemoved(tab)) }
 
         if (_drawerTabs.isEmpty()) {
             unselectDrawerTab()
@@ -115,11 +123,15 @@ class DrawerViewModel : ViewModel() {
 
         currentDrawerTabIndex = index
         currentServiceTabIndex = -1
+
+        viewModelScope.launch { Events.publish(DrawerEvent.TabSelected(currentDrawerTab)) }
     }
 
     fun unselectDrawerTab() {
         currentDrawerTabIndex = -1
         currentServiceTabIndex = -1
+
+        viewModelScope.launch { Events.publish(DrawerEvent.TabSelected(null)) }
     }
 
     fun selectServiceTab(serviceTab: DrawerTab) {
@@ -131,10 +143,14 @@ class DrawerViewModel : ViewModel() {
         if (index !in _serviceTabs.indices) return
 
         currentServiceTabIndex = index
+
+        viewModelScope.launch { Events.publish(DrawerEvent.ServiceTabSelected(currentServiceTab)) }
     }
 
     fun unselectServiceTab() {
         currentServiceTabIndex = -1
+
+        viewModelScope.launch { Events.publish(DrawerEvent.ServiceTabSelected(null)) }
     }
 
     fun forcePushDrawerTabs(drawerTabs: List<DrawerTab>) {

--- a/core/main/src/main/java/com/rk/editor/Editor.kt
+++ b/core/main/src/main/java/com/rk/editor/Editor.kt
@@ -9,6 +9,9 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
+import com.rk.DefaultScope
+import com.rk.events.EditorEvent
+import com.rk.events.Events
 import com.rk.settings.Settings
 import com.rk.settings.editor.DEFAULT_EDITOR_FONT_PATH
 import com.rk.settings.editor.LineEnding
@@ -63,6 +66,7 @@ class Editor : CodeEditor {
         applySettings()
 
         getComponent(EditorAutoCompletion::class.java).setEnabledAnimation(true)
+        scope.launch { Events.publish(EditorEvent.InstanceCreated(this@Editor)) }
     }
 
     fun setThemeColors(isDarkMode: Boolean, selectionColors: TextSelectionColors, colorScheme: ColorScheme) {
@@ -141,6 +145,10 @@ class Editor : CodeEditor {
     override fun release() {
         scope.cancel()
         super.release()
+
+        DefaultScope.launch {
+            Events.publish(EditorEvent.InstanceDestroyed(this@Editor))
+        }
     }
 
     fun applySettings() {
@@ -253,18 +261,18 @@ class Editor : CodeEditor {
 
     fun applyFont() {
         runCatching {
-                val fontPath = Settings.editor_font_path
-                val font =
-                    if (fontPath.isNotEmpty()) {
-                        FontCache.getTypeface(context, fontPath, Settings.is_editor_font_asset)
-                            ?: FontCache.getTypeface(context, DEFAULT_EDITOR_FONT_PATH, true)
-                    } else {
-                        FontCache.getTypeface(context, DEFAULT_EDITOR_FONT_PATH, true)
-                    }
+            val fontPath = Settings.editor_font_path
+            val font =
+                if (fontPath.isNotEmpty()) {
+                    FontCache.getTypeface(context, fontPath, Settings.is_editor_font_asset)
+                        ?: FontCache.getTypeface(context, DEFAULT_EDITOR_FONT_PATH, true)
+                } else {
+                    FontCache.getTypeface(context, DEFAULT_EDITOR_FONT_PATH, true)
+                }
 
-                typefaceText = font ?: Typeface.DEFAULT
-                typefaceLineNumber = font ?: Typeface.DEFAULT
-            }
+            typefaceText = font ?: Typeface.DEFAULT
+            typefaceLineNumber = font ?: Typeface.DEFAULT
+        }
             .onFailure { errorDialog(throwable = it) }
     }
 

--- a/core/main/src/main/java/com/rk/events/Events.kt
+++ b/core/main/src/main/java/com/rk/events/Events.kt
@@ -1,0 +1,154 @@
+package com.rk.events
+
+import com.rk.drawer.DrawerTab
+import com.rk.extension.api.XedExtensionPoint
+import com.rk.file.FileObject
+import com.rk.tabs.base.Tab
+import com.rk.tabs.editor.EditorTab
+import com.rk.theme.ThemeConfig
+import kotlin.reflect.KClass
+
+interface Event
+
+sealed interface DrawerEvent : Event {
+
+    /** Event triggered when a drawer tab has been added. */
+    data class TabAdded(val tab: DrawerTab) : DrawerEvent
+
+    /** Event triggered when a drawer tab has been removed. */
+    data class TabRemoved(val tab: DrawerTab) : DrawerEvent
+
+    /** Event triggered when the active drawer tab changes. */
+    data class TabSelected(val tab: DrawerTab?) : DrawerEvent
+
+    /** Event triggered when the registered service tabs have been initialized. */
+    data class ServicesInitialized(val tabs: List<DrawerTab>) : DrawerEvent
+
+    /** Event triggered when the active service tab changes. */
+    data class ServiceTabSelected(val tab: DrawerTab?) : DrawerEvent
+}
+
+sealed interface FileTreeEvent : Event {
+
+    data class NodeExpanded(
+        val projectRoot: String,
+        val path: String,
+    ) : FileTreeEvent
+
+    data class NodeCollapsed(
+        val projectRoot: String,
+        val path: String,
+    ) : FileTreeEvent
+
+    /**
+     * Event triggered when a specific path or the entire tree has been refreshed. The [TreeSynchronized] event will
+     * also be triggered after this event.
+     *
+     * @see TreeSynchronized
+     */
+    data class Refreshed(val projectRoot: String, val path: String) : FileTreeEvent
+
+    data class Focused(
+        val projectRoot: String,
+        val path: String,
+    ) : FileTreeEvent
+
+    data class SelectionChanged(
+        val projectRoot: String,
+        val selected: List<String>,
+    ) : FileTreeEvent
+
+    /** Event triggered when a file tree drawer tab has been selected. */
+    data class Opened(val projectRoot: FileObject) : FileTreeEvent // TODO: HERE
+
+    /**
+     * Event triggered when the file tree structure has been updated/synchronized with the file system.
+     *
+     * **NOTE:** This event is not triggered on initial file tree load.
+     */
+    data class TreeSynchronized(val parent: FileObject) : FileTreeEvent // TODO: HERE
+}
+
+sealed interface FileEvent : Event {
+
+    data class Created(val path: String) : FileEvent
+
+    data class Deleted(val path: String) : FileEvent
+
+    data class Renamed(
+        val oldPath: String,
+        val newPath: String,
+    ) : FileEvent
+
+    data class Moved(
+        val oldPath: String,
+        val newPath: String,
+    ) : FileEvent
+}
+
+sealed interface TabEvent : Event {
+
+    data class Opened(val tab: Tab) : TabEvent
+
+    data class Closed(val tab: Tab) : TabEvent
+
+    data class Reordered(
+        val tab: Tab,
+        val from: Int,
+        val to: Int,
+    ) : TabEvent
+
+    data class Selected(val tab: Tab) : TabEvent
+}
+
+sealed interface EditorTabEvent : Event {
+
+    data class Saved(val tab: EditorTab) : EditorTabEvent // TODO: HERE
+
+    data class Opened(val tab: EditorTab) : EditorTabEvent
+
+    data class Closed(val tab: EditorTab) : EditorTabEvent
+
+    data class Reordered(
+        val tab: EditorTab,
+        val from: Int,
+        val to: Int,
+    ) : TabEvent
+
+    data class Selected(val tab: EditorTab) : TabEvent
+}
+
+sealed interface ThemeEvent : Event {
+
+    data class Changed(val newTheme: ThemeConfig, val oldTheme: ThemeConfig) : ThemeEvent
+}
+
+interface Subscription {
+    fun unsubscribe()
+}
+
+object Events {
+
+    @PublishedApi internal val listeners = mutableMapOf<KClass<out Event>, MutableList<suspend (Event) -> Unit>>()
+
+    @XedExtensionPoint
+    inline fun <reified T : Event> subscribe(noinline listener: suspend (T) -> Unit): Subscription {
+        val list = listeners.getOrPut(T::class) { mutableListOf() }
+
+        val wrapper: suspend (Event) -> Unit = {
+            listener(it as T)
+        }
+
+        list += wrapper
+
+        return object : Subscription {
+            override fun unsubscribe() {
+                list -= wrapper
+            }
+        }
+    }
+
+    suspend fun publish(event: Event) {
+        listeners.filterKeys { it.isInstance(event) }.values.flatten().forEach { it(event) }
+    }
+}

--- a/core/main/src/main/java/com/rk/events/Events.kt
+++ b/core/main/src/main/java/com/rk/events/Events.kt
@@ -1,11 +1,19 @@
 package com.rk.events
 
 import com.rk.drawer.DrawerTab
+import com.rk.editor.Editor
 import com.rk.extension.api.XedExtensionPoint
 import com.rk.file.FileObject
+import com.rk.icons.pack.IconPack
+import com.rk.lsp.LspConnectionStatus
+import com.rk.lsp.LspLogEntry
+import com.rk.lsp.LspServerInstance
+import com.rk.settings.debugOptions.LogEntry
 import com.rk.tabs.base.Tab
 import com.rk.tabs.editor.EditorTab
-import com.rk.theme.ThemeConfig
+import com.rk.theme.ThemeHolder
+import com.rk.utils.logError
+import java.util.Locale
 import kotlin.reflect.KClass
 
 interface Event
@@ -31,58 +39,59 @@ sealed interface DrawerEvent : Event {
 sealed interface FileTreeEvent : Event {
 
     data class NodeExpanded(
-        val projectRoot: String,
-        val path: String,
+        val projectRoot: FileObject,
+        val path: FileObject,
     ) : FileTreeEvent
 
     data class NodeCollapsed(
-        val projectRoot: String,
-        val path: String,
+        val projectRoot: FileObject,
+        val path: FileObject,
     ) : FileTreeEvent
 
-    /**
-     * Event triggered when a specific path or the entire tree has been refreshed. The [TreeSynchronized] event will
-     * also be triggered after this event.
-     *
-     * @see TreeSynchronized
-     */
-    data class Refreshed(val projectRoot: String, val path: String) : FileTreeEvent
-
     data class Focused(
-        val projectRoot: String,
-        val path: String,
+        val projectRoot: FileObject,
+        val path: FileObject,
     ) : FileTreeEvent
 
     data class SelectionChanged(
-        val projectRoot: String,
-        val selected: List<String>,
+        val projectRoot: FileObject,
+        val selected: List<FileObject>,
     ) : FileTreeEvent
 
     /** Event triggered when a file tree drawer tab has been selected. */
-    data class Opened(val projectRoot: FileObject) : FileTreeEvent // TODO: HERE
+    data class Opened(val projectRoot: FileObject) : FileTreeEvent
+
+    /** Event triggered when a file tree drawer tab has been closed. */
+    data class Closed(val projectRoot: FileObject) : FileTreeEvent
 
     /**
-     * Event triggered when the file tree structure has been updated/synchronized with the file system.
+     * Event triggered when the file tree structure has been updated/synchronized with the file system. This can occur
+     * after files have been moved or the refresh button has been pressed.
      *
      * **NOTE:** This event is not triggered on initial file tree load.
      */
-    data class TreeSynchronized(val parent: FileObject) : FileTreeEvent // TODO: HERE
+    data class TreeSynchronized(val parent: FileObject) : FileTreeEvent
 }
 
 sealed interface FileEvent : Event {
 
-    data class Created(val path: String) : FileEvent
+    data class Created(val file: FileObject) : FileEvent
 
     data class Deleted(val path: String) : FileEvent
 
     data class Renamed(
+        val file: FileObject,
         val oldPath: String,
-        val newPath: String,
     ) : FileEvent
 
     data class Moved(
+        val file: FileObject,
         val oldPath: String,
-        val newPath: String,
+    ) : FileEvent
+
+    data class Copied(
+        val file: FileObject,
+        val sourcePath: String,
     ) : FileEvent
 }
 
@@ -103,7 +112,9 @@ sealed interface TabEvent : Event {
 
 sealed interface EditorTabEvent : Event {
 
-    data class Saved(val tab: EditorTab) : EditorTabEvent // TODO: HERE
+    data class Refreshed(val tab: EditorTab) : EditorTabEvent
+
+    data class Saved(val tab: EditorTab) : EditorTabEvent
 
     data class Opened(val tab: EditorTab) : EditorTabEvent
 
@@ -118,9 +129,34 @@ sealed interface EditorTabEvent : Event {
     data class Selected(val tab: EditorTab) : TabEvent
 }
 
-sealed interface ThemeEvent : Event {
+sealed interface EditorEvent : Event {
+    data class InstanceCreated(val editor: Editor) : EditorEvent
 
-    data class Changed(val newTheme: ThemeConfig, val oldTheme: ThemeConfig) : ThemeEvent
+    data class InstanceDestroyed(val editor: Editor) : EditorEvent
+}
+
+sealed interface LSPEvent : Event {
+
+    data class InstanceCreated(val instance: LspServerInstance) : LSPEvent
+
+    data class StatusChanged(
+        val instance: LspServerInstance,
+        val newStatus: LspConnectionStatus,
+        val oldStatus: LspConnectionStatus,
+    ) : LSPEvent
+
+    data class LogEntryWritten(val instance: LspServerInstance, val logEntry: LspLogEntry) : LSPEvent
+}
+
+sealed interface AppEvent : Event {
+
+    data class ThemeChanged(val newTheme: ThemeHolder, val oldTheme: ThemeHolder?) : AppEvent
+
+    data class IconPackChanged(val newIconPack: IconPack?, val oldIconPack: IconPack?) : AppEvent
+
+    data class LanguageChanged(val newLanguage: Locale, val oldLanguage: Locale?) : AppEvent
+
+    data class LogEntryWritten(val logEntry: LogEntry, val extensionId: String?) : AppEvent
 }
 
 interface Subscription {
@@ -149,6 +185,16 @@ object Events {
     }
 
     suspend fun publish(event: Event) {
-        listeners.filterKeys { it.isInstance(event) }.values.flatten().forEach { it(event) }
+        listeners
+            .filterKeys { it.isInstance(event) }
+            .values
+            .flatten()
+            .forEach { listener ->
+                try {
+                    listener(event)
+                } catch (t: Throwable) {
+                    logError(t, "Listener failed for ${event::class.simpleName}")
+                }
+            }
     }
 }

--- a/core/main/src/main/java/com/rk/events/Events.kt
+++ b/core/main/src/main/java/com/rk/events/Events.kt
@@ -16,8 +16,10 @@ import com.rk.utils.logError
 import java.util.Locale
 import kotlin.reflect.KClass
 
+/** Base interface for all events in the application. */
 interface Event
 
+/** Events related to the drawer and its tabs. */
 sealed interface DrawerEvent : Event {
 
     /** Event triggered when a drawer tab has been added. */
@@ -36,23 +38,28 @@ sealed interface DrawerEvent : Event {
     data class ServiceTabSelected(val tab: DrawerTab?) : DrawerEvent
 }
 
+/** Events related to the file tree and its nodes. */
 sealed interface FileTreeEvent : Event {
 
+    /** Event triggered when a node in the file tree is expanded. */
     data class NodeExpanded(
         val projectRoot: FileObject,
         val path: FileObject,
     ) : FileTreeEvent
 
+    /** Event triggered when a node in the file tree is collapsed. */
     data class NodeCollapsed(
         val projectRoot: FileObject,
         val path: FileObject,
     ) : FileTreeEvent
 
+    /** Event triggered when a node in the file tree becomes focused. */
     data class Focused(
         val projectRoot: FileObject,
         val path: FileObject,
     ) : FileTreeEvent
 
+    /** Event triggered when the selection in the file tree changes. */
     data class SelectionChanged(
         val projectRoot: FileObject,
         val selected: List<FileObject>,
@@ -73,102 +80,150 @@ sealed interface FileTreeEvent : Event {
     data class TreeSynchronized(val parent: FileObject) : FileTreeEvent
 }
 
+/** Events related to file system operations. */
 sealed interface FileEvent : Event {
 
+    /** Event triggered when a new file or directory is created. */
     data class Created(val file: FileObject) : FileEvent
 
+    /** Event triggered when a file or directory is deleted. */
     data class Deleted(val path: String) : FileEvent
 
+    /** Event triggered when a file or directory is renamed. */
     data class Renamed(
         val file: FileObject,
         val oldPath: String,
     ) : FileEvent
 
+    /** Event triggered when a file or directory is moved. */
     data class Moved(
         val file: FileObject,
         val oldPath: String,
     ) : FileEvent
 
+    /** Event triggered when a file or directory is copied. */
     data class Copied(
         val file: FileObject,
         val sourcePath: String,
     ) : FileEvent
 }
 
+/**
+ * Events related to tab lifecycle and interaction.
+ *
+ * @see EditorTabEvent
+ */
 sealed interface TabEvent : Event {
 
+    /** Event triggered when a tab is opened. */
     data class Opened(val tab: Tab) : TabEvent
 
+    /** Event triggered when a tab is closed. */
     data class Closed(val tab: Tab) : TabEvent
 
+    /** Event triggered when tabs are reordered. */
     data class Reordered(
         val tab: Tab,
         val from: Int,
         val to: Int,
     ) : TabEvent
 
+    /** Event triggered when a tab is selected. */
     data class Selected(val tab: Tab) : TabEvent
 }
 
+/**
+ * Events specifically related to editor tabs.
+ *
+ * @see TabEvent
+ */
 sealed interface EditorTabEvent : Event {
 
+    /** Event triggered when an editor tab is refreshed. */
     data class Refreshed(val tab: EditorTab) : EditorTabEvent
 
+    /** Event triggered when the content of an editor tab is saved. */
     data class Saved(val tab: EditorTab) : EditorTabEvent
 
+    /** Event triggered when an editor tab is opened. */
     data class Opened(val tab: EditorTab) : EditorTabEvent
 
+    /** Event triggered when an editor tab is closed. */
     data class Closed(val tab: EditorTab) : EditorTabEvent
 
+    /** Event triggered when editor tabs are reordered. */
     data class Reordered(
         val tab: EditorTab,
         val from: Int,
         val to: Int,
-    ) : TabEvent
+    ) : EditorTabEvent
 
-    data class Selected(val tab: EditorTab) : TabEvent
+    /** Event triggered when an editor tab is selected. */
+    data class Selected(val tab: EditorTab) : EditorTabEvent
 }
 
+/** Events related to the editor instances. */
 sealed interface EditorEvent : Event {
+    /** Event triggered when a new editor instance is created. */
     data class InstanceCreated(val editor: Editor) : EditorEvent
 
+    /** Event triggered when an editor instance is destroyed. */
     data class InstanceDestroyed(val editor: Editor) : EditorEvent
 }
 
+/** Events related to Language Server Protocol (LSP) operations. */
 sealed interface LSPEvent : Event {
 
+    /** Event triggered when an LSP server instance is created. */
     data class InstanceCreated(val instance: LspServerInstance) : LSPEvent
 
+    /** Event triggered when the status of an LSP server instance changes. */
     data class StatusChanged(
         val instance: LspServerInstance,
         val newStatus: LspConnectionStatus,
         val oldStatus: LspConnectionStatus,
     ) : LSPEvent
 
+    /** Event triggered when a log entry is written by an LSP server. */
     data class LogEntryWritten(val instance: LspServerInstance, val logEntry: LspLogEntry) : LSPEvent
 }
 
+/** General application-level events. */
 sealed interface AppEvent : Event {
 
+    /** Event triggered when the application theme changes. */
     data class ThemeChanged(val newTheme: ThemeHolder, val oldTheme: ThemeHolder?) : AppEvent
 
+    /** Event triggered when the application icon pack changes. */
     data class IconPackChanged(val newIconPack: IconPack?, val oldIconPack: IconPack?) : AppEvent
 
+    /** Event triggered when the application language changes. */
     data class LanguageChanged(val newLanguage: Locale, val oldLanguage: Locale?) : AppEvent
 
+    /** Event triggered when a log entry is written to the application debug logs. */
     data class LogEntryWritten(val logEntry: LogEntry, val extensionId: String?) : AppEvent
 }
 
-interface Subscription {
+/** Represents a subscription to an event. */
+interface EventSubscription {
+    /** Unsubscribes from the event. */
     fun unsubscribe()
 }
 
+/** Central event bus for the application. */
 object Events {
 
     @PublishedApi internal val listeners = mutableMapOf<KClass<out Event>, MutableList<suspend (Event) -> Unit>>()
 
+    /**
+     * Subscribes to events of type [T].
+     *
+     * @param T The type of [Event] to subscribe to.
+     * @param listener The listener function to be called when the event is published.
+     * @return An [EventSubscription] object that can be used to unsubscribe.
+     */
     @XedExtensionPoint
-    inline fun <reified T : Event> subscribe(noinline listener: suspend (T) -> Unit): Subscription {
+    inline fun <reified T : Event> subscribe(noinline listener: suspend (T) -> Unit): EventSubscription {
         val list = listeners.getOrPut(T::class) { mutableListOf() }
 
         val wrapper: suspend (Event) -> Unit = {
@@ -177,13 +232,18 @@ object Events {
 
         list += wrapper
 
-        return object : Subscription {
+        return object : EventSubscription {
             override fun unsubscribe() {
                 list -= wrapper
             }
         }
     }
 
+    /**
+     * Triggers an event for all subscribed listeners.
+     *
+     * @param event The event to trigger.
+     */
     suspend fun publish(event: Event) {
         listeners
             .filterKeys { it.isInstance(event) }

--- a/core/main/src/main/java/com/rk/extension/api/XedExtensionPoint.kt
+++ b/core/main/src/main/java/com/rk/extension/api/XedExtensionPoint.kt
@@ -1,7 +1,10 @@
 package com.rk.extension.api
 
 /**
- * Annotation to mark entry points or extension points that are used or exposed to extensions.
+ * Marks a recommended entry point for extensions.
+ *
+ * APIs annotated with this annotation are intended to be called by extensions and are considered stable integration
+ * points. Extension authors should prefer these APIs over internal methods when interacting with the app.
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.CONSTRUCTOR)
 @Retention(AnnotationRetention.SOURCE)

--- a/core/main/src/main/java/com/rk/feature/FeatureRegistry.kt
+++ b/core/main/src/main/java/com/rk/feature/FeatureRegistry.kt
@@ -2,13 +2,9 @@ package com.rk.feature
 
 import android.app.Activity
 import android.app.Application
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.navigation.NamedNavArgument
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavController
 import com.rk.resources.drawables
 import com.rk.resources.getString
 import com.rk.resources.strings
@@ -88,31 +84,5 @@ object FeatureRegistry {
 
     fun isEnabled(key: String): Boolean {
         return toggles.find { it.key == key }?.state?.value ?: false
-    }
-}
-
-data class SettingsCategory(
-    val labelRes: Int,
-    val descriptionRes: Int,
-    val iconRes: Int,
-    val route: String,
-)
-
-data class SettingsRoute(
-    val route: String,
-    val arguments: List<NamedNavArgument> = emptyList(),
-    val content: @Composable (NavController, NavBackStackEntry) -> Unit,
-)
-
-object SettingsRegistry {
-    val categories = mutableStateListOf<SettingsCategory>()
-    val routes = mutableStateListOf<SettingsRoute>()
-
-    fun registerCategory(category: SettingsCategory) {
-        categories.add(category)
-    }
-
-    fun registerRoute(route: SettingsRoute) {
-        routes.add(route)
     }
 }

--- a/core/main/src/main/java/com/rk/file/FileManager.kt
+++ b/core/main/src/main/java/com/rk/file/FileManager.kt
@@ -71,9 +71,9 @@ class FileManager(private val activity: ComponentActivity) {
         launchDirectoryPicker { uri ->
             uri?.let {
                 runCatching {
-                        val takeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-                        activity.contentResolver.takePersistableUriPermission(it, takeFlags)
-                    }
+                    val takeFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    activity.contentResolver.takePersistableUriPermission(it, takeFlags)
+                }
                     .onFailure { e -> e.printStackTrace() }
             }
             callback(uri)

--- a/core/main/src/main/java/com/rk/file/FileOperations.kt
+++ b/core/main/src/main/java/com/rk/file/FileOperations.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import com.rk.activities.main.MainActivity
 import com.rk.components.ContentProgress
+import com.rk.events.Events
+import com.rk.events.FileEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.apache.commons.net.io.Util
@@ -156,13 +158,20 @@ object FileOperations {
 
                 // Perform the copy operation
                 copyRecursive(context, sourceFile, destinationFolder, onProgress)
+                val newFile =
+                    destinationFolder.getChildForName(sourceFile.getName())
+                        ?: throw IllegalStateException("Failed to find pasted file")
 
                 // If it's a cut operation, delete the source
                 if (isCut) {
+                    val oldPath = sourceFile.getAbsolutePath()
                     val deleteSuccess = sourceFile.delete()
                     if (!deleteSuccess) {
                         throw IllegalStateException("Failed to delete source file after moving")
                     }
+                    Events.publish(FileEvent.Moved(newFile, oldPath))
+                } else {
+                    Events.publish(FileEvent.Copied(newFile, sourceFile.getAbsolutePath()))
                 }
             }
         }

--- a/core/main/src/main/java/com/rk/file/FileRegistries.kt
+++ b/core/main/src/main/java/com/rk/file/FileRegistries.kt
@@ -1,47 +1,64 @@
 package com.rk.file
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.graphics.Color
-
-object FileChangeNotifier {
-    val fileChangeListeners = mutableStateListOf<suspend (String) -> Unit>()
-    val projectOpenListeners = mutableStateListOf<suspend (String) -> Unit>()
-
-    suspend fun notifyFileChanged(path: String) {
-        fileChangeListeners.forEach { it(path) }
-    }
-
-    suspend fun notifyProjectOpened(root: String) {
-        projectOpenListeners.forEach { it(root) }
-    }
-}
 
 data class FileDecoration(
     val color: Color? = null,
-    val badge: String? = null
+    val badge: String? = null,
 )
 
-interface FileDecorationProvider {
-    @Composable
-    fun getDecoration(file: FileObject): FileDecoration?
+fun interface FileDecorationProvider {
+    @Composable fun provideDecoration(file: FileObject): FileDecoration?
 }
 
 object FileDecorationRegistry {
-    var provider: FileDecorationProvider? = null
+
+    private val providers = mutableListOf<FileDecorationProvider>()
+
+    fun register(provider: FileDecorationProvider) {
+        providers += provider
+    }
+
+    fun unregister(provider: FileDecorationProvider) {
+        providers -= provider
+    }
+
+    @Composable
+    fun getDecoration(file: FileObject): FileDecoration {
+        val decorations = providers.mapNotNull { it.provideDecoration(file) }
+
+        return FileDecoration(
+            color = decorations.firstNotNullOfOrNull { it.color },
+            badge = decorations.firstNotNullOfOrNull { it.badge },
+        )
+    }
 }
 
 data class FileProperty(
     val label: String,
     val value: String,
-    val valueColor: Color? = null
+    val valueColor: Color? = null,
 )
 
-interface FilePropertiesProvider {
-    @Composable
-    fun getProperties(file: FileObject): List<FileProperty>
+fun interface FilePropertiesProvider {
+    @Composable fun provideProperties(file: FileObject): List<FileProperty>
 }
 
 object FilePropertiesRegistry {
-    val providers = mutableStateListOf<FilePropertiesProvider>()
+
+    private val providers = mutableListOf<FilePropertiesProvider>()
+
+    fun register(provider: FilePropertiesProvider) {
+        providers += provider
+    }
+
+    fun unregister(provider: FilePropertiesProvider) {
+        providers -= provider
+    }
+
+    @Composable
+    fun getProperties(file: FileObject): List<FileProperty> {
+        return providers.flatMap { it.provideProperties(file) }
+    }
 }

--- a/core/main/src/main/java/com/rk/filetree/FileAction.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileAction.kt
@@ -1,7 +1,6 @@
 package com.rk.filetree
 
 import android.content.Context
-import android.content.Intent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Delete
@@ -13,7 +12,6 @@ import com.rk.activities.main.MainActivity
 import com.rk.drawer.DrawerViewModel
 import com.rk.file.FileObject
 import com.rk.file.FileOperations
-import com.rk.file.FileWrapper
 import com.rk.icons.CreateNewFile
 import com.rk.icons.CreateNewFolder
 import com.rk.icons.Icon
@@ -101,7 +99,6 @@ object RefreshAction : MultiFileAction() {
 
     override val type = FileActionType(file = false, folder = true, rootFolder = true)
 }
-
 
 object CreateNewFileAction : FileAction() {
     override val icon = Icon.VectorIcon(XedIcons.CreateNewFile)
@@ -238,17 +235,6 @@ object SaveAsAction : FileAction() {
     }
 
     override val type = FileActionType.All
-}
-
-object AddFileAction : FileAction() {
-    override val icon = Icon.ResourceIcon(drawables.arrow_downward)
-    override val title = strings.add_file.getString()
-
-    override fun action(context: FileActionContext) {
-        FileOperations.addFile(context.file)
-    }
-
-    override val type = FileActionType(file = false, folder = true, rootFolder = true)
 }
 
 object OpenAsProjectAction : FileAction() {

--- a/core/main/src/main/java/com/rk/filetree/FileActionDialogs.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileActionDialogs.kt
@@ -14,6 +14,8 @@ import com.rk.activities.main.drawerStateRef
 import com.rk.components.PropertiesDialog
 import com.rk.components.SingleInputDialog
 import com.rk.drawer.DrawerViewModel
+import com.rk.events.Events
+import com.rk.events.FileEvent
 import com.rk.file.FileObject
 import com.rk.file.FileOperations
 import com.rk.resources.fillPlaceholders
@@ -66,6 +68,8 @@ fun FileActionDialogs(
                         return@launch
                     }
 
+                    Events.publish(FileEvent.Renamed(file, oldPath))
+
                     val parentFile = file.getParentFile() ?: return@launch
                     viewModel.updateCache(parentFile)
 
@@ -87,10 +91,12 @@ fun FileActionDialogs(
             onConfirm = {
                 scope.launch {
                     for (file in files) {
+                        val path = file.getAbsolutePath()
                         viewModel.withFileOperation {
                             FileOperations.deleteFile(file)
                                 .onFailure { toast(it.message ?: strings.delete_failed.getString()) }
                                 .onSuccess {
+                                    Events.publish(FileEvent.Deleted(path))
                                     val parentFile = file.getParentFile()
                                     if (parentFile != null) {
                                         viewModel.updateCache(file.getParentFile()!!)
@@ -162,6 +168,8 @@ fun FileActionDialogs(
                                     } else {
                                         toast(strings.folder_creation_failed)
                                     }
+                                } else {
+                                    Events.publish(FileEvent.Created(newChild))
                                 }
 
                                 if (viewModel.isCreateFile && newChild != null && Settings.auto_open_new_files) {

--- a/core/main/src/main/java/com/rk/filetree/FileTree.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTree.kt
@@ -52,8 +52,8 @@ import com.rk.icons.XedIcon
 import com.rk.resources.getString
 import com.rk.resources.strings
 import com.rk.settings.Settings
-import kotlin.math.min
 import kotlinx.coroutines.launch
+import kotlin.math.min
 
 enum class SortMode(val stringRes: Int) {
     SORT_BY_NAME(strings.sort_by_name),

--- a/core/main/src/main/java/com/rk/filetree/FileTreeTab.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeTab.kt
@@ -41,11 +41,12 @@ import com.rk.activities.main.MainActivity
 import com.rk.activities.main.drawerStateRef
 import com.rk.activities.main.fileTreeViewModel
 import com.rk.activities.main.searchViewModel
-import com.rk.file.FileChangeNotifier
 import com.rk.components.AddDialogItem
 import com.rk.components.codeSearchDialog
 import com.rk.components.fileSearchDialog
 import com.rk.drawer.DrawerTab
+import com.rk.events.Events
+import com.rk.events.FileTreeEvent
 import com.rk.file.FileObject
 import com.rk.file.FileWrapper
 import com.rk.file.UriWrapper
@@ -80,7 +81,7 @@ class FileTreeTab(val root: FileObject) : DrawerTab() {
         val drawerViewModel = MainActivity.instance?.drawerViewModel
 
         LaunchedEffect(root) {
-            FileChangeNotifier.notifyProjectOpened(root.getAbsolutePath())
+            Events.publish(FileTreeEvent.Opened(root))
         }
 
         LaunchedEffect(enableIndexing) {

--- a/core/main/src/main/java/com/rk/filetree/FileTreeTab.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeTab.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.rk.DefaultScope
 import com.rk.activities.main.MainActivity
 import com.rk.activities.main.drawerStateRef
 import com.rk.activities.main.fileTreeViewModel
@@ -273,5 +274,6 @@ class FileTreeTab(val root: FileObject) : DrawerTab() {
     override fun onRemoved() {
         Preference.removeKey(indexingPreferenceKey)
         searchViewModel.get()?.deleteIndex(MainActivity.instance!!, root)
+        DefaultScope.launch { Events.publish(FileTreeEvent.Closed(root)) }
     }
 }

--- a/core/main/src/main/java/com/rk/filetree/FileTreeViewModel.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeViewModel.kt
@@ -156,6 +156,9 @@ class FileTreeViewModel : ViewModel() {
         } else {
             selectFile(projectRoot, fileObject)
         }
+        viewModelScope.launch {
+            Events.publish(FileTreeEvent.SelectionChanged(projectRoot, getSelectedFiles(projectRoot)))
+        }
     }
 
     fun selectFile(projectRoot: FileObject, fileObject: FileObject) {
@@ -171,6 +174,9 @@ class FileTreeViewModel : ViewModel() {
 
     fun unselectAllFiles(projectRoot: FileObject) {
         selectedFiles.remove(projectRoot)
+        viewModelScope.launch {
+            Events.publish(FileTreeEvent.SelectionChanged(projectRoot, emptyList()))
+        }
     }
 
     fun isFileSelected(projectRoot: FileObject, fileObject: FileObject): Boolean {
@@ -259,6 +265,7 @@ class FileTreeViewModel : ViewModel() {
         if (expandedNodes[projectRoot]?.isEmpty() == true) {
             expandedNodes.remove(projectRoot)
         }
+        viewModelScope.launch { Events.publish(FileTreeEvent.NodeCollapsed(projectRoot, fileObject)) }
     }
 
     private fun expandFile(projectRoot: FileObject, fileObject: FileObject) {
@@ -268,6 +275,7 @@ class FileTreeViewModel : ViewModel() {
         if (!fileListCache.containsKey(fileObject)) {
             _loadingStates[fileObject] = true
         }
+        viewModelScope.launch { Events.publish(FileTreeEvent.NodeExpanded(projectRoot, fileObject)) }
     }
 
     fun getCollapsedName(node: FileTreeNode): String {
@@ -333,6 +341,7 @@ class FileTreeViewModel : ViewModel() {
     suspend fun goToFolder(projectFile: FileObject, fileObject: FileObject) {
         focusedFile[projectFile] = fileObject
         viewModelScope.launch {
+            Events.publish(FileTreeEvent.Focused(projectFile, fileObject))
             delay(1000.milliseconds)
             focusedFile.remove(projectFile)
         }

--- a/core/main/src/main/java/com/rk/filetree/FileTreeViewModel.kt
+++ b/core/main/src/main/java/com/rk/filetree/FileTreeViewModel.kt
@@ -10,15 +10,16 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.rk.activities.main.searchViewModel
+import com.rk.events.Events
+import com.rk.events.FileTreeEvent
 import com.rk.file.FileObject
-import com.rk.file.FileChangeNotifier
 import com.rk.search.GlobExcluder
 import com.rk.settings.Settings
-import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.milliseconds
 
 fun FileObject.toFileTreeNode(): FileTreeNode {
     return FileTreeNode(file = this, isFile = isFile(), isDirectory = isDirectory(), name = getAppropriateName())
@@ -294,33 +295,35 @@ class FileTreeViewModel : ViewModel() {
         return currentNode
     }
 
-    fun updateCache(file: FileObject) {
-        searchViewModel.get()?.syncIndex(file)
-        viewModelScope.launch { FileChangeNotifier.notifyFileChanged(file.getAbsolutePath()) }
-        if (file.isDirectory().not()) {
-            return
+    fun updateCache(parent: FileObject) {
+        if (!parent.isDirectory()) return
+        searchViewModel.get()?.syncIndex(parent)
+
+        viewModelScope.launch {
+            Events.publish(FileTreeEvent.TreeSynchronized(parent))
         }
-        collapsedNameCache.remove(file)
-        _loadingStates[file] = true // Mark as loading
+
+        collapsedNameCache.remove(parent)
+        _loadingStates[parent] = true // Mark as loading
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 // Safely access file listing
                 val fileList =
                     try {
-                        file.listFiles()
-                    } catch (e: Exception) {
-                        _loadingStates[file] = false
+                        parent.listFiles()
+                    } catch (_: Exception) {
+                        _loadingStates[parent] = false
                         return@launch
                     }
 
                 // Process files
                 val sortedFiles = sortAndFilterFiles(fileList)
 
-                fileListCache[file] = sortedFiles
+                fileListCache[parent] = sortedFiles
 
-                viewModelScope.launch { clearLoadingState(file) }
+                viewModelScope.launch { clearLoadingState(parent) }
             } catch (_: Exception) {
-                _loadingStates[file] = false
+                _loadingStates[parent] = false
             }
         }
     }

--- a/core/main/src/main/java/com/rk/icons/pack/IconPackManager.kt
+++ b/core/main/src/main/java/com/rk/icons/pack/IconPackManager.kt
@@ -14,20 +14,23 @@ import com.rk.resources.strings
 import com.rk.settings.Settings
 import com.rk.utils.application
 import com.rk.utils.dialogRes
-import java.io.File
-import java.util.zip.ZipFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.json.Json
+import java.io.File
+import java.util.zip.ZipFile
 
 val currentIconPack = mutableStateOf<IconPack?>(null)
 val iconPackDir = localDir().child("icon_pack").also { it.createDirIfNot() }
 
 class IconPackManager(private val context: Application) {
     val iconPacks = mutableStateMapOf<IconPackId, IconPack>()
-    val json = Json { ignoreUnknownKeys = true }
+    val json = Json {
+        ignoreUnknownKeys = true
+        allowTrailingComma = true
+    }
 
     suspend fun installIconPack(zipFile: File) =
         withContext(Dispatchers.IO) {
@@ -100,27 +103,28 @@ class IconPackManager(private val context: Application) {
 
             return null
         }
-        val iconPackManifest =
-            runCatching { json.decodeFromString<IconPackManifest>(iconPackJson.readText()) }
-                .getOrElse { e ->
-                    if (e is MissingFieldException) {
-                        val fields = e.missingFields.joinToString("\n") { "• $it" }
-                        dialogRes(
-                            SettingsActivity.instance,
-                            strings.icon_pack_install_failed.getString(),
-                            strings.manifest_missing_fields.getFilledString(fields),
-                            cancelable = false,
-                        )
-                        return null
-                    }
+        val iconPackManifest = runCatching {
+            json.decodeFromString<IconPackManifest>(iconPackJson.readText())
+        }
+            .getOrElse { e ->
+                if (e is MissingFieldException) {
+                    val fields = e.missingFields.joinToString("\n") { "• $it" }
                     dialogRes(
                         SettingsActivity.instance,
                         strings.icon_pack_install_failed.getString(),
-                        e.localizedMessage ?: strings.unknown_err.getString(),
+                        strings.manifest_missing_fields.getFilledString(fields),
                         cancelable = false,
                     )
                     return null
                 }
+                dialogRes(
+                    SettingsActivity.instance,
+                    strings.icon_pack_install_failed.getString(),
+                    e.localizedMessage ?: strings.unknown_err.getString(),
+                    cancelable = false,
+                )
+                return null
+            }
 
         return iconPackManifest
     }

--- a/core/main/src/main/java/com/rk/lsp/LspConnector.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspConnector.kt
@@ -3,11 +3,14 @@ package com.rk.lsp
 import android.content.Intent
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarResult
+import com.rk.DefaultScope
 import com.rk.activities.main.MainActivity
 import com.rk.activities.main.snackbarHostStateRef
 import com.rk.activities.settings.SettingsActivity
 import com.rk.activities.settings.SettingsRoutes
 import com.rk.editor.Editor
+import com.rk.events.Events
+import com.rk.events.LSPEvent
 import com.rk.file.FileObject
 import com.rk.resources.getString
 import com.rk.resources.strings
@@ -30,9 +33,6 @@ import io.github.rosemoe.sora.lsp.events.AsyncEventListener
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
 import io.github.rosemoe.sora.widget.CodeEditor
-import java.net.URI
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -60,6 +60,10 @@ import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.jsonrpc.messages.Either3
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * A utility object to temporarily prevent specific LSP servers from being used for a project.
@@ -183,14 +187,13 @@ class LspConnector(
             } finally {
                 editorTab.editorState.isConnectingLsp = false
 
-                val failedConnections =
-                    servers.filter { server ->
-                        server.instances.any { instance ->
-                            val isCrashed = instance.status == LspConnectionStatus.CRASHED
-                            val isTimeout = instance.status == LspConnectionStatus.TIMEOUT
-                            instance.lspProject == project && (isCrashed || isTimeout)
-                        }
+                val failedConnections = servers.filter { server ->
+                    server.instances.any { instance ->
+                        val isCrashed = instance.status == LspConnectionStatus.CRASHED
+                        val isTimeout = instance.status == LspConnectionStatus.TIMEOUT
+                        instance.lspProject == project && (isCrashed || isTimeout)
                     }
+                }
 
                 if (failedConnections.isNotEmpty()) {
                     launch {
@@ -217,8 +220,13 @@ class LspConnector(
         fileExt: String,
         lspProject: LspProject,
     ): CustomLanguageServerDefinition {
+
         val instance =
-            LspServerInstance(server = this@createServerDefinition, lspProject = lspProject, projectRoot = projectFile)
+            LspServerInstance(
+                    server = this@createServerDefinition,
+                    lspProject = lspProject,
+                    projectRoot = projectFile,
+                )
                 .also { addInstance(it) }
 
         return object :
@@ -342,6 +350,7 @@ class LspConnector(
                                 return
                             }
 
+                            val oldConnectionStatus = instance.status
                             instance.status =
                                 when (newStatus) {
                                     ServerStatus.IDLE -> LspConnectionStatus.NOT_RUNNING
@@ -365,6 +374,10 @@ class LspConnector(
                                         }
                                     }
                                 }
+
+                            DefaultScope.launch {
+                                Events.publish(LSPEvent.StatusChanged(instance, instance.status, oldConnectionStatus))
+                            }
                         }
                     }
         }
@@ -376,7 +389,12 @@ class LspConnector(
 
     fun getCapabilities(): ServerCapabilities? = runBlocking {
         if (!isConnected()) return@runBlocking null
-        withTimeoutOrNull(100) { runCatching { lspEditor?.requestManager?.capabilities }.getOrNull() }
+        withTimeoutOrNull(100.milliseconds) {
+            runCatching {
+                lspEditor?.requestManager?.capabilities
+            }
+                .getOrNull()
+        }
     }
 
     fun isGoToDefinitionSupported(): Boolean {
@@ -489,9 +507,9 @@ class LspConnector(
 
     suspend fun disconnect() {
         runCatching {
-                lspEditor?.disposeAsync()
-                lspEditor = null
-            }
+            lspEditor?.disposeAsync()
+            lspEditor = null
+        }
             .onFailure { it.printStackTrace() }
     }
 }

--- a/core/main/src/main/java/com/rk/lsp/LspPersistence.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspPersistence.kt
@@ -6,9 +6,9 @@ import com.rk.lsp.servers.ExternalProcessServer
 import com.rk.lsp.servers.ExternalSocketServer
 import com.rk.settings.Preference
 import com.rk.utils.application
-import kotlin.random.Random
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlin.random.Random
 
 @Serializable
 data class SavedLspConfig(
@@ -32,7 +32,10 @@ object LspPersistence {
         }
     }
 
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = Json {
+        ignoreUnknownKeys = true
+        allowTrailingComma = true
+    }
     private val saveFile = application!!.filesDir.child("externalLSPServer").createFileIfNot()
 
     fun saveServers() {
@@ -65,11 +68,12 @@ object LspPersistence {
         val jsonStr = saveFile.readText()
         if (jsonStr.isEmpty()) return
 
-        val configs =
-            runCatching { json.decodeFromString<List<SavedLspConfig>>(jsonStr) }
-                .getOrElse {
-                    return
-                }
+        val configs = runCatching {
+            json.decodeFromString<List<SavedLspConfig>>(jsonStr)
+        }
+            .getOrElse {
+                return
+            }
 
         var shouldUpdateServers = false
         configs.forEach { config ->

--- a/core/main/src/main/java/com/rk/lsp/LspServer.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspServer.kt
@@ -6,14 +6,18 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.graphics.Color
+import com.rk.DefaultScope
 import com.rk.TerminalLauncher
 import com.rk.activities.main.MainActivity
+import com.rk.events.Events
+import com.rk.events.LSPEvent
 import com.rk.file.FileObject
 import com.rk.icons.Icon
 import com.rk.tabs.editor.EditorTab
 import com.rk.tabs.editor.applyHighlightingAndConnectLSP
 import com.rk.theme.greenStatus
 import com.rk.theme.yellowStatus
+import kotlinx.coroutines.launch
 import org.eclipse.lsp4j.ServerCapabilities
 import java.io.File
 import java.net.URI
@@ -84,6 +88,9 @@ abstract class LspServer {
 
     fun addInstance(instance: LspServerInstance) {
         _instances.add(instance)
+        DefaultScope.launch {
+            Events.publish(LSPEvent.InstanceCreated(instance))
+        }
     }
 
     fun removeInstance(instance: LspServerInstance) {

--- a/core/main/src/main/java/com/rk/lsp/LspServerInstance.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspServerInstance.kt
@@ -16,7 +16,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.rk.DefaultScope
 import com.rk.activities.main.MainActivity
+import com.rk.events.Events
+import com.rk.events.LSPEvent
 import com.rk.file.FileObject
 import com.rk.icons.Error
 import com.rk.icons.XedIcons
@@ -29,6 +32,7 @@ import com.rk.theme.yellowStatus
 import io.github.rosemoe.sora.lsp.client.languageserver.wrapper.LanguageServerWrapper
 import io.github.rosemoe.sora.lsp.editor.LspProject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.eclipse.lsp4j.MessageParams
 import org.eclipse.lsp4j.MessageType
@@ -60,7 +64,7 @@ data class LspLogEntry(
 data class LspServerInstance(
     val server: LspServer,
     internal val lspProject: LspProject,
-    val projectRoot: FileObject
+    val projectRoot: FileObject,
 ) {
     val id = "${server.id}_${projectRoot.getAbsolutePath().hashCode()}"
 
@@ -74,19 +78,25 @@ data class LspServerInstance(
             LspLogEntry(
                 type = messageParams.type,
                 message = messageParams.message,
-                source = MessageSource.LSP
+                source = MessageSource.LSP,
             )
         )
     }
 
     fun addLog(lspLogEntry: LspLogEntry) {
-        if (lspLogEntry.type == MessageType.Error) hasError = true
+        if (lspLogEntry.type == MessageType.Error) {
+            hasError = true
+        }
 
         logs.add(lspLogEntry)
 
         if (logs.size > Settings.lsp_log_limit) {
             val removeCount = logs.size - Settings.lsp_log_limit
             logs.removeRange(0, removeCount)
+        }
+
+        DefaultScope.launch {
+            Events.publish(LSPEvent.LogEntryWritten(this@LspServerInstance, lspLogEntry))
         }
     }
 
@@ -102,7 +112,7 @@ data class LspServerInstance(
                     LspLogEntry(
                         MessageSource.Client,
                         MessageType.Error,
-                        "Language server instance not found..."
+                        "Language server instance not found...",
                     )
                 )
                 return null
@@ -116,7 +126,7 @@ data class LspServerInstance(
                 LspLogEntry(
                     MessageSource.Client,
                     MessageType.Info,
-                    "User stopped language server instance..."
+                    "User stopped language server instance...",
                 )
             )
             val wrapper = getWrapper() ?: return@withContext
@@ -136,7 +146,7 @@ data class LspServerInstance(
                 LspLogEntry(
                     MessageSource.Client,
                     MessageType.Info,
-                    "User restarted language server instance..."
+                    "User restarted language server instance...",
                 )
             )
             val wrapper = getWrapper() ?: return@withContext
@@ -159,7 +169,7 @@ data class LspServerInstance(
                 LspLogEntry(
                     MessageSource.Client,
                     MessageType.Info,
-                    "User started language server instance..."
+                    "User started language server instance...",
                 )
             )
             val wrapper = getWrapper() ?: return@withContext emptyList()
@@ -183,8 +193,7 @@ data class LspServerInstance(
         filteredEditors.forEach { editor ->
             val matchingEditorTab =
                 MainActivity.instance!!.viewModel.run {
-                    tabs.filterIsInstance<EditorTab>()
-                        .find { it.editorState.editor.get() == editor.editor }
+                    tabs.filterIsInstance<EditorTab>().find { it.editorState.editor.get() == editor.editor }
                 } ?: return@forEach
             matchingEditorTab.applyHighlightingAndConnectLSP()
             reconnectedEditors.add(matchingEditorTab)
@@ -197,7 +206,7 @@ data class LspServerInstance(
             server.supportedExtensions.forEach {
                 lspProject.removeServerDefinition(
                     it,
-                    server.serverName
+                    server.serverName,
                 )
             }
             lspProject.getEditors().forEach { wrapper.disconnect(it) }
@@ -211,8 +220,8 @@ fun LspServerInstance.getStatusColor(): Color? {
         MaterialTheme.colorScheme.error
     } else if (
         status == LspConnectionStatus.STARTING ||
-        status == LspConnectionStatus.RESTARTING ||
-        status == LspConnectionStatus.STOPPING
+            status == LspConnectionStatus.RESTARTING ||
+            status == LspConnectionStatus.STOPPING
     ) {
         MaterialTheme.colorScheme.yellowStatus
     } else if (status == LspConnectionStatus.RUNNING) {
@@ -232,7 +241,7 @@ fun LspServerInstance.getStatusText(): String {
         status == LspConnectionStatus.STOPPING -> stringResource(strings.status_stopping)
         DefinitionPrevention.isServerPrevented(
             lspProject,
-            server
+            server,
         ) -> stringResource(strings.status_not_running_forced)
 
         else -> stringResource(strings.status_not_running)
@@ -252,8 +261,8 @@ fun LspServerInstance.StatusIcon() {
         }
 
         status == LspConnectionStatus.STARTING ||
-                status == LspConnectionStatus.RESTARTING ||
-                status == LspConnectionStatus.STOPPING -> {
+            status == LspConnectionStatus.RESTARTING ||
+            status == LspConnectionStatus.STOPPING -> {
             CircularProgressIndicator(modifier = Modifier.size(24.dp))
         }
 

--- a/core/main/src/main/java/com/rk/settings/SettingsRegistry.kt
+++ b/core/main/src/main/java/com/rk/settings/SettingsRegistry.kt
@@ -1,0 +1,39 @@
+package com.rk.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+
+data class SettingsCategory(
+    val labelRes: Int,
+    val descriptionRes: Int,
+    val iconRes: Int,
+    val route: String,
+)
+
+data class SettingsRoute(
+    val route: String,
+    val arguments: List<NamedNavArgument> = emptyList(),
+    val content: @Composable (NavController, NavBackStackEntry) -> Unit,
+)
+
+object SettingsRegistry {
+
+    private val _categories = mutableStateListOf<SettingsCategory>()
+    val categories: List<SettingsCategory>
+        get() = _categories.toList()
+
+    private val _routes = mutableStateListOf<SettingsRoute>()
+    val routes: List<SettingsRoute>
+        get() = _routes.toList()
+
+    fun registerCategory(category: SettingsCategory) {
+        _categories.add(category)
+    }
+
+    fun registerRoute(route: SettingsRoute) {
+        _routes.add(route)
+    }
+}

--- a/core/main/src/main/java/com/rk/settings/SettingsScreen.kt
+++ b/core/main/src/main/java/com/rk/settings/SettingsScreen.kt
@@ -31,12 +31,11 @@ import com.rk.activities.settings.SettingsRoutes
 import com.rk.components.compose.preferences.base.PreferenceLayout
 import com.rk.components.compose.preferences.base.PreferenceTemplate
 import com.rk.components.compose.preferences.category.PreferenceCategory
+import com.rk.feature.FeatureRegistry
 import com.rk.resources.drawables
 import com.rk.resources.getFilledString
 import com.rk.resources.getString
 import com.rk.resources.strings
-import com.rk.feature.FeatureRegistry
-import com.rk.feature.SettingsRegistry
 
 @Composable
 fun SettingsScreen(navController: NavController) {

--- a/core/main/src/main/java/com/rk/settings/debugOptions/LogCollector.kt
+++ b/core/main/src/main/java/com/rk/settings/debugOptions/LogCollector.kt
@@ -1,8 +1,12 @@
 package com.rk.settings.debugOptions
 
 import androidx.compose.runtime.mutableStateListOf
+import com.rk.DefaultScope
+import com.rk.events.AppEvent
+import com.rk.events.Events
 import com.rk.resources.getString
 import com.rk.resources.strings
+import kotlinx.coroutines.launch
 
 enum class LogLevel(val label: String, val value: Int) {
     ERROR(strings.error.getString(), 1),
@@ -16,20 +20,57 @@ data class LogEntry(val level: LogLevel, val message: String, val timestamp: Lon
 object LogCollector {
     val logs = mutableStateListOf<LogEntry>()
 
-    fun reportDebug(message: String) {
-        logs.add(LogEntry(LogLevel.DEBUG, message))
+    fun reportDebug(message: String, extensionId: String? = null) {
+        appendEntry(
+            LogEntry(
+                LogLevel.DEBUG,
+                buildMessage(message, extensionId),
+            ),
+            extensionId,
+        )
     }
 
-    fun reportInfo(message: String) {
-        logs.add(LogEntry(LogLevel.INFO, message))
+    fun reportInfo(message: String, extensionId: String? = null) {
+        appendEntry(
+            LogEntry(
+                LogLevel.INFO,
+                buildMessage(message, extensionId),
+            ),
+            extensionId,
+        )
     }
 
-    fun reportWarn(message: String) {
-        logs.add(LogEntry(LogLevel.WARN, message))
+    fun reportWarn(message: String, extensionId: String? = null) {
+        appendEntry(
+            LogEntry(
+                LogLevel.WARN,
+                buildMessage(message, extensionId),
+            ),
+            extensionId,
+        )
     }
 
-    fun reportError(message: String) {
-        logs.add(LogEntry(LogLevel.ERROR, message))
+    fun reportError(message: String, extensionId: String? = null) {
+        appendEntry(
+            LogEntry(
+                LogLevel.ERROR,
+                buildMessage(message, extensionId),
+            ),
+            extensionId,
+        )
+    }
+
+    private fun buildMessage(message: String, extensionId: String? = null): String {
+        return extensionId?.let {
+            "[${extensionId}] $message"
+        } ?: message
+    }
+
+    private fun appendEntry(logEntry: LogEntry, extensionId: String? = null) {
+        logs.add(logEntry)
+        DefaultScope.launch {
+            Events.publish(AppEvent.LogEntryWritten(logEntry, extensionId))
+        }
     }
 
     fun clearLogs() {

--- a/core/main/src/main/java/com/rk/settings/language/Language.kt
+++ b/core/main/src/main/java/com/rk/settings/language/Language.kt
@@ -26,16 +26,20 @@ import androidx.core.net.toUri
 import androidx.core.os.LocaleListCompat
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.rk.DefaultScope
 import com.rk.components.InfoBlock
 import com.rk.components.SettingsItem
 import com.rk.components.compose.preferences.base.PreferenceGroup
 import com.rk.components.compose.preferences.base.PreferenceLayout
+import com.rk.events.AppEvent
+import com.rk.events.Events
 import com.rk.resources.strings
 import com.rk.settings.Settings
 import com.rk.utils.application
-import java.util.Locale
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.Locale
 
 // Data class to hold locale with its availability status
 data class LocaleInfo(val locale: Locale, val isInstalled: Boolean, val displayName: String)
@@ -56,15 +60,14 @@ fun LanguageScreen(modifier: Modifier = Modifier) {
             val installedTags = application?.resources?.assets?.locales?.toSet() ?: emptySet()
 
             // Process all data at once
-            val processed =
-                supportedLocales.map { locale ->
-                    val tag = locale.toLanguageTag()
-                    LocaleInfo(
-                        locale = locale,
-                        isInstalled = installedTags.contains(tag),
-                        displayName = "${locale.getDisplayLanguage(locale)} ($tag)",
-                    )
-                }
+            val processed = supportedLocales.map { locale ->
+                val tag = locale.toLanguageTag()
+                LocaleInfo(
+                    locale = locale,
+                    isInstalled = installedTags.contains(tag),
+                    displayName = "${locale.getDisplayLanguage(locale)} ($tag)",
+                )
+            }
             localeInfoList.value = processed
         }
     }
@@ -108,13 +111,13 @@ fun LanguageScreen(modifier: Modifier = Modifier) {
                         modifier = Modifier,
                         label = localeInfo.displayName,
                         default = false,
-                        sideEffect = { setAppLanguage(localeInfo.locale) },
+                        sideEffect = { setAppLanguage(localeInfo.locale, currentLocale) },
                         showSwitch = false,
                         isEnabled = localeInfo.isInstalled,
                         startWidget = {
                             RadioButton(
                                 selected = selectedLocaleInfo == localeInfo,
-                                onClick = { setAppLanguage(localeInfo.locale) },
+                                onClick = { setAppLanguage(localeInfo.locale, currentLocale) },
                             )
                         },
                     )
@@ -145,8 +148,12 @@ private suspend fun readSupportedLocales(context: Context): List<Locale> =
         }
     }
 
-fun setAppLanguage(locale: Locale) {
+fun setAppLanguage(locale: Locale, oldLocale: Locale) {
     val appLocale = LocaleListCompat.create(locale)
     AppCompatDelegate.setApplicationLocales(appLocale)
     Settings.current_lang = locale.toLanguageTag()
+
+    DefaultScope.launch {
+        Events.publish(AppEvent.LanguageChanged(locale, oldLocale))
+    }
 }

--- a/core/main/src/main/java/com/rk/settings/theme/Theme.kt
+++ b/core/main/src/main/java/com/rk/settings/theme/Theme.kt
@@ -39,6 +39,8 @@ import com.rk.components.SettingsItem
 import com.rk.components.compose.preferences.base.PreferenceGroup
 import com.rk.components.compose.preferences.base.PreferenceLayout
 import com.rk.components.compose.preferences.base.PreferenceTemplate
+import com.rk.events.AppEvent
+import com.rk.events.Events
 import com.rk.file.child
 import com.rk.file.copyToTempDir
 import com.rk.file.themeDir
@@ -119,25 +121,34 @@ fun ThemeScreen(modifier: Modifier = Modifier) {
                         )
                     },
                     sideEffect = {
+                        val oldTheme = currentTheme.value
                         currentTheme.value = theme
                         Settings.theme = theme.id
                         refreshEditors()
+                        DefaultScope.launch { Events.publish(AppEvent.ThemeChanged(theme, oldTheme)) }
                     },
                     endWidget = {
                         if (!builtInThemes.contains(theme)) {
                             IconButton(
                                 onClick = {
                                     if (currentTheme.value?.id == theme.id) {
+                                        val oldTheme = currentTheme.value
                                         currentTheme.value = blueberry
                                         Settings.theme = blueberry.id
                                         refreshEditors()
+                                        DefaultScope.launch {
+                                            Events.publish(AppEvent.ThemeChanged(blueberry, oldTheme))
+                                        }
                                     }
 
                                     themeDir().child(theme.name).delete()
                                     themes.remove(theme)
                                 }
                             ) {
-                                Icon(imageVector = Icons.Outlined.Delete, stringResource(strings.delete))
+                                Icon(
+                                    imageVector = Icons.Outlined.Delete,
+                                    stringResource(strings.delete),
+                                )
                             }
                         }
                     },
@@ -174,8 +185,13 @@ fun ThemeScreen(modifier: Modifier = Modifier) {
                     )
                 },
                 sideEffect = {
+                    val oldIconPack = currentIconPack.value
                     currentIconPack.value = null
                     Settings.icon_pack = ""
+
+                    DefaultScope.launch {
+                        Events.publish(AppEvent.IconPackChanged(null, oldIconPack))
+                    }
                 },
             )
 
@@ -195,15 +211,25 @@ fun ThemeScreen(modifier: Modifier = Modifier) {
                         )
                     },
                     sideEffect = {
+                        val oldIconPack = currentIconPack.value
                         currentIconPack.value = iconPack
                         Settings.icon_pack = id
+
+                        DefaultScope.launch {
+                            Events.publish(AppEvent.IconPackChanged(iconPack, oldIconPack))
+                        }
                     },
                     endWidget = {
                         IconButton(
                             onClick = {
                                 if (currentIconPack.value?.manifest?.id == id) {
+                                    val oldIconPack = currentIconPack.value
                                     currentIconPack.value = null
                                     Settings.icon_pack = ""
+
+                                    DefaultScope.launch {
+                                        Events.publish(AppEvent.IconPackChanged(null, oldIconPack))
+                                    }
                                 }
 
                                 iconPackManager.uninstallIconPack(id)

--- a/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
@@ -1,14 +1,10 @@
 package com.rk.tabs.editor
 
-import android.content.Context
-import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -17,7 +13,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -32,24 +27,21 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import com.rk.DefaultScope
 import com.rk.activities.main.EditorCursorState
 import com.rk.activities.main.EditorTabState
 import com.rk.activities.main.MainActivity
 import com.rk.activities.main.MainViewModel
 import com.rk.activities.main.TabState
 import com.rk.activities.main.searchViewModel
-import com.rk.file.FileChangeNotifier
 import com.rk.color.ColorPicker
-import com.rk.components.AddDialogItem
 import com.rk.components.SingleInputDialog
 import com.rk.editor.intelligent.IntelligentFeatureRegistry
+import com.rk.events.EditorTabEvent
+import com.rk.events.Events
 import com.rk.extension.api.XedExtensionPoint
 import com.rk.file.FileObject
 import com.rk.file.FileTypeManager
 import com.rk.file.child
-import com.rk.icons.Icon
 import com.rk.lsp.LspConnector
 import com.rk.lsp.formatDocumentSuspend
 import com.rk.resources.drawables
@@ -65,8 +57,6 @@ import com.rk.utils.errorDialog
 import com.rk.utils.getTempDir
 import com.rk.utils.hasBinaryChars
 import io.github.rosemoe.sora.text.ContentIO
-import java.nio.charset.Charset
-import java.nio.file.Paths
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -85,6 +75,8 @@ import org.ec4j.core.ResourcePath
 import org.ec4j.core.ResourceProperties
 import org.ec4j.core.ResourcePropertiesService
 import org.ec4j.core.model.PropertyType
+import java.nio.charset.Charset
+import java.nio.file.Paths
 
 @OptIn(DelicateCoroutinesApi::class)
 open class EditorTab(override var file: FileObject, var projectRoot: FileObject?, val viewModel: MainViewModel) :
@@ -156,14 +148,14 @@ open class EditorTab(override var file: FileObject, var projectRoot: FileObject?
             if (editorState.content == null) {
                 withContext(Dispatchers.IO) {
                     runCatching {
-                            editorState.content = file.getInputStream().use { ContentIO.createFrom(it, charset) }
-                            editorState.contentLoaded.complete(Unit)
+                        editorState.content = file.getInputStream().use { ContentIO.createFrom(it, charset) }
+                        editorState.contentLoaded.complete(Unit)
 
-                            if (Settings.detect_bin_files && hasBinaryChars(editorState.content.toString())) {
-                                editorState.editable = false
-                                showNotice(BINARY_NOTICE_KEY) { id -> BinaryNotice(id) }
-                            }
+                        if (Settings.detect_bin_files && hasBinaryChars(editorState.content.toString())) {
+                            editorState.editable = false
+                            showNotice(BINARY_NOTICE_KEY) { id -> BinaryNotice(id) }
                         }
+                    }
                         .onFailure { errorDialog(throwable = it) }
                 }
             }
@@ -291,60 +283,58 @@ open class EditorTab(override var file: FileObject, var projectRoot: FileObject?
     private suspend fun write() {
         withContext(Dispatchers.IO) {
             runCatching {
-                    if (!file.canWrite()) {
-                        errorDialog(strings.cant_write)
-                        return@withContext
-                    }
-
-                    val content = editorState.content.toString()
-                    val normalizedContent = editorState.editor.get()!!.lineEnding.applyOn(content)
-                    file.writeText(normalizedContent, charset)
-
-                    editorState.isDirty = false
-                    lspConnector?.notifySave()
+                if (!file.canWrite()) {
+                    errorDialog(strings.cant_write)
+                    return@withContext
                 }
+
+                val content = editorState.content.toString()
+                val normalizedContent = editorState.editor.get()!!.lineEnding.applyOn(content)
+                file.writeText(normalizedContent, charset)
+
+                editorState.isDirty = false
+                lspConnector?.notifySave()
+            }
                 .onFailure { errorDialog(throwable = it) }
         }
     }
 
-    suspend fun quickSave() =
-        saveMutex.withLock {
-            if (isTemp) return@withLock
-            write()
-            searchViewModel.get()?.syncIndex(file)
-            FileChangeNotifier.notifyFileChanged(file.getAbsolutePath())
+    suspend fun quickSave() = saveMutex.withLock {
+        if (isTemp) return@withLock
+        write()
+        searchViewModel.get()?.syncIndex(file)
+        Events.publish(EditorTabEvent.Saved(this))
+    }
+
+    suspend fun save() = saveMutex.withLock {
+        if (Settings.format_on_save && lspConnector?.isFormattingSupported() == true) {
+            formatDocumentSuspend(this@EditorTab)
         }
 
-    suspend fun save() =
-        saveMutex.withLock {
-            if (Settings.format_on_save && lspConnector?.isFormattingSupported() == true) {
-                formatDocumentSuspend(this@EditorTab)
-            }
-
-            if (isTemp) {
-                MainActivity.instance?.apply {
-                    fileManager.createNewFile(mimeType = "*/*", title = file.getName()) {
-                        if (it != null) {
-                            file = it
-                            tabTitle.value = it.getName()
-                            scope.launch {
-                                write()
-                                searchViewModel.get()?.syncIndex(file)
-                                FileChangeNotifier.notifyFileChanged(file.getAbsolutePath())
-                            }
+        if (isTemp) {
+            MainActivity.instance?.apply {
+                fileManager.createNewFile(mimeType = "*/*", title = file.getName()) {
+                    if (it != null) {
+                        file = it
+                        tabTitle.value = it.getName()
+                        scope.launch {
+                            write()
+                            searchViewModel.get()?.syncIndex(file)
+                            Events.publish(EditorTabEvent.Saved(this@EditorTab))
                         }
                     }
                 }
-                return@withLock
             }
-
-            write()
-            searchViewModel.get()?.syncIndex(file)
-            FileChangeNotifier.notifyFileChanged(file.getAbsolutePath())
-
-            Settings.saves += 1
-            MainActivity.instance?.handleSupport()
+            return@withLock
         }
+
+        write()
+        searchViewModel.get()?.syncIndex(file)
+        Events.publish(EditorTabEvent.Saved(this))
+
+        Settings.saves += 1
+        MainActivity.instance?.handleSupport()
+    }
 
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
@@ -355,7 +345,6 @@ open class EditorTab(override var file: FileObject, var projectRoot: FileObject?
             LaunchedEffect(editorState.editable) { editorState.editor.get()?.editable = editorState.editable }
 
             Column {
-
                 if (editorState.showFindingsDialog) {
                     FindingsDialog(
                         title = editorState.findingsTitle,
@@ -537,5 +526,3 @@ open class EditorTab(override var file: FileObject, var projectRoot: FileObject?
         return "[EditorTab] ${file.getAbsolutePath()}"
     }
 }
-
-

--- a/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
@@ -77,6 +77,7 @@ import org.ec4j.core.ResourcePropertiesService
 import org.ec4j.core.model.PropertyType
 import java.nio.charset.Charset
 import java.nio.file.Paths
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(DelicateCoroutinesApi::class)
 open class EditorTab(override var file: FileObject, var projectRoot: FileObject?, val viewModel: MainViewModel) :
@@ -100,7 +101,6 @@ open class EditorTab(override var file: FileObject, var projectRoot: FileObject?
     override var tabTitle: MutableState<String> =
         mutableStateOf(file.getName()).also {
             scope.launch(Dispatchers.IO) {
-                delay(100)
                 val parent = file.getParentFile()
                 if (
                     viewModel.tabs.any { it.tabTitle.value == tabTitle.value && it != this@EditorTab } && parent != null
@@ -339,8 +339,6 @@ open class EditorTab(override var file: FileObject, var projectRoot: FileObject?
     @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
-        val context = LocalContext.current
-
         key(refreshKey) {
             LaunchedEffect(editorState.editable) { editorState.editor.get()?.editable = editorState.editable }
 
@@ -434,7 +432,7 @@ open class EditorTab(override var file: FileObject, var projectRoot: FileObject?
                             scope.launch(Dispatchers.IO) {
                                 quickSave()
                                 saveMutex.lock()
-                                delay(Settings.auto_save_delay)
+                                delay(Settings.auto_save_delay.milliseconds)
                                 saveMutex.unlock()
                             }
                         } else {

--- a/core/main/src/main/java/com/rk/utils/Utils.kt
+++ b/core/main/src/main/java/com/rk/utils/Utils.kt
@@ -40,9 +40,9 @@ import com.blankj.utilcode.util.ThreadUtils
 import com.caverock.androidsvg.SVG
 import com.rk.extension.ActivityProvider
 import com.rk.file.BuiltinFileType
+import com.rk.file.FileDecorationRegistry
 import com.rk.file.FileObject
 import com.rk.filetree.FileTreeViewModel
-import com.rk.file.FileDecorationRegistry
 import com.rk.resources.getQuantityString
 import com.rk.resources.getString
 import com.rk.resources.plurals
@@ -50,6 +50,12 @@ import com.rk.resources.strings
 import com.rk.settings.Settings
 import com.rk.theme.currentTheme
 import io.github.rosemoe.sora.widget.schemes.EditorColorScheme
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.InputStream
 import java.io.ObjectInputStream
@@ -57,12 +63,6 @@ import java.io.ObjectOutputStream
 import java.text.NumberFormat
 import java.util.Locale
 import kotlin.math.roundToInt
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @OptIn(DelicateCoroutinesApi::class)
 inline fun runOnUiThread(runnable: Runnable) {
@@ -83,7 +83,6 @@ suspend fun FileObject.readObject(): Any? =
         }
     }
 
-
 fun toast(message: String?) {
     if (message.isNullOrBlank()) {
         Log.w("UTILS", "Toast with null or empty message")
@@ -96,12 +95,11 @@ fun toast(message: String?) {
 
     runOnUiThread {
         val context = ActivityProvider.currentActivity as? Context
-        if (context != null){
+        if (context != null) {
             Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-        }else{
-            Log.w("Utils","no valid ui context available for making toast: $message")
+        } else {
+            Log.w("Utils", "no valid ui context available for making toast: $message")
         }
-
     }
 }
 
@@ -117,7 +115,7 @@ fun isDarkTheme(ctx: Context): Boolean {
 /** Returns true if the system theme is dark. **NOTE:** Prefer [isDarkTheme] to respect user settings. */
 fun isSystemInDarkTheme(ctx: Context): Boolean {
     return ((ctx.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-            Configuration.UI_MODE_NIGHT_YES)
+        Configuration.UI_MODE_NIGHT_YES)
 }
 
 inline fun dpToPx(dp: Float, ctx: Context): Int {
@@ -167,7 +165,6 @@ fun origin(): String {
 val isV =
     byteArrayOf(99, 111, 109, 46, 97, 110, 100, 114, 111, 105, 100, 46, 118, 101, 110, 100, 105, 110, 103)
         .toString(Charsets.UTF_8) == origin()
-
 
 fun copyToClipboard(label: String, text: String, showToast: Boolean = true) {
     val clipboard = application!!.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
@@ -326,8 +323,7 @@ fun Modifier.drawErrorUnderline(errorColor: Color): Modifier = drawBehind {
 
 @Composable
 fun getFileColor(file: FileObject?): Color? {
-    if (file == null) return null
-    return FileDecorationRegistry.provider?.getDecoration(file)?.color
+    return file?.let { FileDecorationRegistry.getDecoration(it).color }
 }
 
 fun hasBinaryChars(text: String): Boolean {
@@ -341,8 +337,9 @@ fun hasBinaryChars(text: String): Boolean {
     if (checkText.any { it.code == 0 }) return true
 
     // Amount of unusual control characters
-    val unusualCharCount =
-        checkText.count { c -> c.isISOControl() && c.code != 9 && c.code != 10 && c.code != 12 && c.code != 13 }
+    val unusualCharCount = checkText.count { c ->
+        c.isISOControl() && c.code != 9 && c.code != 10 && c.code != 12 && c.code != 13
+    }
 
     // If the amount of unusual control chars in the file content is over 30%
     return unusualCharCount.toDouble() / checkText.length > threshold

--- a/features/extensions/src/main/java/com/rk/ExtensionFeature.kt
+++ b/features/extensions/src/main/java/com/rk/ExtensionFeature.kt
@@ -8,28 +8,28 @@ import com.rk.extension.loader.loadAllExtensions
 import com.rk.extension.manager.ExtensionAPIManager
 import com.rk.extension.manager.ExtensionManager
 import com.rk.feature.Feature
-import com.rk.feature.SettingsRegistry
-import com.rk.feature.SettingsCategory
-import com.rk.feature.SettingsRoute
-import com.rk.resources.strings
-import com.rk.resources.drawables
-import com.rk.settings.extension.ExtensionScreen
-import com.rk.settings.extension.ExtensionDetail
-import com.rk.settings.extension.ExtensionSettings
-import com.rk.feature.FeatureRegistry
 import com.rk.feature.FeatureToggle
+import com.rk.resources.drawables
+import com.rk.resources.strings
+import com.rk.settings.SettingsCategory
+import com.rk.settings.SettingsRegistry
+import com.rk.settings.SettingsRoute
+import com.rk.settings.extension.ExtensionDetail
+import com.rk.settings.extension.ExtensionScreen
+import com.rk.settings.extension.ExtensionSettings
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 class ExtensionFeature : Feature {
-    override val toggle = FeatureToggle(
-        nameRes = strings.ext,
-        key = "enable_extension",
-        default = true,
-        iconRes = drawables.extension
-    )
+    override val toggle =
+        FeatureToggle(
+            nameRes = strings.ext,
+            key = "enable_extension",
+            default = true,
+            iconRes = drawables.extension,
+        )
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun init(application: Application) {
@@ -49,7 +49,7 @@ class ExtensionFeature : Feature {
                 labelRes = strings.store,
                 descriptionRes = strings.store_desc,
                 iconRes = drawables.store,
-                route = SettingsRoutes.Extensions.route
+                route = SettingsRoutes.Extensions.route,
             )
         )
 

--- a/features/extensions/src/main/java/com/rk/extension/ExtensionEvent.kt
+++ b/features/extensions/src/main/java/com/rk/extension/ExtensionEvent.kt
@@ -2,13 +2,24 @@ package com.rk.extension
 
 import com.rk.events.Event
 
+/** Events related to extension lifecycle and state. */
 sealed interface ExtensionEvent : Event {
 
+    /** Event triggered when an extension is installed. */
     data class Installed(val extension: Extension) : ExtensionEvent
 
+    /** Event triggered when an extension has been successfully loaded. */
     data class Loaded(val extension: LocalExtension) : ExtensionEvent
 
+    /** Event triggered when an extension has crashed and been disabled. */
     data class Crashed(val extension: Extension) : ExtensionEvent
 
+    /**
+     * Event triggered when an extension is uninstalled.
+     *
+     * This also includes temporary uninstallation during an update.
+     *
+     * @param isUpdate Whether the extension was temporarily uninstalled as a result of an update.
+     */
     data class Uninstalled(val extension: Extension, val isUpdate: Boolean) : ExtensionEvent
 }

--- a/features/extensions/src/main/java/com/rk/extension/ExtensionEvent.kt
+++ b/features/extensions/src/main/java/com/rk/extension/ExtensionEvent.kt
@@ -1,0 +1,14 @@
+package com.rk.extension
+
+import com.rk.events.Event
+
+sealed interface ExtensionEvent : Event {
+
+    data class Installed(val extension: Extension) : ExtensionEvent
+
+    data class Loaded(val extension: LocalExtension) : ExtensionEvent
+
+    data class Crashed(val extension: Extension) : ExtensionEvent
+
+    data class Uninstalled(val extension: Extension, val isUpdate: Boolean) : ExtensionEvent
+}

--- a/features/extensions/src/main/java/com/rk/extension/api/Logger.kt
+++ b/features/extensions/src/main/java/com/rk/extension/api/Logger.kt
@@ -6,20 +6,20 @@ import com.rk.settings.debugOptions.LogCollector
 
 fun ExtensionId.logDebug(msg: String) {
     Log.d(this, msg)
-    LogCollector.reportDebug("[${this}] $msg")
+    LogCollector.reportDebug("[${this}] $msg", this)
 }
 
 fun ExtensionId.logInfo(msg: String) {
     Log.i(this, msg)
-    LogCollector.reportInfo("[${this}] $msg")
+    LogCollector.reportInfo("[${this}] $msg", this)
 }
 
 fun ExtensionId.logWarn(msg: String) {
     Log.w(this, msg)
-    LogCollector.reportWarn("[${this}] $msg")
+    LogCollector.reportWarn("[${this}] $msg", this)
 }
 
 fun ExtensionId.logError(msg: String) {
     Log.e(this, msg)
-    LogCollector.reportError("[${this}] $msg")
+    LogCollector.reportError("[${this}] $msg", this)
 }

--- a/features/extensions/src/main/java/com/rk/extension/loader/ExtensionLoader.kt
+++ b/features/extensions/src/main/java/com/rk/extension/loader/ExtensionLoader.kt
@@ -2,9 +2,12 @@ package com.rk.extension.loader
 
 import android.app.Application
 import androidx.core.content.pm.PackageInfoCompat
+import com.rk.DefaultScope
 import com.rk.crashhandler.CrashActivity
+import com.rk.events.Events
 import com.rk.extension.ExtensionAPI
 import com.rk.extension.ExtensionContext
+import com.rk.extension.ExtensionEvent
 import com.rk.extension.LocalExtension
 import com.rk.extension.apkFile
 import com.rk.extension.extensionManager
@@ -60,6 +63,11 @@ fun LocalExtension.load(
         instance.onExtensionLoaded()
 
         extensionManager.loadedExtensions[this] = LoadedExtension(instance, scope)
+
+        DefaultScope.launch {
+            Events.publish(ExtensionEvent.Loaded(this@load))
+        }
+
         instance
     }
 }
@@ -154,12 +162,12 @@ suspend fun ExtensionManager.installExtensionFromZip(fileObject: FileObject) = r
 suspend fun ExtensionManager.loadAllExtensions() =
     withContext(Dispatchers.IO) {
         for ((_, extension) in localExtensions) {
-            if (isExtensionCrashed(extension.id)) {
+            if (isExtensionCrashed(extension)) {
                 continue
             }
             launch(Dispatchers.IO) {
                 extension.load(application!!).onFailure { error ->
-                    setExtensionCrashed(extension.id, true)
+                    setExtensionCrashed(extension, true)
                     withContext(Dispatchers.Main) {
                         CrashActivity.start(
                             context = application!!,

--- a/features/extensions/src/main/java/com/rk/extension/manager/ExtensionManager.kt
+++ b/features/extensions/src/main/java/com/rk/extension/manager/ExtensionManager.kt
@@ -5,9 +5,12 @@ import android.content.Context
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.core.content.edit
 import androidx.core.content.pm.PackageInfoCompat
+import com.rk.DefaultScope
+import com.rk.events.Events
 import com.rk.extension.Extension
 import com.rk.extension.ExtensionAPI
 import com.rk.extension.ExtensionError
+import com.rk.extension.ExtensionEvent
 import com.rk.extension.ExtensionId
 import com.rk.extension.ExtensionManifest
 import com.rk.extension.InstallResult
@@ -55,7 +58,10 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
     private val mutex = Mutex()
     val localExtensions = mutableStateMapOf<ExtensionId, LocalExtension>()
     val storeExtension = mutableStateMapOf<ExtensionId, StoreExtension>()
-    val json = Json { ignoreUnknownKeys = true }
+    val json = Json {
+        ignoreUnknownKeys = true
+        allowTrailingComma = true
+    }
 
     val loadedExtensions = mutableStateMapOf<LocalExtension, LoadedExtension?>()
 
@@ -72,12 +78,17 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
         context.getSharedPreferences("disabled_extensions", Context.MODE_PRIVATE)
     }
 
-    fun isExtensionCrashed(id: ExtensionId): Boolean {
-        return disabledPrefs.getBoolean(id, false)
+    fun isExtensionCrashed(extension: Extension): Boolean {
+        return disabledPrefs.getBoolean(extension.id, false)
     }
 
-    fun setExtensionCrashed(id: ExtensionId, disabled: Boolean) {
-        disabledPrefs.edit { putBoolean(id, disabled) }
+    fun setExtensionCrashed(extension: Extension, disabled: Boolean) {
+        disabledPrefs.edit { putBoolean(extension.id, disabled) }
+        if (disabled) {
+            launch {
+                Events.publish(ExtensionEvent.Crashed(extension))
+            }
+        }
     }
 
     fun isInstalled(extensionId: ExtensionId) = localExtensions.containsKey(extensionId)
@@ -288,6 +299,8 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
                 )
             localExtensions[extensionInfo.id] = extension
 
+            Events.publish(ExtensionEvent.Installed(extension))
+
             InstallResult.Success(extension, performedUpdate)
         }
 
@@ -316,6 +329,9 @@ open class ExtensionManager(private val context: Application) : CoroutineScope b
 
                 extensionDir.deleteRecursively()
                 localExtensions.remove(extensionId)
+
+                DefaultScope.launch { Events.publish(ExtensionEvent.Uninstalled(extension, update)) }
+
                 context.compiledDexDir().deleteWithPackageName(extension.manifest.id)
                 disabledPrefs.edit { remove(extensionId) }
 

--- a/features/extensions/src/main/java/com/rk/extension/manager/ExtensionRegistry.kt
+++ b/features/extensions/src/main/java/com/rk/extension/manager/ExtensionRegistry.kt
@@ -64,7 +64,10 @@ object ExtensionRegistry {
     private const val BASE_URL = EXTENSION_API_BASE
 
     private val client: OkHttpClient = okHttpClient
-    private val json = Json { ignoreUnknownKeys = true }
+    private val json = Json {
+        ignoreUnknownKeys = true
+        allowTrailingComma = true
+    }
 
     val downloadProgress = mutableStateMapOf<String, Float>()
     val activeInstalls = mutableStateMapOf<String, InstallState>()

--- a/features/extensions/src/main/java/com/rk/settings/extension/ExtensionCard.kt
+++ b/features/extensions/src/main/java/com/rk/settings/extension/ExtensionCard.kt
@@ -98,7 +98,7 @@ fun ExtensionCard(
                         )
                     }
 
-                    if (extensionManager.isExtensionCrashed(extension.id)) {
+                    if (extensionManager.isExtensionCrashed(extension)) {
                         Text(
                             text = " • ${stringResource(strings.disabled_crashed)}",
                             style = Typography.labelMedium,

--- a/features/extensions/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
+++ b/features/extensions/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
@@ -88,7 +88,7 @@ fun ExtensionDetail(extension: Extension?, navController: NavController) {
             if (extension?.hasSettings == true) {
                 IconButton(
                     enabled = extensionManager.isInstalled(extension.id),
-                    onClick = { navController.navigate("${SettingsRoutes.ExtensionSettings.route}/{extensionId}") },
+                    onClick = { navController.navigate("${SettingsRoutes.ExtensionSettings.route}/${extension.id}") },
                 ) {
                     Icon(
                         painter = painterResource(drawables.settings),

--- a/features/extensions/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
+++ b/features/extensions/src/main/java/com/rk/settings/extension/ExtensionDetail.kt
@@ -65,6 +65,7 @@ import com.rk.resources.strings
 import com.rk.theme.Typography
 import com.rk.utils.formatFileSize
 import com.rk.utils.formatNumberCompact
+import com.rk.utils.toast
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -197,7 +198,10 @@ private fun AboutSection(
                         ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    ExtensionAuthorIcon(extension.author, Modifier.size(24.dp).padding(end = 4.dp))
+                    ExtensionAuthorIcon(
+                        extension.author,
+                        Modifier.size(24.dp).padding(end = 4.dp),
+                    )
                     Text(
                         text = "${extension.author}",
                         style = Typography.labelLarge,
@@ -229,6 +233,37 @@ private fun AboutSection(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
+                }
+
+                var isCrashed by remember {
+                    mutableStateOf(extensionManager.isExtensionCrashed(extension))
+                }
+                if (isCrashed) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = " • ",
+                            style = Typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                        )
+
+                        Text(
+                            text = stringResource(strings.disabled_crashed),
+                            style = Typography.labelLarge,
+                            color = MaterialTheme.colorScheme.error,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier =
+                                Modifier.clickable(
+                                    onClick = {
+                                        // TODO: Crash detail screen
+                                        extensionManager.setExtensionCrashed(extension, false)
+                                        toast("Re-enabled extension. Restart the app for changes to take effect.")
+                                        isCrashed = false
+                                    }
+                                ),
+                        )
+                    }
                 }
             }
         }

--- a/features/extensions/src/main/java/com/rk/settings/extension/ExtensionScreen.kt
+++ b/features/extensions/src/main/java/com/rk/settings/extension/ExtensionScreen.kt
@@ -856,7 +856,7 @@ private fun applyFilter(
         when (currentFilterOption) {
             ExtensionFilterOptions.ALL -> true
             ExtensionFilterOptions.SUPPORTED -> !outdatedClient && !outdatedExtension
-            ExtensionFilterOptions.CRASHED -> extensionManager.isExtensionCrashed(it.id)
+            ExtensionFilterOptions.CRASHED -> extensionManager.isExtensionCrashed(it)
         }
     }
 }

--- a/features/extensions/src/main/java/com/rk/settings/extension/extensionActions.kt
+++ b/features/extensions/src/main/java/com/rk/settings/extension/extensionActions.kt
@@ -188,9 +188,9 @@ fun runExtensionInstallAction(
 
                 val result = extensionManager.installExtensionFromZip(tempFile)
                 if (result is InstallResult.Success) {
-                    extensionManager.setExtensionCrashed(result.extension.id, false)
+                    extensionManager.setExtensionCrashed(result.extension, false)
                     result.extension.load(application!!, true).onFailure { error ->
-                        extensionManager.setExtensionCrashed(result.extension.id, true)
+                        extensionManager.setExtensionCrashed(result.extension, true)
                         errorMsg = error.message ?: "Failed to load extension"
                         withContext(Dispatchers.Main) {
                             activity?.let {
@@ -290,38 +290,43 @@ fun runExtensionUpdateAction(
             if (downloadSuccess) {
                 showDownloadNotification(context, id, name, 1f)
 
-                val result = extensionManager.installExtensionFromZip(tempFile)
-                if (result is InstallResult.Success) {
-                    extensionManager.setExtensionCrashed(result.extension.id, false)
-                    result.extension.load(application!!).onFailure { error ->
-                        extensionManager.setExtensionCrashed(result.extension.id, true)
-                        errorMsg = error.message ?: "Failed to load extension"
-                        withContext(Dispatchers.Main) {
-                            activity?.let {
-                                CrashActivity.start(
-                                    context = it,
-                                    extensionId = result.extension.id,
-                                    extensionName = result.extension.name,
-                                    extensionVersion = result.extension.version,
-                                    extensionAuthor = result.extension.author.toString(),
-                                    repository = result.extension.repository,
-                                    error = error,
-                                )
-                            }
-                                ?: run {
-                                    errorDialog(activity, msg = errorMsg)
+                when (val result = extensionManager.installExtensionFromZip(tempFile)) {
+                    is InstallResult.Success -> {
+                        extensionManager.setExtensionCrashed(result.extension, false)
+                        result.extension.load(application!!).onFailure { error ->
+                            extensionManager.setExtensionCrashed(result.extension, true)
+                            errorMsg = error.message ?: "Failed to load extension"
+                            withContext(Dispatchers.Main) {
+                                activity?.let {
+                                    CrashActivity.start(
+                                        context = it,
+                                        extensionId = result.extension.id,
+                                        extensionName = result.extension.name,
+                                        extensionVersion = result.extension.version,
+                                        extensionAuthor = result.extension.author.toString(),
+                                        repository = result.extension.repository,
+                                        error = error,
+                                    )
                                 }
+                                    ?: run {
+                                        errorDialog(activity, msg = errorMsg)
+                                    }
+                            }
                         }
+                        success = errorMsg == null
                     }
-                    success = errorMsg == null
-                } else if (result is InstallResult.Error) {
-                    errorMsg =
-                        when (result.error) {
-                            ExtensionError.OUTDATED_CLIENT -> strings.outdated_client.getString(context)
-                            ExtensionError.OUTDATED_EXTENSION -> strings.outdated_extension.getString(context)
-                        }
-                } else if (result is InstallResult.ValidationFailed) {
-                    errorMsg = result.error?.message ?: "Validation failed"
+
+                    is InstallResult.Error -> {
+                        errorMsg =
+                            when (result.error) {
+                                ExtensionError.OUTDATED_CLIENT -> strings.outdated_client.getString(context)
+                                ExtensionError.OUTDATED_EXTENSION -> strings.outdated_extension.getString(context)
+                            }
+                    }
+
+                    is InstallResult.ValidationFailed -> {
+                        errorMsg = result.error?.message ?: "Validation failed"
+                    }
                 }
             } else {
                 errorMsg = "Download failed"
@@ -444,10 +449,10 @@ fun installExtensionFromUri(scope: CoroutineScope, uri: Uri?, activity: AppCompa
                 val result = extensionManager.installExtensionFromZip(fileObject)
 
                 if (result is InstallResult.Success) {
-                    extensionManager.setExtensionCrashed(result.extension.id, false)
+                    extensionManager.setExtensionCrashed(result.extension, false)
                     val initialInstallation = !result.performedUpdate
                     result.extension.load(application!!, initialInstallation).onFailure { error ->
-                        extensionManager.setExtensionCrashed(result.extension.id, true)
+                        extensionManager.setExtensionCrashed(result.extension, true)
                         withContext(Dispatchers.Main) {
                             activity?.let {
                                 CrashActivity.start(

--- a/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
+++ b/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -26,9 +25,8 @@ import com.rk.file.FileObject
 import com.rk.file.toFileObject
 import com.rk.resources.getString
 import com.rk.resources.strings
-import java.io.File
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.File
 
 private fun validateValue(value: String): String? {
     return when {
@@ -102,11 +100,10 @@ fun GitCloneDialog(
                     runCatching {
                         context.contentResolver.takePersistableUriPermission(
                             it,
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION or
-                                Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
                         )
                     }
-                    .onFailure { it.printStackTrace() }
+                        .onFailure { it.printStackTrace() }
                     scope.launch {
                         val fileObject =
                             it.toFileObject(expectedIsFile = false)
@@ -114,26 +111,29 @@ fun GitCloneDialog(
                                     false,
                                     repoURL.substringAfterLast("/").substringBeforeLast("."),
                                 )
-                        gitViewModel.get()?.cloneRepository(
-                            repoURL = repoURL,
-                            repoBranch = repoBranch,
-                            targetDir = File(fileObject!!.getAbsolutePath()),
-                            progressCoordinator = monitor,
-                            onComplete = { success ->
-                                repoURL = ""
-                                repoBranch = "main"
-                                repoURLError = null
-                                repoBranchError = null
-                                onDismiss()
-                                if (success) {
-                                    onCloneComplete(fileObject)
-                                }
-                            },
-                        )
+                        gitViewModel
+                            .get()
+                            ?.cloneRepository(
+                                repoURL = repoURL,
+                                repoBranch = repoBranch,
+                                targetDir = File(fileObject!!.getAbsolutePath()),
+                                progressCoordinator = monitor,
+                                onComplete = { success ->
+                                    repoURL = ""
+                                    repoBranch = "main"
+                                    repoURLError = null
+                                    repoBranchError = null
+                                    onDismiss()
+                                    if (success) {
+                                        onCloneComplete(fileObject)
+                                    }
+                                },
+                            )
                     }
-                } ?: run {
-                    onDismiss()
                 }
+                    ?: run {
+                        onDismiss()
+                    }
             },
         )
 

--- a/features/git/src/main/java/com/rk/git/GitEvent.kt
+++ b/features/git/src/main/java/com/rk/git/GitEvent.kt
@@ -1,0 +1,52 @@
+package com.rk.git
+
+import com.rk.events.Event
+import com.rk.file.FileObject
+
+sealed interface GitEvent : Event {
+    // TODO: Implement repo init, branch deletion, stash management, rebase, merge, conflicts
+    // data class RepositoryInitialized(val path: String) : GitEvent
+
+    data class RepositoryCloned(
+        val remoteUrl: String,
+        val branch: String,
+        val destination: FileObject,
+    ) : GitEvent
+
+    data class BranchCreated(
+        val root: FileObject,
+        val name: String,
+        val fromBranch: String?,
+    ) : GitEvent
+
+    // data class BranchDeleted(val name: String) : GitEvent
+
+    data class BranchCheckedOut(val root: FileObject, val name: String) : GitEvent
+
+    data class CommitCreated(
+        val root: FileObject,
+        val message: String,
+    ) : GitEvent
+
+    data class CommitAmended(
+        val root: FileObject,
+        val message: String,
+    ) : GitEvent
+
+    data class FetchCompleted(val root: FileObject, val remote: String, val branch: String) : GitEvent
+
+    data class PullCompleted(
+        val root: FileObject,
+        val remote: String,
+        val branch: String,
+    ) : GitEvent
+
+    data class PushCompleted(
+        val root: FileObject,
+        val remote: String,
+        val branch: String,
+        val force: Boolean = false,
+    ) : GitEvent
+
+    data class WorkingTreeUpdated(val root: FileObject, val changes: List<GitChange>) : GitEvent
+}

--- a/features/git/src/main/java/com/rk/git/GitEvent.kt
+++ b/features/git/src/main/java/com/rk/git/GitEvent.kt
@@ -3,16 +3,19 @@ package com.rk.git
 import com.rk.events.Event
 import com.rk.file.FileObject
 
+/** Events related to Git version control operations. */
 sealed interface GitEvent : Event {
     // TODO: Implement repo init, branch deletion, stash management, rebase, merge, conflicts
     // data class RepositoryInitialized(val path: String) : GitEvent
 
+    /** Event triggered when a Git repository has been successfully cloned. */
     data class RepositoryCloned(
         val remoteUrl: String,
         val branch: String,
         val destination: FileObject,
     ) : GitEvent
 
+    /** Event triggered when a new Git branch has been created. */
     data class BranchCreated(
         val root: FileObject,
         val name: String,
@@ -21,26 +24,40 @@ sealed interface GitEvent : Event {
 
     // data class BranchDeleted(val name: String) : GitEvent
 
+    /** Event triggered when a Git branch has been checked out. */
     data class BranchCheckedOut(val root: FileObject, val name: String) : GitEvent
 
+    /**
+     * Event triggered when a new Git commit has been created.
+     *
+     * @see CommitAmended
+     */
     data class CommitCreated(
         val root: FileObject,
         val message: String,
     ) : GitEvent
 
+    /**
+     * Event triggered when a Git commit has been amended.
+     *
+     * @see CommitCreated
+     */
     data class CommitAmended(
         val root: FileObject,
         val message: String,
     ) : GitEvent
 
+    /** Event triggered when a Git fetch operation has completed. */
     data class FetchCompleted(val root: FileObject, val remote: String, val branch: String) : GitEvent
 
+    /** Event triggered when a Git pull operation has completed. */
     data class PullCompleted(
         val root: FileObject,
         val remote: String,
         val branch: String,
     ) : GitEvent
 
+    /** Event triggered when a Git push operation has completed. */
     data class PushCompleted(
         val root: FileObject,
         val remote: String,
@@ -48,5 +65,6 @@ sealed interface GitEvent : Event {
         val force: Boolean = false,
     ) : GitEvent
 
+    /** Event triggered when the Git working tree has been updated with changes. */
     data class WorkingTreeUpdated(val root: FileObject, val changes: List<GitChange>) : GitEvent
 }

--- a/features/git/src/main/java/com/rk/git/GitFeature.kt
+++ b/features/git/src/main/java/com/rk/git/GitFeature.kt
@@ -119,9 +119,9 @@ class GitFeature : Feature {
                 if (showCloneDialog) {
                     GitCloneDialog(
                         onDismiss = { showCloneDialog = false },
-                        onCloneComplete = { fileObject ->
+                        onCloneComplete = { destination ->
                             // Add file tree tab on success
-                            MainActivity.instance?.drawerViewModel?.addFileTreeTab(fileObject)
+                            MainActivity.instance?.drawerViewModel?.addFileTreeTab(destination)
                         },
                     )
                 }

--- a/features/git/src/main/java/com/rk/git/GitFeature.kt
+++ b/features/git/src/main/java/com/rk/git/GitFeature.kt
@@ -7,18 +7,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.ViewModelProvider
+import com.rk.activities.main.MainActivity
 import com.rk.activities.settings.SettingsRoutes
+import com.rk.components.DialogProvider
 import com.rk.components.DialogRegistry
 import com.rk.drawer.AddProjectOption
 import com.rk.drawer.AddProjectRegistry
 import com.rk.drawer.ServiceTabRegistry
+import com.rk.events.EditorTabEvent
+import com.rk.events.Events
+import com.rk.events.FileTreeEvent
 import com.rk.feature.Feature
 import com.rk.feature.FeatureRegistry
 import com.rk.feature.FeatureToggle
-import com.rk.feature.SettingsCategory
-import com.rk.feature.SettingsRegistry
-import com.rk.feature.SettingsRoute
-import com.rk.file.FileChangeNotifier
 import com.rk.file.FileDecoration
 import com.rk.file.FileDecorationProvider
 import com.rk.file.FileDecorationRegistry
@@ -28,7 +30,12 @@ import com.rk.file.FilePropertiesRegistry
 import com.rk.file.FileProperty
 import com.rk.icons.Icon
 import com.rk.resources.drawables
+import com.rk.resources.getString
 import com.rk.resources.strings
+import com.rk.settings.Settings
+import com.rk.settings.SettingsCategory
+import com.rk.settings.SettingsRegistry
+import com.rk.settings.SettingsRoute
 import com.rk.settings.git.GitSettings
 import com.rk.theme.gitAdded
 import com.rk.theme.gitConflicted
@@ -66,98 +73,101 @@ class GitFeature : Feature {
             }
         )
 
-        // Register FileDecorationProvider
-        FileDecorationRegistry.provider =
-            object : FileDecorationProvider {
-                @Composable
-                override fun getDecoration(file: FileObject): FileDecoration? {
-                    if (!FeatureRegistry.isEnabled("enable_git") || !com.rk.settings.Settings.git_colorize_names)
-                        return null
-                    val changeType = gitViewModel.get()?.getChangeType(file.getAbsolutePath()) ?: return null
-                    val color =
-                        when (changeType) {
-                            ChangeType.ADDED,
-                            ChangeType.UNTRACKED -> MaterialTheme.colorScheme.gitAdded
-                            ChangeType.DELETED -> MaterialTheme.colorScheme.gitDeleted
-                            ChangeType.CONFLICTING -> MaterialTheme.colorScheme.gitConflicted
-                            ChangeType.MODIFIED -> MaterialTheme.colorScheme.gitModified
-                            ChangeType.RENAMED -> MaterialTheme.colorScheme.gitModified
-                        }
-                    return FileDecoration(color = color)
-                }
-            }
+        FileDecorationRegistry.register(GitFileDecorationProvider)
+        FilePropertiesRegistry.register(GitProperty)
 
-        // Register FilePropertiesProvider
-        FilePropertiesRegistry.providers.add(
-            object : FilePropertiesProvider {
-                @Composable
-                override fun getProperties(file: FileObject): List<FileProperty> {
-                    val changeType = gitViewModel.get()?.getChangeType(file.getAbsolutePath()) ?: return emptyList()
-                    val gitStatus = changeType.name.lowercase().replaceFirstChar { it.uppercase() }
-                    val color =
-                        when (changeType) {
-                            ChangeType.ADDED,
-                            ChangeType.UNTRACKED -> MaterialTheme.colorScheme.gitAdded
-                            ChangeType.DELETED -> MaterialTheme.colorScheme.gitDeleted
-                            ChangeType.CONFLICTING -> MaterialTheme.colorScheme.gitConflicted
-                            ChangeType.MODIFIED -> MaterialTheme.colorScheme.gitModified
-                            ChangeType.RENAMED -> MaterialTheme.colorScheme.gitModified
-                        }
-                    return listOf(
-                        FileProperty(
-                            label = stringResource(strings.git_status),
-                            value = gitStatus,
-                            valueColor = color,
-                        )
-                    )
-                }
-            }
-        )
-
-        // Register Service Tab Provider
-        ServiceTabRegistry.providers.add { owner ->
-            val viewModel: GitViewModel = androidx.lifecycle.ViewModelProvider(owner)[GitViewModel::class.java]
+        ServiceTabRegistry.register { owner ->
+            val viewModel = ViewModelProvider(owner)[GitViewModel::class.java]
             gitViewModel = WeakReference(viewModel)
             GitTab(viewModel)
         }
 
         // Register file change notification listeners
-        FileChangeNotifier.fileChangeListeners.add { path ->
-            gitViewModel.get()?.syncChanges(path)
-        }
-        FileChangeNotifier.projectOpenListeners.add { root ->
-            val gitRoot = findGitRoot(root)
+        Events.subscribe<FileTreeEvent.Opened> { event ->
+            val gitRoot = findGitRoot(event.projectRoot.getAbsolutePath())
             if (gitRoot != null) {
                 gitViewModel.get()?.loadRepository(gitRoot)
             }
         }
 
+        Events.subscribe<FileTreeEvent.TreeSynchronized> { event ->
+            gitViewModel.get()?.syncChanges(event.parent.getAbsolutePath())
+        }
+
+        Events.subscribe<EditorTabEvent.Saved> { event ->
+            gitViewModel.get()?.syncChanges(event.tab.file.getAbsolutePath())
+        }
+
         // Register Git Clone Overlay and Add Project Sheet action
         var showCloneDialog by mutableStateOf(false)
         if (FeatureRegistry.isEnabled("enable_git")) {
-            AddProjectRegistry.options.add(
+            val option =
                 AddProjectOption(
                     icon = Icon.ResourceIcon(drawables.git),
-                    titleRes = strings.clone_repo,
-                    descriptionRes = strings.clone_repo_desc,
+                    title = strings.clone_repo.getString(),
+                    description = strings.clone_repo_desc.getString(),
                     onClick = { onDismiss ->
                         showCloneDialog = true
                         onDismiss()
                     },
                 )
-            )
+            AddProjectRegistry.register(option)
         }
 
-        DialogRegistry.dialogs.add {
-            if (showCloneDialog) {
-                GitCloneDialog(
-                    onDismiss = { showCloneDialog = false },
-                    onCloneComplete = { fileObject ->
-                        // Add file tree tab on success
-                        com.rk.activities.main.MainActivity.instance?.drawerViewModel?.addFileTreeTab(fileObject)
-                    },
-                )
+        DialogRegistry.register(
+            DialogProvider {
+                if (showCloneDialog) {
+                    GitCloneDialog(
+                        onDismiss = { showCloneDialog = false },
+                        onCloneComplete = { fileObject ->
+                            // Add file tree tab on success
+                            MainActivity.instance?.drawerViewModel?.addFileTreeTab(fileObject)
+                        },
+                    )
+                }
             }
-        }
+        )
+    }
+}
+
+object GitProperty : FilePropertiesProvider {
+    @Composable
+    override fun provideProperties(file: FileObject): List<FileProperty> {
+        val changeType = gitViewModel.get()?.getChangeType(file.getAbsolutePath()) ?: return emptyList()
+        val gitStatus = changeType.name.lowercase().replaceFirstChar { it.uppercase() }
+        val color =
+            when (changeType) {
+                ChangeType.ADDED,
+                ChangeType.UNTRACKED -> MaterialTheme.colorScheme.gitAdded
+                ChangeType.DELETED -> MaterialTheme.colorScheme.gitDeleted
+                ChangeType.CONFLICTING -> MaterialTheme.colorScheme.gitConflicted
+                ChangeType.MODIFIED -> MaterialTheme.colorScheme.gitModified
+                ChangeType.RENAMED -> MaterialTheme.colorScheme.gitModified
+            }
+        return listOf(
+            FileProperty(
+                label = stringResource(strings.git_status),
+                value = gitStatus,
+                valueColor = color,
+            )
+        )
+    }
+}
+
+object GitFileDecorationProvider : FileDecorationProvider {
+    @Composable
+    override fun provideDecoration(file: FileObject): FileDecoration? {
+        if (!FeatureRegistry.isEnabled("enable_git") || !Settings.git_colorize_names) return null
+        val changeType = gitViewModel.get()?.getChangeType(file.getAbsolutePath()) ?: return null
+        val color =
+            when (changeType) {
+                ChangeType.ADDED,
+                ChangeType.UNTRACKED -> MaterialTheme.colorScheme.gitAdded
+                ChangeType.DELETED -> MaterialTheme.colorScheme.gitDeleted
+                ChangeType.CONFLICTING -> MaterialTheme.colorScheme.gitConflicted
+                ChangeType.MODIFIED -> MaterialTheme.colorScheme.gitModified
+                ChangeType.RENAMED -> MaterialTheme.colorScheme.gitModified
+            }
+        return FileDecoration(color = color)
     }
 }

--- a/features/git/src/main/java/com/rk/git/GitViewModel.kt
+++ b/features/git/src/main/java/com/rk/git/GitViewModel.kt
@@ -6,12 +6,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.rk.DefaultScope
+import com.rk.events.Events
+import com.rk.feature.FeatureRegistry
+import com.rk.file.FileWrapper
 import com.rk.resources.strings
 import com.rk.settings.Settings
-import com.rk.feature.FeatureRegistry
-import com.rk.git.findGitRoot
 import com.rk.utils.toast
-import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -27,6 +28,7 @@ import org.eclipse.jgit.lib.SubmoduleConfig.FetchRecurseSubmodulesMode
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
+import java.io.File
 
 class GitViewModel : ViewModel() {
     var currentRoot = mutableStateOf<File?>(null)
@@ -148,6 +150,15 @@ class GitViewModel : ViewModel() {
                         .setProgressMonitor(progressCoordinator)
                         .call()
                     done = true
+                    DefaultScope.launch {
+                        Events.publish(
+                            GitEvent.RepositoryCloned(
+                                repoURL,
+                                repoBranch,
+                                FileWrapper(targetDir),
+                            )
+                        )
+                    }
                 } catch (e: TransportException) {
                     if (
                         e.message?.contains("Auth", true) == true ||
@@ -192,6 +203,12 @@ class GitViewModel : ViewModel() {
                     }
                     withContext(Dispatchers.Main) { currentBranch = git.repository.branch }
                 }
+                Events.publish(
+                    GitEvent.BranchCheckedOut(
+                        root = FileWrapper(currentRoot.value!!),
+                        name = branchName,
+                    )
+                )
             } catch (e: Exception) {
                 toast(e.message)
             } finally {
@@ -232,6 +249,11 @@ class GitViewModel : ViewModel() {
                         toast(errorMessage)
                     }
                 }
+                GitEvent.PullCompleted(
+                    root = FileWrapper(currentRoot.value!!),
+                    remote = GIT_ORIGIN,
+                    branch = currentBranch,
+                )
             } catch (e: TransportException) {
                 if (
                     e.message?.contains("Auth", true) == true ||
@@ -274,6 +296,13 @@ class GitViewModel : ViewModel() {
                         .setRemoveDeletedRefs(true)
                         .call()
                 }
+                Events.publish(
+                    GitEvent.FetchCompleted(
+                        root = FileWrapper(currentRoot.value!!),
+                        remote = GIT_ORIGIN,
+                        branch = currentBranch,
+                    )
+                )
             } catch (e: TransportException) {
                 if (
                     e.message?.contains("Auth", true) == true ||
@@ -348,6 +377,9 @@ class GitViewModel : ViewModel() {
                         newChanges
                     }
                 changes[gitRoot] = mergedChanges
+                viewModelScope.launch {
+                    Events.publish(GitEvent.WorkingTreeUpdated(FileWrapper(root), mergedChanges))
+                }
             } catch (e: Exception) {
                 toast(e.message)
             } finally {
@@ -360,8 +392,12 @@ class GitViewModel : ViewModel() {
         return viewModelScope.launch(Dispatchers.IO) {
             withContext(Dispatchers.Main) { isLoading = true }
             try {
-                Git.open(currentRoot.value).use { git ->
-                    changes[currentRoot.value!!.absolutePath]!!
+                val currentRoot = currentRoot.value!!
+                val message = commitMessages[currentRoot.absolutePath]
+                val amend = amends[currentRoot.absolutePath] ?: false
+
+                Git.open(currentRoot).use { git ->
+                    changes[currentRoot.absolutePath]!!
                         .filter { it.isChecked }
                         .forEach { change ->
                             when (change.type) {
@@ -375,10 +411,25 @@ class GitViewModel : ViewModel() {
                     git.commit()
                         .setAuthor(Settings.git_name, Settings.git_email)
                         .setCommitter(Settings.git_name, Settings.git_email)
-                        .setMessage(commitMessages[currentRoot.value!!.absolutePath])
-                        .setAmend(amends[currentRoot.value!!.absolutePath]!!)
+                        .setMessage(message)
+                        .setAmend(amend)
                         .call()
                     toast(strings.commit_complete)
+                }
+                if (amend) {
+                    Events.publish(
+                        GitEvent.CommitAmended(
+                            root = FileWrapper(currentRoot),
+                            message = message.orEmpty(),
+                        )
+                    )
+                } else {
+                    Events.publish(
+                        GitEvent.CommitCreated(
+                            root = FileWrapper(currentRoot),
+                            message = message.orEmpty(),
+                        )
+                    )
                 }
             } catch (e: Exception) {
                 toast(e.message)
@@ -449,6 +500,14 @@ class GitViewModel : ViewModel() {
                         toast(strings.push_complete)
                     }
                 }
+                Events.publish(
+                    GitEvent.PushCompleted(
+                        root = FileWrapper(currentRoot.value!!),
+                        remote = GIT_ORIGIN,
+                        branch = currentBranch,
+                        force = force,
+                    )
+                )
             } catch (e: TransportException) {
                 if (
                     e.message?.contains("Auth", true) == true ||
@@ -483,6 +542,7 @@ class GitViewModel : ViewModel() {
                     }
                     toast(strings.checkout_complete)
                 }
+                Events.publish(GitEvent.BranchCreated(FileWrapper(currentRoot.value!!), branchName, branchBase))
             } catch (e: Exception) {
                 toast(e.message)
             } finally {

--- a/features/runner/src/main/java/com/rk/commands/editor/RunCommand.kt
+++ b/features/runner/src/main/java/com/rk/commands/editor/RunCommand.kt
@@ -1,7 +1,6 @@
 package com.rk.commands.editor
 
 import android.view.KeyEvent
-import com.rk.DefaultScope
 import com.rk.commands.CommandProvider
 import com.rk.commands.EditorActionContext
 import com.rk.commands.EditorCommand
@@ -12,10 +11,9 @@ import com.rk.resources.drawables
 import com.rk.resources.getString
 import com.rk.resources.strings
 import com.rk.runner.RunnerManager
+import com.rk.runner.RunnerUI
 import com.rk.settings.Settings
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.launch
-import com.rk.runner.RunnerUI
 
 @OptIn(DelicateCoroutinesApi::class)
 class RunCommand : EditorCommand() {
@@ -27,17 +25,15 @@ class RunCommand : EditorCommand() {
         val editorTab = editorActionContext.editorTab
         val activity = editorActionContext.currentActivity
         CommandProvider.SaveCommand.action(editorActionContext)
-        DefaultScope.launch {
-            Settings.runs += 1
-            RunnerManager.run(
-                activity = activity,
-                fileObject = editorTab.file,
-                onMultipleRunners = {
-                    RunnerUI.runnersToShow = it
-                    RunnerUI.showRunnerDialog = true
-                },
-            )
-        }
+        Settings.runs += 1
+        RunnerManager.run(
+            activity = activity,
+            fileObject = editorTab.file,
+            onMultipleRunners = {
+                RunnerUI.runnersToShow = it
+                RunnerUI.showRunnerDialog = true
+            },
+        )
     }
 
     override fun isSupported(editorNonActionContext: EditorNonActionContext): Boolean {

--- a/features/runner/src/main/java/com/rk/runner/Runner.kt
+++ b/features/runner/src/main/java/com/rk/runner/Runner.kt
@@ -1,0 +1,32 @@
+package com.rk.runner
+
+import android.app.Activity
+import android.content.Context
+import com.rk.file.FileObject
+import com.rk.icons.Icon
+import com.rk.settings.Preference
+
+abstract class Runner {
+    abstract val id: String
+    abstract val label: String
+    open val description: String? = null
+    open val onConfigure: (() -> Unit)? = null
+
+    abstract fun getIcon(context: Context): Icon?
+
+    abstract fun matcher(fileObject: FileObject): Boolean
+
+    abstract suspend fun run(activity: Activity, fileObject: FileObject)
+
+    abstract suspend fun isRunning(): Boolean
+
+    abstract suspend fun stop()
+
+    fun isEnabled(): Boolean {
+        return Preference.getBoolean("runner_$id", true)
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        Preference.setBoolean("runner_$id", enabled)
+    }
+}

--- a/features/runner/src/main/java/com/rk/runner/RunnerEvent.kt
+++ b/features/runner/src/main/java/com/rk/runner/RunnerEvent.kt
@@ -1,0 +1,8 @@
+package com.rk.runner
+
+import com.rk.events.Event
+
+sealed interface RunnerEvent : Event {
+
+    data class RunnerRun(val runner: Runner) : RunnerEvent
+}

--- a/features/runner/src/main/java/com/rk/runner/RunnerFeature.kt
+++ b/features/runner/src/main/java/com/rk/runner/RunnerFeature.kt
@@ -1,34 +1,37 @@
 package com.rk.runner
 
 import android.app.Application
+import com.rk.activities.settings.SettingsRoutes
 import com.rk.commands.CommandProvider
 import com.rk.commands.editor.RunCommand
-import com.rk.feature.Feature
-import com.rk.feature.SettingsRegistry
-import com.rk.feature.SettingsCategory
-import com.rk.feature.SettingsRoute
-import com.rk.activities.settings.SettingsRoutes
+import com.rk.components.DialogProvider
 import com.rk.components.DialogRegistry
+import com.rk.feature.Feature
 import com.rk.resources.drawables
 import com.rk.resources.strings
-import com.rk.settings.runners.RunnerSettings
+import com.rk.settings.SettingsCategory
+import com.rk.settings.SettingsRegistry
+import com.rk.settings.SettingsRoute
 import com.rk.settings.runners.HtmlRunnerSettings
+import com.rk.settings.runners.RunnerSettings
 
 class RunnerFeature : Feature {
     override fun init(application: Application) {
         // Register RunnerSheet overlay
-        DialogRegistry.dialogs.add {
-            if (RunnerUI.showRunnerDialog) {
-                RunnerSheet()
+        DialogRegistry.register(
+            DialogProvider {
+                if (RunnerUI.showRunnerDialog) {
+                    RunnerSheet()
+                }
             }
-        }
+        )
         // Register settings category
         SettingsRegistry.registerCategory(
             SettingsCategory(
                 labelRes = strings.runners,
                 descriptionRes = strings.runners_desc,
                 iconRes = drawables.run,
-                route = SettingsRoutes.Runners.route
+                route = SettingsRoutes.Runners.route,
             )
         )
 

--- a/features/runner/src/main/java/com/rk/runner/RunnerManager.kt
+++ b/features/runner/src/main/java/com/rk/runner/RunnerManager.kt
@@ -2,40 +2,16 @@ package com.rk.runner
 
 import android.app.Activity
 import android.content.Context
-import kotlinx.coroutines.launch
 import androidx.compose.runtime.mutableStateListOf
+import com.rk.DefaultScope
+import com.rk.events.Events
 import com.rk.extension.api.XedExtensionPoint
 import com.rk.file.FileObject
 import com.rk.icons.Icon
 import com.rk.runner.runners.web.html.HtmlRunner
 import com.rk.runner.runners.web.markdown.MarkdownRunner
-import com.rk.settings.Preference
 import com.rk.utils.errorDialog
-
-abstract class Runner {
-    abstract val id: String
-    abstract val label: String
-    open val description: String? = null
-    open val onConfigure: (() -> Unit)? = null
-
-    abstract fun getIcon(context: Context): Icon?
-
-    abstract fun matcher(fileObject: FileObject): Boolean
-
-    abstract suspend fun run(activity: Activity, fileObject: FileObject)
-
-    abstract suspend fun isRunning(): Boolean
-
-    abstract suspend fun stop()
-
-    fun isEnabled(): Boolean {
-        return Preference.getBoolean("runner_$id", true)
-    }
-
-    fun setEnabled(enabled: Boolean) {
-        Preference.setBoolean("runner_$id", enabled)
-    }
-}
+import kotlinx.coroutines.launch
 
 object RunnerManager {
 
@@ -75,7 +51,7 @@ object RunnerManager {
         return result
     }
 
-    suspend fun run(activity: Activity, fileObject: FileObject, onMultipleRunners: (List<RunnableOption>) -> Unit) {
+    fun run(activity: Activity, fileObject: FileObject, onMultipleRunners: (List<RunnableOption>) -> Unit) {
         val availableRunners = getAvailableRunners(fileObject)
 
         if (availableRunners.isEmpty()) {
@@ -84,15 +60,21 @@ object RunnerManager {
         }
 
         if (availableRunners.size == 1) {
-            availableRunners[0].run(activity, fileObject)
+            DefaultScope.launch {
+                availableRunners.first().run(activity, fileObject)
+                Events.publish(RunnerEvent.RunnerRun(availableRunners.first()))
+            }
         } else {
             val options = availableRunners.map { runner ->
                 object : RunnableOption {
                     override val label: String = runner.label
+
                     override fun getIcon(context: Context): Icon? = runner.getIcon(context)
+
                     override fun run(activity: Activity) {
-                        com.rk.DefaultScope.launch {
+                        DefaultScope.launch {
                             runner.run(activity, fileObject)
+                            Events.publish(RunnerEvent.RunnerRun(runner))
                         }
                     }
                 }

--- a/features/terminal/src/main/java/com/rk/TerminalFeature.kt
+++ b/features/terminal/src/main/java/com/rk/TerminalFeature.kt
@@ -15,9 +15,6 @@ import com.rk.exec.ubuntuProcess
 import com.rk.feature.Feature
 import com.rk.feature.FeatureRegistry
 import com.rk.feature.FeatureToggle
-import com.rk.feature.SettingsCategory
-import com.rk.feature.SettingsRegistry
-import com.rk.feature.SettingsRoute
 import com.rk.file.FileObject
 import com.rk.file.FileWrapper
 import com.rk.file.sandboxHomeDir
@@ -41,6 +38,9 @@ import com.rk.resources.strings
 import com.rk.runner.RunnerManager
 import com.rk.runner.runners.UniversalRunner
 import com.rk.settings.Settings
+import com.rk.settings.SettingsCategory
+import com.rk.settings.SettingsRegistry
+import com.rk.settings.SettingsRoute
 import com.rk.settings.editor.TerminalFontScreen
 import com.rk.settings.terminal.SettingsTerminalScreen
 import com.rk.settings.terminal.TerminalCheckScreen
@@ -73,11 +73,11 @@ class TerminalFeature : Feature {
         )
 
         if (FeatureRegistry.isEnabled("feature_terminal")) {
-            AddProjectRegistry.options.add(
+            AddProjectRegistry.register(
                 AddProjectOption(
                     icon = Icon.ResourceIcon(drawables.terminal),
-                    titleRes = strings.terminal_home,
-                    descriptionRes = strings.terminal_home_desc,
+                    title = strings.terminal_home.getString(),
+                    description = strings.terminal_home_desc.getString(),
                     onClick = { onDismiss ->
                         if (!Settings.has_shown_terminal_dir_warning) {
                             dialogRes(


### PR DESCRIPTION
## Changes
- replace direct registry mutations with register/unregister APIs
- move settings registry out of feature package into settings module
- add centralized event bus for file, tab, drawer, and theme events
- migrate file change notifications to typed events
- refactor providers for decorations and properties into extensible registries
- update features to use new dialog, service tab, and project option registries
- fix extension settings navigation route handling
- clean up imports and formatting across affected files
- add editor, LSP, runner, app, and extension lifecycle events
- publish events for file, editor, runner, theme, language, and icon pack actions
- add listener error handling to prevent event dispatch failures
- improve extension crash state management and re-enable support
- emit log and LSP status events for observers
- allow trailing commas in JSON parsers
- refactor runner API and extension management
- document events with KDocs