### PR TITLE
fix: #1536

### DIFF
--- a/core/main/src/main/java/com/rk/drawer/DrawerPersistence.kt
+++ b/core/main/src/main/java/com/rk/drawer/DrawerPersistence.kt
@@ -28,8 +28,9 @@ object DrawerPersistence {
             file.writeObject(serializableList)
 
             val currentTabFile = FileWrapper(application!!.filesDir.child(CURRENT_DRAWER_TAB))
-            if (viewModel.currentDrawerTab != null) {
-                currentTabFile.writeObject(viewModel.currentDrawerTab!!)
+            val currentTab = viewModel.currentDrawerTab
+            if (currentTab != null) {
+                currentTabFile.writeObject(currentTab)
             } else {
                 currentTabFile.delete()
             }


### PR DESCRIPTION
### Issue:

After null check of `viewModel.currentDrawerTab`, before `currentTabFile.writeObject(viewModel.currentDrawerTab!!)` is being executed, some other routine makes `viewModel.currentDrawerTab` null.

### Solution:

Storing `viewModel.currentDrawerTab` in a separate variable, null checking it which makes it 100% null-safe and using it.