### PR TITLE
refactor: improve PreferenceList and add VIBRATE permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission
         android:name="android.permission.READ_PHONE_STATE"
         tools:node="remove" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <queries>
         <package android:name="com.github.android" />
@@ -44,8 +45,6 @@
         <profileable
             android:shell="true"
             tools:targetApi="29" />
-
-
 
         <activity
             android:name="com.rk.activities.main.MainActivity"

--- a/core/main/src/main/java/com/rk/components/PreferenceList.kt
+++ b/core/main/src/main/java/com/rk/components/PreferenceList.kt
@@ -1,16 +1,12 @@
 package com.rk.components
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,7 +14,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
 import com.rk.components.compose.preferences.base.PreferenceTemplate
 import com.rk.resources.getString
 import com.rk.resources.strings
@@ -35,21 +30,15 @@ fun <T> PreferenceList(
     enabled: Boolean = true,
 ) {
     var showDialog by remember { mutableStateOf(false) }
-    val interactionSource = remember { MutableInteractionSource() }
 
-    PreferenceTemplate(
-        modifier =
-            modifier.clickable(
-                enabled = enabled,
-                indication = ripple(),
-                interactionSource = interactionSource,
-                onClick = { showDialog = true },
-            ),
-        contentModifier = Modifier.fillMaxHeight().padding(vertical = 16.dp).padding(start = 16.dp),
-        title = { Text(text = label) },
-        description = { description?.let { Text(text = it) } },
-        enabled = enabled,
-        applyPaddings = false,
+    SettingsItem(
+        modifier = modifier,
+        onClick = { showDialog = true },
+        label = label,
+        description = description,
+        isEnabled = enabled,
+        default = false,
+        showSwitch = false,
     )
 
     if (showDialog) {


### PR DESCRIPTION
Whilst the vibrate permission is currently not used inside of the core application, it might be used by extensions.