### PR TITLE
feat: implement persistent document state using Room

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainActivity.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.rk.activities.main.navigation.MainRouteRegistry
 import com.rk.activities.main.navigation.MainRoutes
+import com.rk.activities.main.session.DocumentStateDatabase
 import com.rk.activities.main.session.SessionManager
 import com.rk.activities.main.ui.DisclaimerScreen
 import com.rk.activities.main.ui.MainContentHost
@@ -134,6 +135,14 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         AppCompatDelegate.setDefaultNightMode(Settings.theme_mode)
         super.onCreate(savedInstanceState)
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val db = DocumentStateDatabase.getDatabase(applicationContext)
+            val thirtyDaysInMillis = 1000L * 60 * 60 * 24 * 30
+            val timestamp = System.currentTimeMillis() - thirtyDaysInMillis
+            db.documentStateDao().deleteOlderThan(timestamp)
+        }
+
         enableEdgeToEdge()
         instance = this
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/core/main/src/main/java/com/rk/activities/main/session/DocumentStateDatabase.kt
+++ b/core/main/src/main/java/com/rk/activities/main/session/DocumentStateDatabase.kt
@@ -1,0 +1,62 @@
+package com.rk.activities.main.session
+
+import android.content.Context
+import androidx.room.Dao
+import androidx.room.Database
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import java.io.Serializable
+
+@Entity(tableName = "document_state")
+data class DocumentState(
+    @PrimaryKey val path: String,
+    val cursorLineLeft: Int,
+    val cursorColumnLeft: Int,
+    val cursorLineRight: Int,
+    val cursorColumnRight: Int,
+    val scrollX: Int,
+    val scrollY: Int,
+    val lastOpened: Long,
+) : Serializable
+
+@Dao
+interface DocumentStateDao {
+    @Query("SELECT * FROM document_state WHERE path = :path") suspend fun getState(path: String): DocumentState?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE) suspend fun insertState(state: DocumentState)
+
+    @Query("DELETE FROM document_state WHERE path = :path") suspend fun deleteByPath(path: String)
+
+    @Query("DELETE FROM document_state WHERE lastOpened < :timestamp") suspend fun deleteOlderThan(timestamp: Long)
+
+    @Query("DELETE FROM document_state") suspend fun clear()
+}
+
+@Database(entities = [DocumentState::class], version = 1, exportSchema = false)
+abstract class DocumentStateDatabase : RoomDatabase() {
+    abstract fun documentStateDao(): DocumentStateDao
+
+    companion object {
+        @Volatile private var INSTANCE: DocumentStateDatabase? = null
+
+        fun getDatabase(context: Context): DocumentStateDatabase {
+            return INSTANCE
+                ?: synchronized(this) {
+                    val instance =
+                        Room.databaseBuilder(
+                                context,
+                                DocumentStateDatabase::class.java,
+                                "document_state_database",
+                            )
+                            .build()
+                    INSTANCE = instance
+                    instance
+                }
+        }
+    }
+}

