### PR TITLE
feat: implement extension activites/routes & Git diff + discard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,5 +94,8 @@
             android:name="com.rk.activities.main.ProjectCreatorActivity"
             android:exported="false"
             android:windowSoftInputMode="adjustResize" />
+        <activity
+            android:name="com.rk.extension.api.ExtensionActivity"
+            android:exported="false" />
     </application>
 </manifest>

--- a/core/main/src/main/assets/textmate/darcula.json
+++ b/core/main/src/main/assets/textmate/darcula.json
@@ -477,6 +477,61 @@
       "settings": {
         "foreground": "#FFC66D"
       }
+    },
+    {
+      "name": "Extra: Diff Range",
+      "scope": [
+        "meta.diff.range",
+        "meta.diff.index",
+        "meta.separator"
+      ],
+      "settings": {
+        "foreground": "#8A8A8A"
+      }
+    },
+    {
+      "name": "Extra: Diff From",
+      "scope": [
+        "meta.diff.header.from-file",
+        "punctuation.definition.from-file.diff"
+      ],
+      "settings": {
+        "foreground": "#7A9EC2"
+      }
+    },
+    {
+      "name": "Extra: Diff To",
+      "scope": [
+        "meta.diff.header.to-file",
+        "punctuation.definition.to-file.diff"
+      ],
+      "settings": {
+        "foreground": "#7A9EC2"
+      }
+    },
+    {
+      "name": "Diff: deleted",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#F16D7A",
+        "background": "#40252B"
+      }
+    },
+    {
+      "name": "Diff: changed",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#E6B450",
+        "background": "#45371F"
+      }
+    },
+    {
+      "name": "Diff: inserted",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#7EC77B",
+        "background": "#243A28"
+      }
     }
   ]
 }

--- a/core/main/src/main/assets/textmate/quietlight.json
+++ b/core/main/src/main/assets/textmate/quietlight.json
@@ -417,7 +417,7 @@
         "meta.separator"
       ],
       "settings": {
-        "foreground": "#434343"
+        "foreground": "#666666"
       }
     },
     {
@@ -427,7 +427,7 @@
         "punctuation.definition.from-file.diff"
       ],
       "settings": {
-        "foreground": "#4B69C6"
+        "foreground": "#4F73D9"
       }
     },
     {
@@ -437,28 +437,31 @@
         "punctuation.definition.to-file.diff"
       ],
       "settings": {
-        "foreground": "#4B69C6"
+        "foreground": "#4F73D9"
       }
     },
     {
-      "name": "diff: deleted",
+      "name": "Diff: deleted",
       "scope": "markup.deleted.diff",
       "settings": {
-        "foreground": "#C73D20"
+        "foreground": "#A92F1B",
+        "background": "#F5D8D2"
       }
     },
     {
-      "name": "diff: changed",
+      "name": "Diff: changed",
       "scope": "markup.changed.diff",
       "settings": {
-        "foreground": "#9C5D27"
+        "foreground": "#86521F",
+        "background": "#F1E3D2"
       }
     },
     {
-      "name": "diff: inserted",
+      "name": "Diff: inserted",
       "scope": "markup.inserted.diff",
       "settings": {
-        "foreground": "#448C27"
+        "foreground": "#2F661F",
+        "background": "#DDEED7"
       }
     },
     {

--- a/core/main/src/main/java/com/rk/activities/main/EditorManager.kt
+++ b/core/main/src/main/java/com/rk/activities/main/EditorManager.kt
@@ -10,6 +10,7 @@ import com.rk.tabs.editor.EditorTab
 import com.rk.utils.dialogRes
 import com.rk.utils.expectOOM
 import io.github.rosemoe.sora.event.SelectionChangeEvent
+import io.github.rosemoe.sora.text.Content
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -25,6 +26,7 @@ class EditorManager(private val viewModel: MainViewModel) {
         isReadOnly: Boolean = false,
         customTitle: String? = null,
         fallbackExtension: String = "txt",
+        initialContent: String? = null,
     ): EditorTab {
         return EditorTab(
             file = file,
@@ -33,6 +35,7 @@ class EditorManager(private val viewModel: MainViewModel) {
             isReadOnly = isReadOnly,
             customTitle = customTitle,
             fallbackExtension = fallbackExtension,
+            initialContent = initialContent?.let { Content(it) },
         )
     }
 
@@ -44,8 +47,9 @@ class EditorManager(private val viewModel: MainViewModel) {
         isReadOnly: Boolean = false,
         customTitle: String? = null,
         fallbackExtension: String = "txt",
+        initialContent: String? = null,
     ) {
-        val editorTab = createEditorTab(file, projectRoot, isReadOnly, customTitle, fallbackExtension)
+        val editorTab = createEditorTab(file, projectRoot, isReadOnly, customTitle, fallbackExtension, initialContent)
         viewModel.tabManager.addTab(editorTab, switchToTab, checkDuplicate)
     }
 
@@ -103,14 +107,21 @@ class EditorManager(private val viewModel: MainViewModel) {
 
     fun addPreviewTab(title: String, content: String, extension: String = "txt", isReadOnly: Boolean = true) {
         val editorTab =
-            createEditorTab(file = null, customTitle = title, fallbackExtension = extension, isReadOnly = isReadOnly)
+            createEditorTab(
+                file = null,
+                customTitle = title,
+                fallbackExtension = extension,
+                isReadOnly = isReadOnly,
+                initialContent = content,
+            )
+
         viewModel.tabManager.addTab(editorTab, switchToTab = true)
-        viewModel.viewModelScope.launch {
-            editorTab.editorState.contentLoaded.await()
-            withContext(Dispatchers.Main) {
-                editorTab.editorState.editor.get()?.setText(content)
-                editorTab.editorState.isDirty = false
-            }
-        }
+        //        viewModel.viewModelScope.launch {
+        //            editorTab.editorState.contentRendered.await()
+        //            withContext(Dispatchers.Main) {
+        //                editorTab.editorState.editor.get()?.setText(content)
+        //                editorTab.editorState.isDirty = false
+        //            }
+        //        }
     }
 }

--- a/core/main/src/main/java/com/rk/activities/main/EditorManager.kt
+++ b/core/main/src/main/java/com/rk/activities/main/EditorManager.kt
@@ -116,12 +116,5 @@ class EditorManager(private val viewModel: MainViewModel) {
             )
 
         viewModel.tabManager.addTab(editorTab, switchToTab = true)
-        //        viewModel.viewModelScope.launch {
-        //            editorTab.editorState.contentRendered.await()
-        //            withContext(Dispatchers.Main) {
-        //                editorTab.editorState.editor.get()?.setText(content)
-        //                editorTab.editorState.isDirty = false
-        //            }
-        //        }
     }
 }

--- a/core/main/src/main/java/com/rk/activities/main/MainActivity.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainActivity.kt
@@ -155,6 +155,12 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
                 composable(MainRoutes.Disclaimer.route) { DisclaimerScreen(navController) { finishAffinity() } }
+
+                MainRouteRegistry.routes.forEach { customRoute ->
+                    composable(customRoute.route, arguments = customRoute.arguments) { backStackEntry ->
+                        customRoute.content(navController, backStackEntry)
+                    }
+                }
             }
         }
     }

