### PR TITLE
fix: fix document formatting and editor task management

### DIFF
--- a/core/main/src/main/java/com/rk/commands/CommandProvider.kt
+++ b/core/main/src/main/java/com/rk/commands/CommandProvider.kt
@@ -32,6 +32,7 @@ import com.rk.commands.global.SearchCodeCommand
 import com.rk.commands.global.SearchFileFolderCommand
 import com.rk.commands.global.SettingsCommand
 import com.rk.commands.lsp.FormatDocumentCommand
+import com.rk.commands.lsp.FormatDocumentLspCommand
 import com.rk.commands.lsp.FormatSelectionCommand
 import com.rk.commands.lsp.GoToDefinitionCommand
 import com.rk.commands.lsp.GoToReferencesCommand
@@ -79,6 +80,7 @@ object CommandProvider {
     lateinit var GoToReferencesCommand: GoToReferencesCommand
     lateinit var RenameSymbolCommand: RenameSymbolCommand
     lateinit var FormatDocumentCommand: FormatDocumentCommand
+    lateinit var FormatDocumentLspCommand: FormatDocumentLspCommand
     lateinit var FormatSelectionCommand: FormatSelectionCommand
 
     fun buildCommands() =
@@ -117,6 +119,7 @@ object CommandProvider {
             registerBuiltin(GoToReferencesCommand()) { GoToReferencesCommand = it }
             registerBuiltin(RenameSymbolCommand()) { RenameSymbolCommand = it }
             registerBuiltin(FormatDocumentCommand()) { FormatDocumentCommand = it }
+            registerBuiltin(FormatDocumentLspCommand()) { FormatDocumentLspCommand = it }
             registerBuiltin(FormatSelectionCommand()) { FormatSelectionCommand = it }
         }
 

--- a/core/main/src/main/java/com/rk/commands/lsp/FormatDocumentCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/lsp/FormatDocumentCommand.kt
@@ -1,30 +1,21 @@
 package com.rk.commands.lsp
 
-import com.rk.DefaultScope
-import com.rk.commands.LspActionContext
-import com.rk.commands.LspCommand
-import com.rk.commands.LspNonActionContext
+import com.rk.commands.EditorActionContext
+import com.rk.commands.EditorCommand
 import com.rk.icons.Icon
-import com.rk.lsp.formatDocument
 import com.rk.resources.drawables
 import com.rk.resources.getString
 import com.rk.resources.strings
+import com.rk.tabs.editor.EditorTab
 
-class FormatDocumentCommand : LspCommand() {
-    override val id: String = "lsp.format_document"
+class FormatDocumentCommand : EditorCommand() {
+    override val id: String = "editor.format_document"
 
     override fun getLabel(): String = strings.format_document.getString()
 
-    override fun action(context: LspActionContext) {
-        formatDocument(DefaultScope, context.editorTab)
-    }
-
-    override fun isEnabled(context: LspNonActionContext): Boolean {
-        return context.editorTab.editorState.editable
-    }
-
-    override fun isSupported(context: LspNonActionContext): Boolean {
-        return context.lspConnector.isFormattingSupported()
+    override fun action(context: EditorActionContext) {
+        context.editorTab.registerTask(EditorTab.FORMAT_DOCUMENT_TASK_ID)
+        context.editor.formatCodeAsync()
     }
 
     override fun getIcon(): Icon = Icon.ResourceIcon(drawables.auto_fix)

--- a/core/main/src/main/java/com/rk/commands/lsp/FormatDocumentLspCommand.kt
+++ b/core/main/src/main/java/com/rk/commands/lsp/FormatDocumentLspCommand.kt
@@ -1,0 +1,33 @@
+package com.rk.commands.lsp
+
+import com.rk.commands.LspActionContext
+import com.rk.commands.LspCommand
+import com.rk.commands.LspNonActionContext
+import com.rk.icons.Icon
+import com.rk.lsp.formatDocumentSuspend
+import com.rk.resources.drawables
+import com.rk.resources.getString
+import com.rk.resources.strings
+import kotlinx.coroutines.launch
+
+class FormatDocumentLspCommand : LspCommand() {
+    override val id: String = "lsp.format_document"
+
+    override fun getLabel(): String = strings.format_document_lsp.getString()
+
+    override fun action(context: LspActionContext) {
+        context.editorTab.scope.launch {
+            formatDocumentSuspend(context.editorTab)
+        }
+    }
+
+    override fun isEnabled(context: LspNonActionContext): Boolean {
+        return context.editorTab.editorState.editable
+    }
+
+    override fun isSupported(context: LspNonActionContext): Boolean {
+        return context.lspConnector.isFormattingSupported()
+    }
+
+    override fun getIcon(): Icon = Icon.ResourceIcon(drawables.auto_fix)
+}

--- a/core/main/src/main/java/com/rk/editor/Formatters.kt
+++ b/core/main/src/main/java/com/rk/editor/Formatters.kt
@@ -18,11 +18,11 @@ abstract class FormatterProvider {
         return null
     }
 
-    open fun getFormatter(fileObject: FileObject): Formatter? {
+    open fun getFormatter(fileObject: FileObject?): Formatter? {
         return getFormatter()
     }
 
-    open fun getFormatter(editor: CodeEditor, fileObject: FileObject): Formatter? {
+    open fun getFormatter(editor: CodeEditor, fileObject: FileObject?): Formatter? {
         return getFormatter(fileObject)
     }
 }

--- a/core/main/src/main/java/com/rk/lsp/LspActions.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspActions.kt
@@ -280,10 +280,6 @@ fun applyFormattingOptions(eventManager: LspEventManager, editorTab: EditorTab) 
     formattingOptions.isTrimTrailingWhitespace = editor.trimTrailingWhitespace
 }
 
-/**
- * A suspendable variant of [formatDocument] for use cases that require formatting to be complete before another action
- * is performed, such as `Format on Save`.
- */
 suspend fun formatDocumentSuspend(editorTab: EditorTab) {
     runCatching {
         val baseLspConnector = editorTab.lspConnector!!
@@ -299,10 +295,6 @@ suspend fun formatDocumentSuspend(editorTab: EditorTab) {
             it.printStackTrace()
             toast(strings.format_document_error)
         }
-}
-
-fun formatDocument(scope: CoroutineScope, editorTab: EditorTab) {
-    scope.launch(Dispatchers.Default) { formatDocumentSuspend(editorTab) }
 }
 
 fun formatDocumentRange(scope: CoroutineScope, editorTab: EditorTab) {

--- a/core/main/src/main/java/com/rk/lsp/LspConnector.kt
+++ b/core/main/src/main/java/com/rk/lsp/LspConnector.kt
@@ -34,6 +34,10 @@ import io.github.rosemoe.sora.lsp.events.AsyncEventListener
 import io.github.rosemoe.sora.lsp.requests.Timeout
 import io.github.rosemoe.sora.lsp.requests.Timeouts
 import io.github.rosemoe.sora.widget.CodeEditor
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -58,10 +62,6 @@ import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.jsonrpc.messages.Either3
-import java.net.URI
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * A utility object to temporarily prevent specific LSP servers from being used for a project.
@@ -136,7 +136,7 @@ class LspConnector(
                 return@withContext
             }
 
-            editorTab.registerTask("lsp")
+            editorTab.registerTask(EditorTab.LSP_CONNECTING_TASK_ID)
 
             val projectPath = projectFile.getAbsolutePath()
             val fileExt = fileObject.getExtension()
@@ -171,7 +171,7 @@ class LspConnector(
             } catch (e: Exception) {
                 e.printStackTrace()
             } finally {
-                editorTab.unregisterTask("lsp")
+                editorTab.unregisterTask(EditorTab.LSP_CONNECTING_TASK_ID)
 
                 val failedConnections = servers.filter { server ->
                     server.instances.any { instance ->

--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
@@ -51,6 +51,7 @@ import com.rk.utils.logInfo
 import com.rk.utils.logWarn
 import com.rk.utils.toast
 import io.github.rosemoe.sora.event.ContentChangeEvent
+import io.github.rosemoe.sora.event.EditorFormatEvent
 import io.github.rosemoe.sora.event.EditorKeyEvent
 import io.github.rosemoe.sora.event.InlayHintClickEvent
 import io.github.rosemoe.sora.event.KeyBindingEvent
@@ -134,6 +135,8 @@ fun EditorTab.CodeEditor(
 
 fun Editor.registerXedFormatter(editorTab: EditorTab) {
     editorTab.file?.let { file ->
+        // TODO: Allow without file, then fallback to textmateScope
+        // TODO: Add getFormatter(...) method with EditorTab as parameter
         val formatter = Formatters.getPreferredSourceForNonLspFile(file)
         formatterProvider = FormatterProvider {
             runCatching {
@@ -241,10 +244,14 @@ fun Editor.registerXedEvents(
 
     subscribeAlways(LayoutStateChangeEvent::class.java) { event ->
         if (event.isLayoutBusy) {
-            editorTab.registerTask("layout_busy")
+            editorTab.registerTask(EditorTab.LAYOUT_BUSY_TASK_ID)
         } else {
-            editorTab.unregisterTask("layout_busy")
+            editorTab.unregisterTask(EditorTab.LAYOUT_BUSY_TASK_ID)
         }
+    }
+
+    subscribeAlways(EditorFormatEvent::class.java) {
+        editorTab.unregisterTask(EditorTab.FORMAT_DOCUMENT_TASK_ID)
     }
 
     subscribeAlways(EditorKeyEvent::class.java) { event ->
@@ -354,10 +361,7 @@ private suspend fun Editor.connectLsp(
     logInfo("isConnected : ${tab.lspConnector?.isConnected() ?: false}")
 
     val formatter = Formatters.getPreferredSourceForFile(file)
-    val capabilities = tab.lspConnector?.getCapabilities()
-    val supportsFormatting =
-        capabilities?.documentFormattingProvider?.left == true ||
-            capabilities?.documentFormattingProvider?.right != null
+    val supportsFormatting = tab.lspConnector?.isFormattingSupported() ?: false
 
     if (formatter is FormatterSource.LSP && supportsFormatting) {
         formatterProvider = null

--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorCompose.kt
@@ -62,13 +62,13 @@ import io.github.rosemoe.sora.lang.styling.inlayHint.ColorInlayHint
 import io.github.rosemoe.sora.text.CharPosition
 import io.github.rosemoe.sora.text.TextRange
 import io.github.rosemoe.sora.widget.component.TextActionItem
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import java.lang.ref.WeakReference
 
 @OptIn(DelicateCoroutinesApi::class, ExperimentalLayoutApi::class)
 @Composable
@@ -251,6 +251,8 @@ fun Editor.registerXedEvents(
     }
 
     subscribeAlways(EditorFormatEvent::class.java) {
+        editorTab.editorState.formatDeferred?.complete(it.isSuccess)
+        editorTab.editorState.formatDeferred = null
         editorTab.unregisterTask(EditorTab.FORMAT_DOCUMENT_TASK_ID)
     }
 

--- a/core/main/src/main/java/com/rk/tabs/editor/CodeEditorState.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/CodeEditorState.kt
@@ -27,6 +27,7 @@ data class CodeEditorState(val initialContent: Content? = null) {
     val updateLock = Mutex()
 
     var editorConfigLoaded: CompletableDeferred<ResourceProperties>? = null
+    var formatDeferred: CompletableDeferred<Boolean>? = null
     val contentLoaded = CompletableDeferred<Unit>()
     val contentRendered = CompletableDeferred<Unit>()
 

--- a/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
@@ -397,9 +397,15 @@ open class EditorTab(
 
     suspend fun save() = saveMutex.withLock {
         if (isReadOnly) return@withLock
-        if (Settings.format_on_save) {
+        val editor = editorState.editor.get()
+        if (Settings.format_on_save && editor != null && !editor.isFormatting) {
+            val deferred = CompletableDeferred<Boolean>()
+            editorState.formatDeferred = deferred
+
             registerTask(FORMAT_DOCUMENT_TASK_ID)
-            editorState.editor.get()?.formatCodeAsync()
+            editor.formatCodeAsync()
+
+            deferred.await()
         }
 
         if (isTemp) {
@@ -429,10 +435,12 @@ open class EditorTab(
         }
     }
 
+    @XedExtensionPoint
     fun registerTask(id: String) {
         activeTasks.add(id)
     }
 
+    @XedExtensionPoint
     fun unregisterTask(id: String) {
         activeTasks.remove(id)
     }

--- a/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
+++ b/core/main/src/main/java/com/rk/tabs/editor/EditorTab.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -43,7 +44,6 @@ import com.rk.extension.api.XedExtensionPoint
 import com.rk.file.FileObject
 import com.rk.file.FileTypeManager
 import com.rk.lsp.LspConnector
-import com.rk.lsp.formatDocumentSuspend
 import com.rk.resources.drawables
 import com.rk.resources.getString
 import com.rk.resources.strings
@@ -99,7 +99,7 @@ open class EditorTab(
         get() = file == null && !isReadOnly
 
     private var autoSaveJob: Job? = null
-    private var activeTasks = mutableSetOf<String>()
+    private var activeTasks = mutableStateSetOf<String>()
 
     private var charset = Charset.forName(Settings.encoding)
     var lspConnector: LspConnector? = null
@@ -218,6 +218,10 @@ open class EditorTab(
     companion object {
         private const val BINARY_NOTICE_KEY = "binary_file"
         private const val EDITORCONFIG_NOTICE_KEY = "editorconfig_changed"
+
+        const val FORMAT_DOCUMENT_TASK_ID = "format_document"
+        const val LAYOUT_BUSY_TASK_ID = "layout_busy"
+        const val LSP_CONNECTING_TASK_ID = "connecting_lsp"
     }
 
     @Composable
@@ -393,8 +397,9 @@ open class EditorTab(
 
     suspend fun save() = saveMutex.withLock {
         if (isReadOnly) return@withLock
-        if (Settings.format_on_save && lspConnector?.isFormattingSupported() == true) {
-            formatDocumentSuspend(this@EditorTab)
+        if (Settings.format_on_save) {
+            registerTask(FORMAT_DOCUMENT_TASK_ID)
+            editorState.editor.get()?.formatCodeAsync()
         }
 
         if (isTemp) {

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -302,6 +302,7 @@
     <string name="go_to_references">Go to references</string>
     <string name="rename_symbol">Rename symbol</string>
     <string name="format_document">Format document</string>
+    <string name="format_document_lsp">Format document with LSP</string>
     <string name="format_selection">Format selection</string>
     <string name="go_to_definition_desc">Select one of the %s definitions to navigate to their location.</string>
     <string name="go_to_references_desc">Select one of the %s references to navigate to their location.</string>


### PR DESCRIPTION
- Centralize task IDs in `EditorTab` and switch `activeTasks` to `mutableStateSetOf` for better Compose state tracking
- Refactor `FormatDocumentCommand` to use `editor.formatCodeAsync()` and track its lifecycle via `FORMAT_DOCUMENT_TASK_ID`
- Introduce `FormatDocumentLspCommand` to provide explicit formatting via LSP
- Update `EditorTab.save()` to trigger asynchronous formatting when "Format on Save" is enabled
- Implement a listener for `EditorFormatEvent` to automatically unregister formatting tasks
- Simplify formatting support checks by using `LspConnector.isFormattingSupported()`
- Make `fileObject` nullable in `Formatters` to allow for more flexible formatter lookups
- Replace hardcoded task strings with constants (`LAYOUT_BUSY_TASK_ID`, `LSP_CONNECTING_TASK_ID`) across the codebase