### PR TITLE
fix: only intercept editor keybinding letters when Ctrl is pressed

### DIFF
--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
@@ -229,20 +229,22 @@ fun Editor.registerXedEvents(
 
         val keyCode = event.keyCode
         val shouldBeIntercepted =
-            keyCode == KeyEvent.KEYCODE_A ||
-                keyCode == KeyEvent.KEYCODE_C ||
-                keyCode == KeyEvent.KEYCODE_X ||
-                keyCode == KeyEvent.KEYCODE_V ||
-                keyCode == KeyEvent.KEYCODE_U ||
-                keyCode == KeyEvent.KEYCODE_R ||
-                keyCode == KeyEvent.KEYCODE_D ||
-                keyCode == KeyEvent.KEYCODE_W ||
-                keyCode == KeyEvent.KEYCODE_Y ||
-                keyCode == KeyEvent.KEYCODE_Z ||
-                keyCode == KeyEvent.KEYCODE_J
+            event.isCtrlPressed &&
+                (keyCode == KeyEvent.KEYCODE_A ||
+                    keyCode == KeyEvent.KEYCODE_C ||
+                    keyCode == KeyEvent.KEYCODE_X ||
+                    keyCode == KeyEvent.KEYCODE_V ||
+                    keyCode == KeyEvent.KEYCODE_U ||
+                    keyCode == KeyEvent.KEYCODE_R ||
+                    keyCode == KeyEvent.KEYCODE_D ||
+                    keyCode == KeyEvent.KEYCODE_W ||
+                    keyCode == KeyEvent.KEYCODE_Y ||
+                    keyCode == KeyEvent.KEYCODE_Z ||
+                    keyCode == KeyEvent.KEYCODE_J)
         if (shouldBeIntercepted) event.markAsConsumed()
 
-        KeybindingsManager.handleEditorEvent(event, MainActivity.instance!!)
+        val wasHandled = KeybindingsManager.handleEditorEvent(event, MainActivity.instance!!)
+        if (wasHandled) event.markAsConsumed()
     }
 }
 


### PR DESCRIPTION
## Summary

Capital letters typed with Shift on a hardware (Bluetooth) keyboard insert normally again. `registerXedEvents` in `core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt` consumed every `KeyBindingEvent` whose key code was one of A/C/X/V/U/R/D/W/Y/Z/J — but sora-editor dispatches that event for any modifier, including Shift alone, so typing a capital W was swallowed as if it were the Ctrl+W keybind and no character was inserted. The interception is now gated on `event.isCtrlPressed`, so Shift-only and Alt-only key presses fall through to normal text input.

## Why this matters

The reporter in #1492 could not type the capital letters A, C, D, J, R, U, V, W, X, Y, or Z at all with an external keyboard — exactly the eleven letters in the hardcoded intercept list, which is what pointed at this block as the root cause. The fix also uses the Boolean that `KeybindingsManager.handleEditorEvent` already returns (`core/main/src/main/java/com/rk/commands/KeybindingsManager.kt:180`) to mark the event consumed when a custom keybinding actually handled it, so user-remapped non-Ctrl combos still suppress default insertion instead of double-typing.

## Testing

The touched module has no test source set, so verification was done by tracing the event flow: `isCtrlPressed` is the same accessor `KeybindingsManager` already reads for its keybind matching, and `handleEditorEvent` returns `true` only when a binding ran. Shift+letter now takes the un-intercepted path into sora-editor's default text insertion; Ctrl+letter keeps the existing intercept behavior.

Closes #1492