--- a/core/main/src/main/java/com/rk/activities/main/MainContent.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainContent.kt
@@ -137,7 +137,7 @@ fun MainContent(
                     divider = {},
                 ) {
                     mainViewModel.tabs.forEachIndexed { index, tabState ->
-                        key(tabState) {
+                        key(tabState.id) {
                             TabItem(
                                 mainViewModel = mainViewModel,
                                 fileTreeViewModel = fileTreeViewModel,
@@ -210,7 +210,7 @@ fun MainContent(
                 modifier = Modifier.fillMaxSize().clipToBounds(),
                 beyondViewportPageCount = mainViewModel.tabs.size,
                 userScrollEnabled = false,
-                key = { mainViewModel.tabs.getOrNull(it).hashCode() },
+                key = { mainViewModel.tabs.getOrNull(it)?.id ?: "" },
             ) { page ->
                 if (page < mainViewModel.tabs.size) {
                     mainViewModel.tabs[page].Content()

--- a/core/main/src/main/java/com/rk/activities/main/MainRouteRegistry.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainRouteRegistry.kt
@@ -1,0 +1,21 @@
+package com.rk.activities.main
+
+import androidx.compose.runtime.mutableStateListOf
+import com.rk.extension.api.DynamicRoute
+import com.rk.extension.api.XedExtensionPoint
+
+object MainRouteRegistry {
+    private val _routes = mutableStateListOf<DynamicRoute>()
+    val routes: List<DynamicRoute>
+        get() = _routes.toList()
+
+    @XedExtensionPoint
+    fun registerRoute(route: DynamicRoute) {
+        _routes.add(route)
+    }
+
+    @XedExtensionPoint
+    fun unregisterRoute(route: DynamicRoute) {
+        _routes.remove(route)
+    }
+}

--- a/core/main/src/main/java/com/rk/activities/main/TabManager.kt
+++ b/core/main/src/main/java/com/rk/activities/main/TabManager.kt
@@ -27,8 +27,8 @@ class TabManager {
 
     fun addTab(tab: Tab, switchToTab: Boolean, checkDuplicate: Boolean = true) {
         val duplicateIndex =
-            if (checkDuplicate && tab.file != null) {
-                _tabs.indexOfFirst { it.file == tab.file }
+            if (checkDuplicate) {
+                _tabs.indexOfFirst { it == tab }
             } else -1
 
         if (duplicateIndex != -1) {

--- a/core/main/src/main/java/com/rk/activities/main/TabState.kt
+++ b/core/main/src/main/java/com/rk/activities/main/TabState.kt
@@ -17,7 +17,8 @@ data class EditorTabState(
     val cursor: EditorCursorState,
     val scrollX: Int,
     val scrollY: Int,
-    val unsavedContent: String?,
+    val content: String?,
+    val isDirty: Boolean = false,
     val isReadOnly: Boolean = false,
     val customTitle: String? = null,
     val fallbackExtension: String = "txt",
@@ -25,17 +26,22 @@ data class EditorTabState(
     override suspend fun toTab(): Tab? {
         if (fileObject != null && !fileObject.exists() && !fileObject.canRead()) return null
 
-        MainActivity.instance!!.viewModel.apply {
+        return MainActivity.instance?.viewModel?.run {
             val editorTab =
-                editorManager.createEditorTab(fileObject, projectRoot, isReadOnly, customTitle, fallbackExtension)
+                editorManager.createEditorTab(
+                    file = fileObject,
+                    projectRoot = projectRoot,
+                    isReadOnly = isReadOnly,
+                    customTitle = customTitle,
+                    fallbackExtension = fallbackExtension,
+                    initialContent = content,
+                )
 
             viewModelScope.launch {
                 editorTab.editorState.contentRendered.await()
                 val editor = editorTab.editorState.editor.get()!!
-                unsavedContent?.let {
-                    editorTab.editorState.isDirty = true
-                    editor.setText(it)
-                }
+
+                editorTab.editorState.isDirty = isDirty
 
                 val maxLine = editor.text.lineCount - 1
                 val lineLeft = cursor.lineLeft.coerceAtMost(maxLine)
@@ -50,7 +56,7 @@ data class EditorTabState(
                 editor.scroller.startScroll(scrollX, scrollY, 0, 0)
             }
 
-            return editorTab
+            editorTab
         }
     }
 }

--- a/core/main/src/main/java/com/rk/commands/editor/ReplaceCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/editor/ReplaceCommand.kt
@@ -4,6 +4,7 @@ import android.view.KeyEvent
 import androidx.compose.ui.text.TextRange
 import com.rk.commands.EditorActionContext
 import com.rk.commands.EditorCommand
+import com.rk.commands.EditorNonActionContext
 import com.rk.commands.KeyCombination
 import com.rk.icons.Icon
 import com.rk.resources.drawables
@@ -23,6 +24,10 @@ class ReplaceCommand : EditorCommand() {
             isSearching = true
             isReplaceShown = true
         }
+    }
+
+    override fun isEnabled(context: EditorNonActionContext): Boolean {
+        return context.editorTab.editorState.editable
     }
 
     override fun getIcon(): Icon = Icon.ResourceIcon(drawables.find_replace)

--- a/core/main/src/main/java/com/rk/components/DialogRegistry.kt
+++ b/core/main/src/main/java/com/rk/components/DialogRegistry.kt
@@ -2,7 +2,9 @@ package com.rk.components
 
 import androidx.compose.runtime.Composable
 
-data class DialogProvider(val content: @Composable () -> Unit)
+fun interface DialogProvider {
+    @Composable fun Content()
+}
 
 object DialogRegistry {
 
@@ -18,6 +20,6 @@ object DialogRegistry {
 
     @Composable
     fun getDialogs(): List<@Composable () -> Unit> {
-        return providers.map { { it.content() } }
+        return providers.map { { it.Content() } }
     }
 }

--- a/core/main/src/main/java/com/rk/extension/api/DynamicRoute.kt
+++ b/core/main/src/main/java/com/rk/extension/api/DynamicRoute.kt
@@ -1,0 +1,13 @@
+package com.rk.extension.api
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+
+@XedExtensionPoint
+data class DynamicRoute(
+    val route: String,
+    val arguments: List<NamedNavArgument> = emptyList(),
+    val content: @Composable (NavController, NavBackStackEntry) -> Unit,
+)

--- a/core/main/src/main/java/com/rk/extension/api/ExtensionActivity.kt
+++ b/core/main/src/main/java/com/rk/extension/api/ExtensionActivity.kt
@@ -1,0 +1,114 @@
+// ExtensionActivity.kt
+package com.rk.extension.api
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.res.Configuration
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+
+class ExtensionActivity : ComponentActivity() {
+    private var screen: ExtensionScreen? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val id = intent.getStringExtra(EXTRA_SCREEN_ID)
+        val screen = id?.let { ExtensionActivityRegistry.getScreen(it) }
+        this.screen = screen
+
+        if (screen == null) {
+            finish()
+            return
+        }
+
+        screen.host = this
+        screen.onCreate(savedInstanceState)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        this.intent = intent
+        screen?.onNewIntent(intent)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        screen?.onStart()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        screen?.onResume()
+    }
+
+    override fun onPause() {
+        screen?.onPause()
+        super.onPause()
+    }
+
+    override fun onStop() {
+        screen?.onStop()
+        super.onStop()
+    }
+
+    override fun onRestart() {
+        super.onRestart()
+        screen?.onRestart()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        screen?.onSaveInstanceState(outState)
+    }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle) {
+        super.onRestoreInstanceState(savedInstanceState)
+        screen?.onRestoreInstanceState(savedInstanceState)
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        screen?.onConfigurationChanged(newConfig)
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        screen?.onLowMemory()
+    }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        screen?.onTrimMemory(level)
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        screen?.onWindowFocusChanged(hasFocus)
+    }
+
+    override fun onUserLeaveHint() {
+        super.onUserLeaveHint()
+        screen?.onUserLeaveHint()
+    }
+
+    override fun onDestroy() {
+        screen?.onDestroy()
+        intent.getStringExtra(EXTRA_SCREEN_ID)?.let(ExtensionActivityRegistry::unregister)
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val EXTRA_SCREEN_ID = "extension_screen_id"
+
+        fun start(context: Context, screen: ExtensionScreen) {
+            val id = ExtensionActivityRegistry.register(screen)
+            val intent = Intent(context, ExtensionActivity::class.java).putExtra(EXTRA_SCREEN_ID, id)
+            if (context !is Activity) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+        }
+    }
+}

--- a/core/main/src/main/java/com/rk/extension/api/ExtensionActivityRegistry.kt
+++ b/core/main/src/main/java/com/rk/extension/api/ExtensionActivityRegistry.kt
@@ -1,0 +1,19 @@
+package com.rk.extension.api
+
+import java.util.UUID
+
+internal object ExtensionActivityRegistry {
+    private val screens = mutableMapOf<String, ExtensionScreen>()
+
+    fun register(screen: ExtensionScreen): String {
+        val id = UUID.randomUUID().toString()
+        screens[id] = screen
+        return id
+    }
+
+    fun unregister(id: String) {
+        screens.remove(id)
+    }
+
+    fun getScreen(id: String): ExtensionScreen? = screens[id]
+}

--- a/core/main/src/main/java/com/rk/extension/api/ExtensionScreen.kt
+++ b/core/main/src/main/java/com/rk/extension/api/ExtensionScreen.kt
@@ -1,0 +1,121 @@
+package com.rk.extension.api
+
+import android.content.Intent
+import android.content.res.Configuration
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+
+@XedExtensionPoint
+abstract class ExtensionScreen {
+    /**
+     * The [ComponentActivity] that hosts this extension screen. This property provides access to the activity context
+     * and is initialized once the screen is attached to the host.
+     *
+     * @see ExtensionActivity
+     * @see isAttached
+     */
+    lateinit var host: ExtensionActivity
+        internal set
+
+    /** True once [host] has been assigned (i.e. onCreate has started). Guards early access. */
+    val isAttached: Boolean
+        get() = ::host.isInitialized
+
+    /** @see ComponentActivity.onCreate */
+    open fun onCreate(savedInstanceState: Bundle?) {}
+
+    /** @see ComponentActivity.onStart */
+    open fun onStart() {}
+
+    /** @see ComponentActivity.onResume */
+    open fun onResume() {}
+
+    /** @see ComponentActivity.onPause */
+    open fun onPause() {}
+
+    /** @see ComponentActivity.onStop */
+    open fun onStop() {}
+
+    /** @see ComponentActivity.onRestart */
+    open fun onRestart() {}
+
+    /** @see ComponentActivity.onDestroy */
+    open fun onDestroy() {}
+
+    /** @see ComponentActivity.onSaveInstanceState */
+    open fun onSaveInstanceState(outState: Bundle) {}
+
+    /** @see ComponentActivity.onRestoreInstanceState */
+    open fun onRestoreInstanceState(savedInstanceState: Bundle) {}
+
+    /** @see ComponentActivity.onNewIntent */
+    open fun onNewIntent(intent: Intent) {}
+
+    /** @see ComponentActivity.onConfigurationChanged */
+    open fun onConfigurationChanged(newConfig: Configuration) {}
+
+    /** @see ComponentActivity.onLowMemory */
+    open fun onLowMemory() {}
+
+    /** @see ComponentActivity.onTrimMemory */
+    open fun onTrimMemory(level: Int) {}
+
+    /** @see ComponentActivity.onWindowFocusChanged */
+    open fun onWindowFocusChanged(hasFocus: Boolean) {}
+
+    /** @see ComponentActivity.onUserLeaveHint */
+    open fun onUserLeaveHint() {}
+
+    /**
+     * @see ComponentActivity.getIntent
+     * @see ComponentActivity.setIntent
+     */
+    var intent: Intent
+        get() = host.intent
+        set(value) {
+            host.intent = value
+        }
+
+    /** @see ComponentActivity.lifecycleScope */
+    val lifecycleScope
+        get() = host.lifecycleScope
+
+    /** @see ComponentActivity.lifecycle */
+    val lifecycle: Lifecycle
+        get() = host.lifecycle
+
+    /**
+     * @see ComponentActivity.getTitle
+     * @see ComponentActivity.setTitle
+     */
+    var title: CharSequence
+        get() = host.title
+        set(value) {
+            host.title = value
+        }
+
+    /** @see ComponentActivity.finish */
+    fun finish() = host.finish()
+
+    /** @see ComponentActivity.setResult */
+    fun setResult(resultCode: Int, data: Intent? = null) = host.setResult(resultCode, data)
+
+    /** @see ComponentActivity.setContent */
+    fun setContent(parent: CompositionContext? = null, content: @Composable () -> Unit) {
+        host.setContent(parent, content)
+    }
+
+    /** @see ComponentActivity.registerForActivityResult */
+    fun <I, O> registerForActivityResult(
+        contract: ActivityResultContract<I, O>,
+        callback: ActivityResultCallback<O>,
+    ): ActivityResultLauncher<I> = host.registerForActivityResult(contract, callback)
+}

--- a/core/main/src/main/java/com/rk/lsp/LspRegistry.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspRegistry.kt
@@ -3,6 +3,7 @@ package com.rk.lsp
 import android.content.Context
 import androidx.compose.runtime.mutableStateListOf
 import com.rk.extension.api.XedExtensionPoint
+import org.jetbrains.annotations.ApiStatus
 
 object LspRegistry {
     private val _extensionServers = mutableStateListOf<LspServer>()
@@ -13,14 +14,18 @@ object LspRegistry {
     val externalServers: List<LspServer>
         get() = _externalServers.toList()
 
+    private val _builtInServers = mutableStateListOf<LspServer>()
+    val builtInServers: List<LspServer>
+        get() = _builtInServers.toList()
+
     private val configuration: MutableMap<LspServer, Boolean> = mutableMapOf()
 
     suspend fun updateConfiguration(context: Context) {
-      externalServers.forEach { configuration[it] = it.isInstalled(context) }
+        (builtInServers + extensionServers + externalServers).forEach { configuration[it] = it.isInstalled(context) }
     }
 
     suspend fun getConfigurationChanges(context: Context): List<LspServer> {
-        return extensionServers + externalServers.filter {
+        return (builtInServers + extensionServers + externalServers).filter {
             val isInstalled = it.isInstalled(context)
             (configuration[it] ?: false) != isInstalled
         }
@@ -43,7 +48,8 @@ object LspRegistry {
     }
 
     fun getForId(id: String): LspServer? {
-        return _externalServers.find { it.id == id }
+        return _builtInServers.find { it.id == id }
+            ?: _externalServers.find { it.id == id }
             ?: _extensionServers.find { it.id == id }
     }
 
@@ -57,5 +63,11 @@ object LspRegistry {
     @XedExtensionPoint
     fun unregisterServer(server: LspServer) {
         _extensionServers.remove(server)
+    }
+
+    @ApiStatus.Internal
+    // TODO: Temp
+    fun addBuiltInServers(vararg servers: LspServer) {
+        _builtInServers.addAll(servers)
     }
 }

--- a/core/main/src/main/java/com/rk/settings/SettingsRegistry.kt
+++ b/core/main/src/main/java/com/rk/settings/SettingsRegistry.kt
@@ -1,10 +1,8 @@
 package com.rk.settings
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
-import androidx.navigation.NamedNavArgument
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavController
+import com.rk.extension.api.DynamicRoute
+import com.rk.extension.api.XedExtensionPoint
 
 data class SettingsCategory(
     val labelRes: Int,
@@ -13,27 +11,33 @@ data class SettingsCategory(
     val route: String,
 )
 
-data class SettingsRoute(
-    val route: String,
-    val arguments: List<NamedNavArgument> = emptyList(),
-    val content: @Composable (NavController, NavBackStackEntry) -> Unit,
-)
-
 object SettingsRegistry {
 
     private val _categories = mutableStateListOf<SettingsCategory>()
     val categories: List<SettingsCategory>
         get() = _categories.toList()
 
-    private val _routes = mutableStateListOf<SettingsRoute>()
-    val routes: List<SettingsRoute>
+    private val _routes = mutableStateListOf<DynamicRoute>()
+    val routes: List<DynamicRoute>
         get() = _routes.toList()
 
+    @XedExtensionPoint
     fun registerCategory(category: SettingsCategory) {
         _categories.add(category)
     }
 
-    fun registerRoute(route: SettingsRoute) {
+    @XedExtensionPoint
+    fun unregisterCategory(category: SettingsCategory) {
+        _categories.remove(category)
+    }
+
+    @XedExtensionPoint
+    fun registerRoute(route: DynamicRoute) {
         _routes.add(route)
+    }
+
+    @XedExtensionPoint
+    fun unregisterRoute(route: DynamicRoute) {
+        _routes.remove(route)
     }
 }

--- a/core/main/src/main/java/com/rk/settings/lsp/LspSettings.kt
+++ b/core/main/src/main/java/com/rk/settings/lsp/LspSettings.kt
@@ -99,6 +99,15 @@ fun LspSettings(navController: NavController) {
     }
 
     @Composable
+    fun BuiltInServersSection(builtInServers: List<LspServer>) {
+        PreferenceGroup(heading = stringResource(strings.built_in)) {
+            builtInServers.forEach { server ->
+                key(server.id) { LspServerItem(context, scope, server, navController, refreshKey) }
+            }
+        }
+    }
+
+    @Composable
     fun ExternalServersSection() {
         PreferenceGroup(heading = stringResource(strings.external)) {
             LspRegistry.externalServers.forEachIndexed { index, server ->
@@ -159,10 +168,19 @@ fun LspSettings(navController: NavController) {
             text = stringResource(strings.info_lsp),
         )
 
-        val extensionServers = LspRegistry.extensionServers
-        if (extensionServers.isNotEmpty()) ExtensionServersSection(extensionServers)
+        val builtInServers = LspRegistry.builtInServers
+        if (builtInServers.isNotEmpty()) {
+            BuiltInServersSection(builtInServers)
+        }
 
-        if (LspRegistry.externalServers.isNotEmpty()) ExternalServersSection()
+        val extensionServers = LspRegistry.extensionServers
+        if (extensionServers.isNotEmpty()) {
+            ExtensionServersSection(extensionServers)
+        }
+
+        if (LspRegistry.externalServers.isNotEmpty()) {
+            ExternalServersSection()
+        }
 
         Spacer(modifier = Modifier.height(60.dp))
 
@@ -363,24 +381,24 @@ private fun ExternalLSPDialog(onDismiss: () -> Unit, onConfirm: (LspServer, Int)
             TextButton(
                 onClick = {
                     runCatching {
-                            var server: LspServer? = null
-                            server =
-                                when (selected) {
-                                    LspType.SOCKET ->
-                                        ExternalSocketServer(
-                                            host = dialogState.lspHost,
-                                            port = dialogState.lspPort.toInt(),
-                                            supportedExtensions = parseExtensions(dialogState.lspExtensions),
-                                        )
+                        var server: LspServer? = null
+                        server =
+                            when (selected) {
+                                LspType.SOCKET ->
+                                    ExternalSocketServer(
+                                        host = dialogState.lspHost,
+                                        port = dialogState.lspPort.toInt(),
+                                        supportedExtensions = parseExtensions(dialogState.lspExtensions),
+                                    )
 
-                                    LspType.PROCESS ->
-                                        ExternalProcessServer(
-                                            command = dialogState.lspCommand,
-                                            supportedExtensions = parseExtensions(dialogState.lspExtensions),
-                                        )
-                                }
-                            onConfirm(server, editingIndex ?: -1)
-                        }
+                                LspType.PROCESS ->
+                                    ExternalProcessServer(
+                                        command = dialogState.lspCommand,
+                                        supportedExtensions = parseExtensions(dialogState.lspExtensions),
+                                    )
+                            }
+                        onConfirm(server, editingIndex ?: -1)
+                    }
                         .onFailure { toast(it.message) }
 
                     onDismiss()

--- a/core/main/src/main/java/com/rk/tabs/base/Tab.kt
+++ b/core/main/src/main/java/com/rk/tabs/base/Tab.kt
@@ -5,8 +5,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.rk.activities.main.TabState
 import com.rk.file.FileObject
+import java.util.UUID
 
 abstract class Tab {
+    val id = UUID.randomUUID().toString()
+
     var refreshKey: Int = 0
     abstract val name: String
     abstract val icon: ImageVector

--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
@@ -365,7 +365,8 @@ private suspend fun FileObject.getExtensionServers(
     activity: Activity,
     scope: CoroutineScope,
 ): List<LspServer> {
-    val servers = LspRegistry.extensionServers.filter { server -> server.isSupported(this) }
+    val servers =
+        (LspRegistry.extensionServers + LspRegistry.builtInServers).filter { server -> server.isSupported(this) }
     return servers.filterActiveLspServers(activity, scope)
 }
 

--- a/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
@@ -54,6 +54,7 @@ import com.rk.settings.support.handleSupport
 import com.rk.tabs.base.Tab
 import com.rk.utils.errorDialog
 import com.rk.utils.hasBinaryChars
+import io.github.rosemoe.sora.text.Content
 import io.github.rosemoe.sora.text.ContentIO
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -86,6 +87,7 @@ open class EditorTab(
     isReadOnly: Boolean = false,
     private val customTitle: String? = null,
     val fallbackExtension: String = "txt",
+    initialContent: Content? = null,
 ) : Tab() {
 
     var isReadOnly: Boolean = isReadOnly
@@ -110,7 +112,7 @@ open class EditorTab(
 
     override var tabTitle by mutableStateOf(customTitle ?: file?.getName() ?: strings.temp_file.getString())
 
-    val editorState by mutableStateOf(CodeEditorState())
+    val editorState by mutableStateOf(CodeEditorState(initialContent))
 
     override fun onTabRemoved() {
         autoSaveJob?.cancel()
@@ -171,7 +173,6 @@ open class EditorTab(
                 withContext(Dispatchers.IO) {
                     runCatching {
                         editorState.content = file.getInputStream().use { ContentIO.createFrom(it, charset) }
-                        editorState.contentLoaded.complete(Unit)
 
                         if (Settings.detect_bin_files && hasBinaryChars(editorState.content.toString())) {
                             editorState.editable = false
@@ -181,6 +182,7 @@ open class EditorTab(
                         .onFailure { errorDialog(throwable = it) }
                 }
             }
+            editorState.contentLoaded.complete(Unit)
         }
     }
 
@@ -600,7 +602,13 @@ open class EditorTab(
                 ),
             scrollX = editor.scrollX,
             scrollY = editor.scrollY,
-            unsavedContent = if (editorState.isDirty) editor.text.toString() else null,
+            content =
+                when {
+                    file == null -> editor.text.toString()
+                    editorState.isDirty -> editor.text.toString()
+                    else -> null
+                },
+            isDirty = editorState.isDirty,
             isReadOnly = isReadOnly,
             customTitle = customTitle,
             fallbackExtension = fallbackExtension,

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -725,5 +725,8 @@
     <string name="template_size">Expected size: %s</string>
     <string name="description">Description</string>
     <string name="display_name">Display name</string>
+    <string name="discard_changes">Discard changes</string>
+    <string name="discard_changes_msg">Are you sure you want to discard your local changes to \'%s\'? This cannot be undone.</string>
+    <string name="discard_failed">Discard failed: %s</string>
     <string name="github_username">GitHub username</string>
 </resources>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -708,6 +708,7 @@
     <string name="dependencies_description">The following extensions are required for this extension to work.</string>
     <string name="recommendations_description">The following extensions are recommended to install alongside this extension.</string>
     <string name="project_runner">Project runner</string>
+    <string name="project_runner_desc">Runs the project using /.xed/runner.sh if the script exists.</string>
     <string name="new_project">New project</string>
     <string name="new_project_desc">Select a template</string>
     <string name="template_settings">Template settings</string>

--- a/features/extensions/src/main/java/com/rk/ExtensionFeature.kt
+++ b/features/extensions/src/main/java/com/rk/ExtensionFeature.kt
@@ -15,7 +15,7 @@ import com.rk.resources.drawables
 import com.rk.resources.strings
 import com.rk.settings.SettingsCategory
 import com.rk.settings.SettingsRegistry
-import com.rk.settings.SettingsRoute
+import com.rk.extension.api.DynamicRoute
 import com.rk.settings.extension.ExtensionDetail
 import com.rk.settings.extension.ExtensionScreen
 import com.rk.settings.extension.ExtensionSettings
@@ -57,7 +57,7 @@ class ExtensionFeature : Feature {
 
         // Register settings routes
         SettingsRegistry.registerRoute(
-            SettingsRoute(
+            DynamicRoute(
                 "${SettingsRoutes.Extensions.route}?query={query}",
                 arguments =
                     listOf(
@@ -75,14 +75,14 @@ class ExtensionFeature : Feature {
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute("${SettingsRoutes.ExtensionDetail.route}/{extensionId}") { navController, backStackEntry ->
+            DynamicRoute("${SettingsRoutes.ExtensionDetail.route}/{extensionId}") { navController, backStackEntry ->
                 val extensionId = backStackEntry.arguments?.getString("extensionId")
                 val extension = extensionId?.let { extensionManager.getExtension(it) }
                 ExtensionDetail(extension, navController)
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute("${SettingsRoutes.ExtensionSettings.route}/{extensionId}") { _, backStackEntry ->
+            DynamicRoute("${SettingsRoutes.ExtensionSettings.route}/{extensionId}") { _, backStackEntry ->
                 val extensionId = backStackEntry.arguments?.getString("extensionId")
                 val extension = extensionId?.let { extensionManager.getExtension(it) }
                 ExtensionSettings(extension)

--- a/features/extensions/src/main/java/com/rk/extension/api/ExtensionContext.kt
+++ b/features/extensions/src/main/java/com/rk/extension/api/ExtensionContext.kt
@@ -5,7 +5,8 @@ import android.content.Context
 import android.content.res.AssetManager
 import android.content.res.Resources
 import androidx.annotation.Keep
-import com.rk.extension.api.XedExtensionPoint
+import com.rk.extension.api.ExtensionActivity
+import com.rk.extension.api.ExtensionScreen
 import com.rk.extension.api.logDebug
 import com.rk.extension.api.logError
 import com.rk.extension.api.logInfo
@@ -14,7 +15,6 @@ import com.rk.file.createDirIfNot
 import kotlinx.coroutines.CoroutineScope
 import java.io.File
 
-@XedExtensionPoint
 @Keep
 class ExtensionContext(val extension: LocalExtension, val appContext: Context, val scope: CoroutineScope) {
 
@@ -46,4 +46,8 @@ class ExtensionContext(val extension: LocalExtension, val appContext: Context, v
     fun logWarn(msg: String) = extension.id.logWarn(msg)
 
     fun logError(msg: String) = extension.id.logError(msg)
+
+    fun startScreen(screen: ExtensionScreen) {
+        ExtensionActivity.start(ActivityProvider.currentActivity ?: appContext, screen)
+    }
 }

--- a/features/git/src/main/java/com/rk/git/GitFeature.kt
+++ b/features/git/src/main/java/com/rk/git/GitFeature.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModelProvider
 import com.rk.activities.main.MainActivity
 import com.rk.activities.settings.SettingsRoutes
-import com.rk.components.DialogProvider
 import com.rk.components.DialogRegistry
 import com.rk.drawer.AddProjectCategory
 import com.rk.drawer.AddProjectOption
@@ -19,6 +18,7 @@ import com.rk.drawer.ServiceTabRegistry
 import com.rk.events.EditorTabEvent
 import com.rk.events.Events
 import com.rk.events.FileTreeEvent
+import com.rk.extension.api.DynamicRoute
 import com.rk.feature.Feature
 import com.rk.feature.FeatureRegistry
 import com.rk.feature.FeatureToggle
@@ -41,7 +41,6 @@ import com.rk.resources.strings
 import com.rk.settings.Settings
 import com.rk.settings.SettingsCategory
 import com.rk.settings.SettingsRegistry
-import com.rk.settings.SettingsRoute
 import com.rk.settings.git.GitSettings
 import com.rk.theme.gitAdded
 import com.rk.theme.gitConflicted
@@ -74,7 +73,7 @@ class GitFeature : Feature {
 
         // Register Git settings route
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.Git.route) { _, _ ->
+            DynamicRoute(SettingsRoutes.Git.route) { _, _ ->
                 GitSettings()
             }
         )
@@ -121,19 +120,17 @@ class GitFeature : Feature {
             AddProjectRegistry.register(option)
         }
 
-        DialogRegistry.register(
-            DialogProvider {
-                if (showCloneDialog) {
-                    GitCloneDialog(
-                        onDismiss = { showCloneDialog = false },
-                        onCloneComplete = { destination ->
-                            // Add file tree tab on success
-                            MainActivity.instance?.drawerViewModel?.addFileTreeTab(destination)
-                        },
-                    )
-                }
+        DialogRegistry.register {
+            if (showCloneDialog) {
+                GitCloneDialog(
+                    onDismiss = { showCloneDialog = false },
+                    onCloneComplete = { destination ->
+                        // Add file tree tab on success
+                        MainActivity.instance?.drawerViewModel?.addFileTreeTab(destination)
+                    },
+                )
             }
-        )
+        }
 
         // Register Xed project templates
         val category =

--- a/features/git/src/main/java/com/rk/git/GitTab.kt
+++ b/features/git/src/main/java/com/rk/git/GitTab.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.rk.activities.main.MainActivity
+import com.rk.activities.main.drawerStateRef
 import com.rk.activities.main.fileTreeViewModel
 import com.rk.activities.main.filesByTab
 import com.rk.components.SingleInputDialog
@@ -608,6 +609,7 @@ class GitTab(val viewModel: GitViewModel) : DrawerTab() {
     @Composable
     private fun ChangesItemList(items: List<GitChange>) {
         val context = LocalContext.current
+        val scope = rememberCoroutineScope()
 
         Column(modifier = Modifier.padding(start = 40.dp)) {
             items.forEach { change ->
@@ -641,6 +643,7 @@ class GitTab(val viewModel: GitViewModel) : DrawerTab() {
                                                 content = diff,
                                                 extension = "diff",
                                             )
+                                        scope.launch { drawerStateRef.get()?.close() }
                                     }
                                 },
                                 onLongClick = { showRollbackDialog = true },

--- a/features/git/src/main/java/com/rk/git/GitTab.kt
+++ b/features/git/src/main/java/com/rk/git/GitTab.kt
@@ -2,7 +2,6 @@ package com.rk.git
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -612,11 +611,40 @@ class GitTab(val viewModel: GitViewModel) : DrawerTab() {
 
         Column(modifier = Modifier.padding(start = 40.dp)) {
             items.forEach { change ->
+                var showRollbackDialog by remember { mutableStateOf(false) }
+                if (showRollbackDialog) {
+                    RollbackConfirmDialog(
+                        change = change,
+                        onDismiss = { showRollbackDialog = false },
+                        onConfirm = {
+                            viewModel.discard(change)
+                            showRollbackDialog = false
+                        },
+                    )
+                }
+
+                val file = File(change.absolutePath).toFileWrapper()
+                val fileName = change.path.substringAfterLast("/")
+
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier =
                         Modifier.width((getDrawerWidth() - 61.dp))
-                            .clickable { viewModel.toggleChange(change) }
+                            .combinedClickable(
+                                onClick = {
+                                    viewModel.getDiff(change) { diff ->
+                                        MainActivity.instance
+                                            ?.viewModel
+                                            ?.editorManager
+                                            ?.addPreviewTab(
+                                                title = fileName,
+                                                content = diff,
+                                                extension = "diff",
+                                            )
+                                    }
+                                },
+                                onLongClick = { showRollbackDialog = true },
+                            )
                             .padding(vertical = 4.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
@@ -626,9 +654,6 @@ class GitTab(val viewModel: GitViewModel) : DrawerTab() {
                         onCheckedChange = { viewModel.toggleChange(change) },
                         modifier = Modifier.size(20.dp),
                     )
-
-                    val file = File(change.absolutePath).toFileWrapper()
-                    val fileName = change.path.substringAfterLast("/")
 
                     FileNameIcon(fileName = fileName, isDirectory = false)
 
@@ -660,6 +685,17 @@ class GitTab(val viewModel: GitViewModel) : DrawerTab() {
                 }
             }
         }
+    }
+
+    @Composable
+    private fun RollbackConfirmDialog(change: GitChange, onDismiss: () -> Unit, onConfirm: () -> Unit) {
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text(stringResource(strings.discard_changes)) },
+            text = { Text(stringResource(strings.discard_changes_msg, change.path)) },
+            confirmButton = { TextButton(onClick = onConfirm) { Text(stringResource(strings.discard)) } },
+            dismissButton = { TextButton(onClick = onDismiss) { Text(stringResource(strings.cancel)) } },
+        )
     }
 
     override fun getName(): String {

--- a/features/git/src/main/java/com/rk/git/GitViewModel.kt
+++ b/features/git/src/main/java/com/rk/git/GitViewModel.kt
@@ -11,6 +11,7 @@ import com.rk.events.Events
 import com.rk.feature.FeatureRegistry
 import com.rk.file.FileWrapper
 import com.rk.resources.getFilledString
+import com.rk.resources.getString
 import com.rk.resources.strings
 import com.rk.settings.Settings
 import com.rk.utils.toast
@@ -31,7 +32,9 @@ import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 import org.eclipse.jgit.treewalk.CanonicalTreeParser
+import org.eclipse.jgit.treewalk.EmptyTreeIterator
 import org.eclipse.jgit.treewalk.FileTreeIterator
+import org.eclipse.jgit.treewalk.filter.PathFilter
 import java.io.ByteArrayOutputStream
 import java.io.File
 
@@ -574,28 +577,23 @@ class GitViewModel : ViewModel() {
                     ByteArrayOutputStream().use { out ->
                         DiffFormatter(out).use { formatter ->
                             formatter.setRepository(repo)
+                            formatter.pathFilter = PathFilter.create(change.path)
 
-                            RevWalk(repo).use { walk ->
-                                val head = walk.parseCommit(repo.resolve(Constants.HEAD))
-
-                                val oldTree =
+                            val headId = repo.resolve(Constants.HEAD + "^{" + Constants.TYPE_TREE + "}")
+                            val oldTree =
+                                if (headId != null) {
                                     CanonicalTreeParser().apply {
-                                        reset(
-                                            repo.newObjectReader(),
-                                            head.tree,
-                                        )
+                                        reset(repo.newObjectReader(), headId)
                                     }
-
-                                val newTree = FileTreeIterator(repo)
-
-                                formatter
-                                    .scan(oldTree, newTree)
-                                    .filter { it.newPath == change.path || it.oldPath == change.path }
-                                    .forEach(formatter::format)
-
-                                withContext(Dispatchers.Main) {
-                                    onResult(out.toString())
+                                } else {
+                                    EmptyTreeIterator()
                                 }
+
+                            val newTree = FileTreeIterator(repo)
+                            formatter.scan(oldTree, newTree).forEach(formatter::format)
+
+                            withContext(Dispatchers.Main) {
+                                onResult(out.toString().ifBlank { strings.no_changes.getString() })
                             }
                         }
                     }

--- a/features/git/src/main/java/com/rk/git/GitViewModel.kt
+++ b/features/git/src/main/java/com/rk/git/GitViewModel.kt
@@ -10,6 +10,7 @@ import com.rk.DefaultScope
 import com.rk.events.Events
 import com.rk.feature.FeatureRegistry
 import com.rk.file.FileWrapper
+import com.rk.resources.getFilledString
 import com.rk.resources.strings
 import com.rk.settings.Settings
 import com.rk.utils.toast
@@ -22,12 +23,16 @@ import org.eclipse.jgit.api.ListBranchCommand
 import org.eclipse.jgit.api.errors.DetachedHeadException
 import org.eclipse.jgit.api.errors.InvalidRemoteException
 import org.eclipse.jgit.api.errors.TransportException
+import org.eclipse.jgit.diff.DiffFormatter
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.lib.SubmoduleConfig.FetchRecurseSubmodulesMode
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
+import org.eclipse.jgit.treewalk.CanonicalTreeParser
+import org.eclipse.jgit.treewalk.FileTreeIterator
+import java.io.ByteArrayOutputStream
 import java.io.File
 
 class GitViewModel : ViewModel() {
@@ -517,6 +522,83 @@ class GitViewModel : ViewModel() {
                     toast(strings.git_auth_error)
                 } else {
                     toast(e.message)
+                }
+            } catch (e: Exception) {
+                toast(e.message)
+            } finally {
+                withContext(Dispatchers.Main) { isLoading = false }
+            }
+        }
+    }
+
+    fun discard(change: GitChange) {
+        viewModelScope.launch(Dispatchers.IO) {
+            withContext(Dispatchers.Main) { isLoading = true }
+            try {
+                val root = currentRoot.value
+                Git.open(root).use { git ->
+                    when (change.type) {
+                        ChangeType.MODIFIED,
+                        ChangeType.DELETED,
+                        ChangeType.RENAMED,
+                        ChangeType.CONFLICTING -> {
+                            git.checkout().addPath(change.path).call()
+                        }
+                        ChangeType.ADDED -> {
+                            git.rm().addFilepattern(change.path).call()
+                        }
+                        ChangeType.UNTRACKED -> {
+                            File(change.absolutePath).delete()
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                toast(strings.discard_failed.getFilledString(e.message ?: ""))
+            } finally {
+                withContext(Dispatchers.Main) {
+                    isLoading = false
+                    syncChanges(currentRoot.value!!)
+                }
+            }
+        }
+    }
+
+    fun getDiff(change: GitChange, onResult: (String) -> Unit) {
+        viewModelScope.launch(Dispatchers.IO) {
+            withContext(Dispatchers.Main) { isLoading = true }
+            try {
+                val root = currentRoot.value
+                Git.open(root).use { git ->
+                    val repo = git.repository
+
+                    ByteArrayOutputStream().use { out ->
+                        DiffFormatter(out).use { formatter ->
+                            formatter.setRepository(repo)
+
+                            RevWalk(repo).use { walk ->
+                                val head = walk.parseCommit(repo.resolve(Constants.HEAD))
+
+                                val oldTree =
+                                    CanonicalTreeParser().apply {
+                                        reset(
+                                            repo.newObjectReader(),
+                                            head.tree,
+                                        )
+                                    }
+
+                                val newTree = FileTreeIterator(repo)
+
+                                formatter
+                                    .scan(oldTree, newTree)
+                                    .filter { it.newPath == change.path || it.oldPath == change.path }
+                                    .forEach(formatter::format)
+
+                                withContext(Dispatchers.Main) {
+                                    onResult(out.toString())
+                                }
+                            }
+                        }
+                    }
                 }
             } catch (e: Exception) {
                 toast(e.message)

--- a/features/git/src/main/java/com/rk/git/template/IconPackTemplate.kt
+++ b/features/git/src/main/java/com/rk/git/template/IconPackTemplate.kt
@@ -52,10 +52,7 @@ object IconPackTemplate : GitTemplate(repoUrl = "https://github.com/Xed-Editor/I
     private var nameError by mutableStateOf<String?>(null)
     private var minAppVersionError by mutableStateOf<String?>(null)
 
-    private fun validateId(value: String): String? {
-        val regex = "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$".toRegex()
-        return if (!regex.matches(value)) strings.invalid_characters.getString() else null
-    }
+    private fun validateId(value: String): String? = if (value.isBlank()) strings.value_empty_err.getString() else null
 
     private fun validateName(value: String): String? = if (value.isBlank()) strings.name_empty_err.getString() else null
 

--- a/features/git/src/main/java/com/rk/git/template/ThemeTemplate.kt
+++ b/features/git/src/main/java/com/rk/git/template/ThemeTemplate.kt
@@ -52,10 +52,7 @@ object ThemeTemplate : GitTemplate(repoUrl = "https://github.com/Xed-Editor/Them
     private var nameError by mutableStateOf<String?>(null)
     private var minAppVersionError by mutableStateOf<String?>(null)
 
-    private fun validateId(value: String): String? {
-        val regex = "^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$".toRegex()
-        return if (!regex.matches(value)) strings.invalid_characters.getString() else null
-    }
+    private fun validateId(value: String): String? = if (value.isBlank()) strings.value_empty_err.getString() else null
 
     private fun validateName(value: String): String? = if (value.isBlank()) strings.name_empty_err.getString() else null
 

--- a/features/runner/src/main/java/com/rk/runner/RunnerFeature.kt
+++ b/features/runner/src/main/java/com/rk/runner/RunnerFeature.kt
@@ -4,27 +4,24 @@ import android.app.Application
 import com.rk.activities.settings.SettingsRoutes
 import com.rk.commands.CommandProvider
 import com.rk.commands.editor.RunCommand
-import com.rk.components.DialogProvider
 import com.rk.components.DialogRegistry
+import com.rk.extension.api.DynamicRoute
 import com.rk.feature.Feature
 import com.rk.resources.drawables
 import com.rk.resources.strings
 import com.rk.settings.SettingsCategory
 import com.rk.settings.SettingsRegistry
-import com.rk.settings.SettingsRoute
 import com.rk.settings.runners.HtmlRunnerSettings
 import com.rk.settings.runners.RunnerSettings
 
 class RunnerFeature : Feature {
     override fun init(application: Application) {
         // Register RunnerSheet overlay
-        DialogRegistry.register(
-            DialogProvider {
-                if (RunnerUI.showRunnerDialog) {
-                    RunnerSheet()
-                }
+        DialogRegistry.register {
+            if (RunnerUI.showRunnerDialog) {
+                RunnerSheet()
             }
-        )
+        }
         // Register settings category
         SettingsRegistry.registerCategory(
             SettingsCategory(
@@ -37,12 +34,12 @@ class RunnerFeature : Feature {
 
         // Register settings routes
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.Runners.route) { navController, _ ->
+            DynamicRoute(SettingsRoutes.Runners.route) { navController, _ ->
                 RunnerSettings(navController = navController)
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.HtmlRunner.route) { _, _ ->
+            DynamicRoute(SettingsRoutes.HtmlRunner.route) { _, _ ->
                 HtmlRunnerSettings()
             }
         )

--- a/features/runner/src/main/java/com/rk/runner/RunnerManager.kt
+++ b/features/runner/src/main/java/com/rk/runner/RunnerManager.kt
@@ -13,6 +13,7 @@ import com.rk.runner.runners.web.html.HtmlRunner
 import com.rk.runner.runners.web.markdown.MarkdownRunner
 import com.rk.utils.errorDialog
 import kotlinx.coroutines.launch
+import org.jetbrains.annotations.ApiStatus
 
 object RunnerManager {
 
@@ -21,13 +22,21 @@ object RunnerManager {
     val extensionRunners: List<Runner>
         get() = _extensionRunners.toList()
 
-    val builtinRunners = listOf(HtmlRunner, MarkdownRunner, XedProjectRunner)
+    private val _builtinRunners = mutableStateListOf(HtmlRunner, MarkdownRunner, XedProjectRunner)
+    val builtinRunners: List<Runner>
+        get() = _builtinRunners.toList()
 
     @XedExtensionPoint
     fun registerRunner(runner: Runner) {
         if (!_extensionRunners.contains(runner)) {
             _extensionRunners.add(runner)
         }
+    }
+
+    @ApiStatus.Internal
+    // TODO: Temp
+    fun addBuiltInRunner(vararg servers: Runner) {
+        _builtinRunners.addAll(servers)
     }
 
     @XedExtensionPoint

--- a/features/runner/src/main/java/com/rk/runner/runners/XedProjectRunner.kt
+++ b/features/runner/src/main/java/com/rk/runner/runners/XedProjectRunner.kt
@@ -16,6 +16,8 @@ object XedProjectRunner : ProjectRunner() {
     override val id: String = "xed_project_runner"
     override val label: String = strings.project_runner.getString()
 
+    override val description = strings.project_runner_desc.getString()
+
     override fun getIcon(context: Context): Icon {
         return Icon.ResourceIcon(drawables.run)
     }

--- a/features/terminal/src/main/assets/terminal/sandbox.sh
+++ b/features/terminal/src/main/assets/terminal/sandbox.sh
@@ -18,8 +18,6 @@ unset system_mnt
 
 ARGS="$ARGS -b /sdcard"
 ARGS="$ARGS -b /storage"
-ARGS="$ARGS -b /storage/emulated:/storage/emulated"
-ARGS="$ARGS -b /storage/emulated/0:/storage/emulated/0"
 ARGS="$ARGS -b /dev"
 ARGS="$ARGS -b /data"
 ARGS="$ARGS -b /dev/urandom:/dev/random"

--- a/features/terminal/src/main/java/com/rk/TerminalFeature.kt
+++ b/features/terminal/src/main/java/com/rk/TerminalFeature.kt
@@ -13,6 +13,7 @@ import com.rk.drawer.AddProjectOption
 import com.rk.drawer.AddProjectRegistry
 import com.rk.exec.pendingCommand
 import com.rk.exec.ubuntuProcess
+import com.rk.extension.api.DynamicRoute
 import com.rk.feature.Feature
 import com.rk.feature.FeatureRegistry
 import com.rk.feature.FeatureToggle
@@ -27,10 +28,8 @@ import com.rk.icons.Icon
 import com.rk.lsp.LspRegistry
 import com.rk.lsp.servers.Bash
 import com.rk.lsp.servers.CSS
-import com.rk.lsp.servers.ESLint
 import com.rk.lsp.servers.Emmet
 import com.rk.lsp.servers.HTML
-import com.rk.lsp.servers.Markdown
 import com.rk.lsp.servers.TypeScript
 import com.rk.lsp.servers.XML
 import com.rk.resources.drawables
@@ -41,7 +40,6 @@ import com.rk.runner.runners.UniversalRunner
 import com.rk.settings.Settings
 import com.rk.settings.SettingsCategory
 import com.rk.settings.SettingsRegistry
-import com.rk.settings.SettingsRoute
 import com.rk.settings.editor.TerminalFontScreen
 import com.rk.settings.terminal.SettingsTerminalScreen
 import com.rk.settings.terminal.TerminalCheckScreen
@@ -103,27 +101,27 @@ class TerminalFeature : Feature {
 
         // Register settings routes
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.TerminalSettings.route) { _, _ ->
+            DynamicRoute(SettingsRoutes.TerminalSettings.route) { _, _ ->
                 SettingsTerminalScreen()
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.TerminalExtraKeys.route) { _, _ ->
+            DynamicRoute(SettingsRoutes.TerminalExtraKeys.route) { _, _ ->
                 TerminalExtraKeys()
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.TerminalCheck.route) { _, _ ->
+            DynamicRoute(SettingsRoutes.TerminalCheck.route) { _, _ ->
                 TerminalCheckScreen()
             }
         )
         SettingsRegistry.registerRoute(
-            SettingsRoute(SettingsRoutes.TerminalFontScreen.route) { _, _ ->
+            DynamicRoute(SettingsRoutes.TerminalFontScreen.route) { _, _ ->
                 TerminalFontScreen()
             }
         )
         // Register UniversalRunner dynamically
-        RunnerManager.registerRunner(UniversalRunner)
+        RunnerManager.addBuiltInRunner(UniversalRunner)
 
         // Register TerminalLauncher handler
         TerminalLauncher.handler = { activity, sandbox, exe, args, id, terminatePreviousSession, workingDir, env ->
@@ -157,14 +155,7 @@ class TerminalFeature : Feature {
         ToolbarConfiguration.addGlobalToolbarCommand(TerminalCommand, index = 1)
 
         // Register built-in LSP servers
-        LspRegistry.registerServer(Bash)
-        LspRegistry.registerServer(CSS)
-        LspRegistry.registerServer(ESLint)
-        LspRegistry.registerServer(Emmet)
-        LspRegistry.registerServer(HTML)
-        LspRegistry.registerServer(Markdown)
-        LspRegistry.registerServer(TypeScript)
-        LspRegistry.registerServer(XML)
+        LspRegistry.addBuiltInServers(HTML, Emmet, CSS, TypeScript, Bash, XML)
     }
 }
 

--- a/features/terminal/src/main/java/com/rk/exec/ubuntuProcess.kt
+++ b/features/terminal/src/main/java/com/rk/exec/ubuntuProcess.kt
@@ -13,12 +13,12 @@ import com.rk.utils.application
 import com.rk.utils.getSourceDirOfPackage
 import com.rk.utils.getTempDir
 import com.rk.xededitor.BuildConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
 import java.io.OutputStreamWriter
 import kotlin.random.Random
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 data class Binding(val outside: String, val inside: String? = null)
 
@@ -50,8 +50,6 @@ fun getDefaultBindings(): List<Binding> {
         bind(sandboxHomeDir().absolutePath, "/home")
         bind("/sdcard")
         bind("/storage")
-        bind("/storage/emulated","/storage/emulated")
-        bind("/storage/emulated/0","/storage/emulated/0")
         bind("/data")
         bind(application!!.filesDir.parentFile!!.absolutePath)
         bind("/dev")

--- a/plugin-sdk/gradle/libs.versions.toml
+++ b/plugin-sdk/gradle/libs.versions.toml
@@ -24,7 +24,6 @@ coreKtx = "1.17.0"
 activity = "1.12.0"
 okhttp = "5.3.2"
 photoview = "2.3.0"
-quickjsAndroid = "0.9.2"
 composeRuntime = "1.10.0"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"
@@ -37,8 +36,8 @@ jgit = "6.2.0.202206071550-r"
 tsBinding = "4.3.2"
 lsp4j = "1.0.0"
 uiautomator = "2.3.0"
-benchmark = "1.4.1"
-baselineprofile = "1.4.1"
+benchmark = "1.5.0-alpha06"
+baselineprofile = "1.5.0-alpha06"
 profileinstaller = "1.4.1"
 runner = "1.7.0"
 composeDnd = "0.4.0"
@@ -77,7 +76,6 @@ android-baselineprofile = { id = "androidx.baselineprofile", version.ref = "base
 android-benchmark = { id = "androidx.benchmark", version.ref = "benchmark" }
 
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
@@ -119,6 +117,8 @@ androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "composeRuntime" }
 androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "materialIconsCore" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 
 # Networking / IO
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
## Changes
- Introduce `ExtensionActivity` and `ExtensionScreen` to allow extensions to host custom activities and UI components
- Replace `SettingsRoute` with a unified `DynamicRoute` and add `MainRouteRegistry` to support dynamic navigation in the main activity
- Refactor `LspRegistry` and `RunnerManager` to distinguish between built-in, extension-provided, and external components
- Convert `DialogProvider` to a functional interface for improved Compose integration
- Add `startScreen` to `ExtensionContext` for launching extension-defined screens
- Simplify ID validation logic in Git project templates
- Update `benchmark` and `baselineprofile` dependencies to `1.5.0-alpha06`
- Remove redundant bind mounts for emulated storage in terminal sandbox configurations
- Add description support to `Runner` interface and implement it for `XedProjectRunner`
---
- Add support for viewing file diffs in a preview tab by clicking on a Git change
- Implement a "Discard changes" feature accessible via long-press on Git changes
- Add `getDiff` and `discard` logic to `GitViewModel` using JGit
- Introduce `initialContent` parameter to `EditorManager` and `EditorTab` for more efficient tab initialization
- Update `TabState` to better handle content restoration and dirty state management
- Enhance Darcula and Quiet Light TextMate themes with syntax highlighting for diff files
- Disable the "Replace" command in the editor when the content is read-only
- Add confirmation dialog and strings for discarding Git changes