### PR TITLE
feat: add property delegate support to extension settings

### DIFF
--- a/core/main/src/main/java/com/rk/settings/Settings.kt
+++ b/core/main/src/main/java/com/rk/settings/Settings.kt
@@ -427,8 +427,14 @@ object Preference {
     }
 }
 
+class CachedExtensionPreference<T>(
+    id: String,
+    key: String,
+    defaultValue: T,
+) : CachedPreference<T>("$id.$key", defaultValue)
+
 @Suppress("UNCHECKED_CAST")
-class CachedPreference<T>(val key: String, val defaultValue: T) : ReadWriteProperty<Any?, T> {
+open class CachedPreference<T>(val key: String, val defaultValue: T) : ReadWriteProperty<Any?, T> {
     private var state by mutableStateOf(loadInitialValue())
 
     init {

--- a/features/extensions/src/main/java/com/rk/extension/api/ExtensionSettings.kt
+++ b/features/extensions/src/main/java/com/rk/extension/api/ExtensionSettings.kt
@@ -1,7 +1,9 @@
 // DO NOT UPDATE PACKAGE NAME OTHERWISE EXTENSIONS WILL BREAK
 package com.rk.extension
 
+import com.rk.settings.CachedExtensionPreference
 import com.rk.settings.Preference
+import kotlin.properties.ReadWriteProperty
 
 interface ExtensionSettings {
     fun getString(key: String, default: String): String?
@@ -15,6 +17,8 @@ interface ExtensionSettings {
     fun putBoolean(key: String, value: Boolean)
 
     fun putInt(key: String, value: Int)
+
+    fun <T> delegate(key: String, defaultValue: T): ReadWriteProperty<Any?, T>
 }
 
 class SharedPrefExtensionSettings(private val id: String) : ExtensionSettings {
@@ -29,4 +33,11 @@ class SharedPrefExtensionSettings(private val id: String) : ExtensionSettings {
     override fun putBoolean(key: String, value: Boolean) = Preference.setBoolean("$id.$key", value)
 
     override fun putInt(key: String, value: Int) = Preference.setInt("$id.$key", value)
+
+    override fun <T> delegate(
+        key: String,
+        defaultValue: T,
+    ): ReadWriteProperty<Any?, T> {
+        return CachedExtensionPreference(id, key, defaultValue)
+    }
 }


### PR DESCRIPTION
Usage in extension:
```kt
var mySetting by context.settings.delegate("mySetting", true)
```

instead of boilerplate logic:

```kt
val mySettingKey = "mySetting"
val mySetting by remember { mutableStateOf(context.settings.getBoolean(mySettingKey)) }

mySetting = /* ... */
context.settings.putBoolean(mySettingsKey, /* ... */)
```