--- a/core/main/src/main/java/com/rk/activities/main/session/TabState.kt
+++ b/core/main/src/main/java/com/rk/activities/main/session/TabState.kt
@@ -15,9 +15,6 @@ sealed interface TabState : Serializable {
 data class EditorTabState(
     val fileObject: FileObject?,
     val projectRoot: FileObject?,
-    val cursor: EditorCursorState,
-    val scrollX: Int,
-    val scrollY: Int,
     val content: String?,
     val isDirty: Boolean = false,
     val isReadOnly: Boolean = false,
@@ -40,21 +37,7 @@ data class EditorTabState(
 
             viewModelScope.launch {
                 editorTab.editorState.contentRendered.await()
-                val editor = editorTab.editorState.editor.get()!!
-
                 editorTab.editorState.isDirty = isDirty
-
-                val maxLine = editor.text.lineCount - 1
-                val lineLeft = cursor.lineLeft.coerceAtMost(maxLine)
-                val lineRight = cursor.lineRight.coerceAtMost(maxLine)
-
-                val maxColumnLeft = editor.text.getColumnCount(lineLeft)
-                val maxColumnRight = editor.text.getColumnCount(lineRight)
-                val columnLeft = cursor.columnLeft.coerceAtMost(maxColumnLeft)
-                val columnRight = cursor.columnRight.coerceAtMost(maxColumnRight)
-
-                editor.setSelectionRegion(lineLeft, columnLeft, lineRight, columnRight)
-                editor.scroller.startScroll(scrollX, scrollY, 0, 0)
             }
 
             editorTab
@@ -62,8 +45,6 @@ data class EditorTabState(
     }
 }
 
-data class EditorCursorState(val lineLeft: Int, val columnLeft: Int, val lineRight: Int, val columnRight: Int) :
-    Serializable
 
 data class FileTabState(val fileObject: FileObject) : TabState {
     override suspend fun toTab() = TabRegistry.getTab(fileObject, null, MainActivity.instance!!.viewModel, false, null)

--- a/core/main/src/main/java/com/rk/file/ZipFileObject.kt
+++ b/core/main/src/main/java/com/rk/file/ZipFileObject.kt
@@ -168,17 +168,11 @@ class ZipFileObject(
 
     override fun canExecute(): Boolean = false
 
-    private var metadataCache: ZipEntryMetadata? = null
-
     private suspend fun getZipEntryMetadata(): ZipEntryMetadata? =
         withContext(Dispatchers.IO) {
-            metadataCache?.let {
-                return@withContext it
-            }
-
             val zipFile = File(zipFileObject.getAbsolutePath())
 
-            val metadata = runCatching {
+            runCatching {
                 ZipFile(zipFile).use { zip ->
                     val entry = zip.getEntry(entryPath) ?: return@use null
 
@@ -193,9 +187,6 @@ class ZipFileObject(
                 }
             }
                 .getOrNull()
-
-            metadataCache = metadata
-            metadata
         }
 
     override suspend fun lastModified(): Long? = getZipEntryMetadata()?.lastModified

--- a/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
@@ -29,7 +29,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.rk.activities.main.MainActivity
 import com.rk.activities.main.MainViewModel
-import com.rk.activities.main.session.EditorCursorState
+import com.rk.activities.main.session.DocumentState
+import com.rk.activities.main.session.DocumentStateDatabase
 import com.rk.activities.main.session.EditorTabState
 import com.rk.activities.main.session.TabState
 import com.rk.activities.main.ui.searchViewModel
@@ -115,7 +116,14 @@ open class EditorTab(
 
     val editorState by mutableStateOf(CodeEditorState(initialContent))
 
+    override fun onTabAdded() {
+        scope.launch(Dispatchers.Main) {
+            restoreDocumentState()
+        }
+    }
+
     override fun onTabRemoved() {
+        saveDocumentState()
         autoSaveJob?.cancel()
         scope.cancel()
         editorState.content = null
@@ -191,11 +199,13 @@ open class EditorTab(
             if (editorState.content == null) {
                 withContext(Dispatchers.IO) {
                     runCatching {
-                        editorState.content = file.getInputStream().use { ContentIO.createFrom(it, charset) }
+                        withTask {
+                            editorState.content = file.getInputStream().use { ContentIO.createFrom(it, charset) }
 
-                        if (Settings.detect_bin_files && hasBinaryChars(editorState.content.toString())) {
-                            editorState.editable = false
-                            showNotice(BINARY_NOTICE_KEY) { id -> BinaryNotice(id) }
+                            if (Settings.detect_bin_files && hasBinaryChars(editorState.content.toString())) {
+                                editorState.editable = false
+                                showNotice(BINARY_NOTICE_KEY) { id -> BinaryNotice(id) }
+                            }
                         }
                     }
                         .onFailure { errorDialog(throwable = it) }
@@ -606,19 +616,11 @@ open class EditorTab(
     }
 
     override fun getState(): TabState? {
+        saveDocumentState()
         val editor = editorState.editor.get() ?: return null
         return EditorTabState(
             fileObject = file,
             projectRoot = projectRoot,
-            cursor =
-                EditorCursorState(
-                    lineLeft = editor.cursor.leftLine,
-                    columnLeft = editor.cursor.leftColumn,
-                    lineRight = editor.cursor.rightLine,
-                    columnRight = editor.cursor.rightColumn,
-                ),
-            scrollX = editor.scrollX,
-            scrollY = editor.scrollY,
             content =
                 when {
                     file == null -> editor.text.toString()
@@ -630,6 +632,54 @@ open class EditorTab(
             customTitle = customTitle,
             fallbackExtension = fallbackExtension,
         )
+    }
+
+    private suspend fun restoreDocumentState() {
+        val file = file ?: return
+        editorState.contentRendered.await()
+        val editor = editorState.editor.get() ?: return
+
+        val db = DocumentStateDatabase.getDatabase(MainActivity.instance!!)
+        val state = db.documentStateDao().getState(file.getAbsolutePath())
+        if (state != null) {
+            val maxLine = editor.text.lineCount - 1
+            val lineLeft = state.cursorLineLeft.coerceAtMost(maxLine)
+            val lineRight = state.cursorLineRight.coerceAtMost(maxLine)
+
+            val maxColumnLeft = editor.text.getColumnCount(lineLeft)
+            val maxColumnRight = editor.text.getColumnCount(lineRight)
+            val columnLeft = state.cursorColumnLeft.coerceAtMost(maxColumnLeft)
+            val columnRight = state.cursorColumnRight.coerceAtMost(maxColumnRight)
+
+            editor.setSelectionRegion(lineLeft, columnLeft, lineRight, columnRight)
+            editor.scroller.startScroll(state.scrollX, state.scrollY, 0, 0)
+        }
+    }
+
+    private fun saveDocumentState() {
+        val file = file ?: return
+        val editor = editorState.editor.get() ?: return
+        val path = file.getAbsolutePath()
+        val cursor = editor.cursor
+        val scrollX = editor.scrollX
+        val scrollY = editor.scrollY
+
+        val state =
+            DocumentState(
+                path = path,
+                cursorLineLeft = cursor.leftLine,
+                cursorColumnLeft = cursor.leftColumn,
+                cursorLineRight = cursor.rightLine,
+                cursorColumnRight = cursor.rightColumn,
+                scrollX = scrollX,
+                scrollY = scrollY,
+                lastOpened = System.currentTimeMillis(),
+            )
+
+        GlobalScope.launch(Dispatchers.IO) {
+            val db = DocumentStateDatabase.getDatabase(MainActivity.instance!!)
+            db.documentStateDao().insertState(state)
+        }
     }
 
     @Composable


### PR DESCRIPTION
This PR closes #445

- Introduce `DocumentStateDatabase` and `DocumentState` entity to persist cursor positions and scroll offsets
- Automatically restore document state in `EditorTab` when a tab is added
- Persist document state when tabs are removed or the editor state is retrieved
- Clean up document states older than 30 days during `MainActivity` initialization
- Remove legacy cursor and scroll state management from `EditorTabState` and `TabState`
- Refactor file loading in `EditorTab` to use `withTask` for better task management