### PR TITLE
feat(git): add clone destination option

### DIFF
--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -58,6 +58,8 @@
     <string name="ok">OK</string>
     <string name="clone_repo">Clone repository</string>
     <string name="clone_repo_desc">Clone remote repository</string>
+    <string name="clone_destination">Destination folder</string>
+    <string name="select_folder">Select folder</string>
     <string name="repo_url">Repository URL</string>
     <string name="branch">Branch</string>
     <string name="private_files">Private files</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="clone_repo">Clone repository</string>
     <string name="clone_repo_desc">Clone remote repository</string>
     <string name="clone_destination">Destination folder</string>
+    <string name="select_folder">Select folder</string>
     <string name="repo_url">Repository URL</string>
     <string name="branch">Branch</string>
     <string name="private_files">Private files</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -59,7 +59,6 @@
     <string name="clone_repo">Clone repository</string>
     <string name="clone_repo_desc">Clone remote repository</string>
     <string name="clone_destination">Destination folder</string>
-    <string name="select_folder">Select folder</string>
     <string name="repo_url">Repository URL</string>
     <string name="branch">Branch</string>
     <string name="private_files">Private files</string>

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="app_name" translatable="false">Xed-Editor</string>
     <string name="unsupported_content">Unsupported content</string>
+    <string name="unsupported_folder_for_feature">Unsupported folder for this feature</string>
     <string name="restart_required">Restart required</string>
     <string name="save">Save</string>
     <string name="open_directory">Open a directory</string>

--- a/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
+++ b/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
@@ -1,9 +1,5 @@
 package com.rk.git
 
-import android.content.Intent
-import android.net.Uri
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.AlertDialog
@@ -18,14 +14,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.rk.components.DoubleInputDialog
 import com.rk.file.FileObject
 import com.rk.file.FileWrapper
 import com.rk.file.sandboxHomeDir
-import com.rk.file.toFileObject
 import com.rk.resources.getString
 import com.rk.resources.strings
 import kotlinx.coroutines.launch
@@ -58,13 +52,10 @@ fun GitCloneDialog(
     onDismiss: () -> Unit,
     onCloneComplete: (FileObject) -> Unit,
 ) {
-    val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     var repoURL by remember { mutableStateOf("") }
     var repoBranch by remember { mutableStateOf("main") }
-    var destinationUri by remember { mutableStateOf<Uri?>(null) }
-    var destinationName by remember { mutableStateOf<String?>(null) }
 
     var repoURLError by remember { mutableStateOf<String?>(null) }
     var repoBranchError by remember { mutableStateOf<String?>(null) }
@@ -113,7 +104,7 @@ fun GitCloneDialog(
     }
 
     fun cloneInto() {
-        val destination = destinationUri?.toFileObject(expectedIsFile = false) ?: FileWrapper(sandboxHomeDir())
+        val destination = FileWrapper(sandboxHomeDir())
         scope.launch {
             val repositoryName = repoURL.substringAfterLast("/").substringBeforeLast(".")
             val repositoryFolder = destination.createChild(false, repositoryName) ?: return@launch
@@ -137,23 +128,6 @@ fun GitCloneDialog(
         }
     }
 
-    val selectDestinationFolder =
-        rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.OpenDocumentTree(),
-            onResult = { uri ->
-                uri?.let {
-                    runCatching {
-                        context.contentResolver.takePersistableUriPermission(
-                            it,
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
-                        )
-                    }
-                        .onFailure { it.printStackTrace() }
-                    destinationUri = it
-                    destinationName = it.toFileObject(expectedIsFile = false).getName()
-                }
-            },
-        )
 
     if (showCloneProgressDialog) {
         GitCloneProgressDialog(progressMessage, progress, maxProgress, monitor, onDismiss)
@@ -186,13 +160,7 @@ fun GitCloneDialog(
             },
             confirmText = stringResource(strings.ok),
             confirmEnabled = repoURLError == null && repoBranchError == null && repoURL.isNotBlank(),
-            message = {
-                val displayedDestination = destinationName ?: stringResource(strings.terminal_home)
-                Text("${stringResource(strings.clone_destination)}: $displayedDestination")
-                TextButton(onClick = { selectDestinationFolder.launch(null) }) {
-                    Text(stringResource(strings.select_folder))
-                }
-            },
+            message = { Text("${stringResource(strings.clone_destination)}: ${stringResource(strings.terminal_home)}") },
         )
     }
 }

--- a/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
+++ b/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
@@ -1,6 +1,7 @@
 package com.rk.git
 
 import android.content.Intent
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -22,6 +23,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.rk.components.DoubleInputDialog
 import com.rk.file.FileObject
+import com.rk.file.FileWrapper
+import com.rk.file.sandboxHomeDir
 import com.rk.file.toFileObject
 import com.rk.resources.getString
 import com.rk.resources.strings
@@ -60,6 +63,8 @@ fun GitCloneDialog(
 
     var repoURL by remember { mutableStateOf("") }
     var repoBranch by remember { mutableStateOf("main") }
+    var destinationUri by remember { mutableStateOf<Uri?>(null) }
+    var destinationName by remember { mutableStateOf<String?>(null) }
 
     var repoURLError by remember { mutableStateOf<String?>(null) }
     var repoBranchError by remember { mutableStateOf<String?>(null) }
@@ -107,7 +112,32 @@ fun GitCloneDialog(
         }
     }
 
-    val cloneGitRepo =
+    fun cloneInto() {
+        val destination = destinationUri?.toFileObject(expectedIsFile = false) ?: FileWrapper(sandboxHomeDir())
+        scope.launch {
+            val repositoryName = repoURL.substringAfterLast("/").substringBeforeLast(".")
+            val repositoryFolder = destination.createChild(false, repositoryName) ?: return@launch
+
+            gitViewModel
+                .get()
+                ?.cloneRepository(
+                    repoURL = normalizeRepoUrl(repoURL),
+                    repoBranch = repoBranch,
+                    targetDir = File(repositoryFolder.getAbsolutePath()),
+                    progressCoordinator = monitor,
+                    onComplete = { success ->
+                        repoURL = ""
+                        repoBranch = "main"
+                        repoURLError = null
+                        repoBranchError = null
+                        onDismiss()
+                        if (success) onCloneComplete(repositoryFolder)
+                    },
+                )
+        }
+    }
+
+    val selectDestinationFolder =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.OpenDocumentTree(),
             onResult = { uri ->
@@ -119,36 +149,9 @@ fun GitCloneDialog(
                         )
                     }
                         .onFailure { it.printStackTrace() }
-                    scope.launch {
-                        val fileObject =
-                            it.toFileObject(expectedIsFile = false)
-                                .createChild(
-                                    false,
-                                    repoURL.substringAfterLast("/").substringBeforeLast("."),
-                                )
-                        gitViewModel
-                            .get()
-                            ?.cloneRepository(
-                                repoURL = normalizeRepoUrl(repoURL),
-                                repoBranch = repoBranch,
-                                targetDir = File(fileObject!!.getAbsolutePath()),
-                                progressCoordinator = monitor,
-                                onComplete = { success ->
-                                    repoURL = ""
-                                    repoBranch = "main"
-                                    repoURLError = null
-                                    repoBranchError = null
-                                    onDismiss()
-                                    if (success) {
-                                        onCloneComplete(fileObject)
-                                    }
-                                },
-                            )
-                    }
+                    destinationUri = it
+                    destinationName = it.toFileObject(expectedIsFile = false).getName()
                 }
-                    ?: run {
-                        onDismiss()
-                    }
             },
         )
 
@@ -172,7 +175,7 @@ fun GitCloneDialog(
             firstErrorMessage = repoURLError,
             secondErrorMessage = repoBranchError,
             onConfirm = {
-                cloneGitRepo.launch(null)
+                cloneInto()
             },
             onDismiss = {
                 onDismiss()
@@ -183,6 +186,13 @@ fun GitCloneDialog(
             },
             confirmText = stringResource(strings.ok),
             confirmEnabled = repoURLError == null && repoBranchError == null && repoURL.isNotBlank(),
+            message = {
+                val displayedDestination = destinationName ?: stringResource(strings.terminal_home)
+                Text("${stringResource(strings.clone_destination)}: $displayedDestination")
+                TextButton(onClick = { selectDestinationFolder.launch(null) }) {
+                    Text(stringResource(strings.select_folder))
+                }
+            },
         )
     }
 }

--- a/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
+++ b/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
@@ -1,5 +1,9 @@
 package com.rk.git
 
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.AlertDialog
@@ -14,12 +18,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.rk.components.DoubleInputDialog
 import com.rk.file.FileObject
 import com.rk.file.FileWrapper
 import com.rk.file.sandboxHomeDir
+import com.rk.file.toFileObject
 import com.rk.resources.getString
 import com.rk.resources.strings
 import kotlinx.coroutines.launch
@@ -52,10 +58,13 @@ fun GitCloneDialog(
     onDismiss: () -> Unit,
     onCloneComplete: (FileObject) -> Unit,
 ) {
+    val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     var repoURL by remember { mutableStateOf("") }
     var repoBranch by remember { mutableStateOf("main") }
+    var destinationUri by remember { mutableStateOf<Uri?>(null) }
+    var destinationName by remember { mutableStateOf<String?>(null) }
 
     var repoURLError by remember { mutableStateOf<String?>(null) }
     var repoBranchError by remember { mutableStateOf<String?>(null) }
@@ -104,7 +113,7 @@ fun GitCloneDialog(
     }
 
     fun cloneInto() {
-        val destination = FileWrapper(sandboxHomeDir())
+        val destination = destinationUri?.toFileObject(expectedIsFile = false) ?: FileWrapper(sandboxHomeDir())
         scope.launch {
             val repositoryName = repoURL.substringAfterLast("/").substringBeforeLast(".")
             val repositoryFolder = destination.createChild(false, repositoryName) ?: return@launch
@@ -128,6 +137,23 @@ fun GitCloneDialog(
         }
     }
 
+    val selectDestinationFolder =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.OpenDocumentTree(),
+            onResult = { uri ->
+                uri?.let {
+                    runCatching {
+                        context.contentResolver.takePersistableUriPermission(
+                            it,
+                            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                        )
+                    }
+                        .onFailure { it.printStackTrace() }
+                    destinationUri = it
+                    destinationName = it.toFileObject(expectedIsFile = false).getName()
+                }
+            },
+        )
 
     if (showCloneProgressDialog) {
         GitCloneProgressDialog(progressMessage, progress, maxProgress, monitor, onDismiss)
@@ -160,7 +186,13 @@ fun GitCloneDialog(
             },
             confirmText = stringResource(strings.ok),
             confirmEnabled = repoURLError == null && repoBranchError == null && repoURL.isNotBlank(),
-            message = { Text("${stringResource(strings.clone_destination)}: ${stringResource(strings.terminal_home)}") },
+            message = {
+                val displayedDestination = destinationName ?: stringResource(strings.terminal_home)
+                Text("${stringResource(strings.clone_destination)}: $displayedDestination")
+                TextButton(onClick = { selectDestinationFolder.launch(null) }) {
+                    Text(stringResource(strings.select_folder))
+                }
+            },
         )
     }
 }

--- a/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
+++ b/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
@@ -131,6 +131,8 @@ fun GitCloneDialog(
                         repoBranch = "main"
                         repoURLError = null
                         repoBranchError = null
+                        destinationName = null
+                        destinationFolder = null
                         onDismiss()
                         if (success) onCloneComplete(repositoryFolder)
                     },
@@ -181,7 +183,7 @@ fun GitCloneDialog(
             firstErrorMessage = repoURLError,
             secondErrorMessage = repoBranchError,
             onConfirm = {
-                if (destinationFolder is FileWrapper) {
+                if (destinationFolder !is FileWrapper) {
                     Toast.makeText(context, strings.unsupported_folder_for_feature, Toast.LENGTH_SHORT).show()
                 } else {
                     cloneInto()
@@ -193,6 +195,8 @@ fun GitCloneDialog(
                 repoBranch = "main"
                 repoURLError = null
                 repoBranchError = null
+                destinationName = null
+                destinationFolder = null
             },
             confirmText = stringResource(strings.ok),
             confirmEnabled = repoURLError == null && repoBranchError == null && repoURL.isNotBlank(),

--- a/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
+++ b/features/git/src/main/java/com/rk/git/GitCloneDialog.kt
@@ -30,6 +30,7 @@ import com.rk.resources.getString
 import com.rk.resources.strings
 import kotlinx.coroutines.launch
 import java.io.File
+import android.widget.Toast
 
 private fun validateValue(value: String): String? {
     return when {
@@ -63,7 +64,7 @@ fun GitCloneDialog(
 
     var repoURL by remember { mutableStateOf("") }
     var repoBranch by remember { mutableStateOf("main") }
-    var destinationUri by remember { mutableStateOf<Uri?>(null) }
+    var destinationFolder by remember { mutableStateOf<FileObject?>(null) }
     var destinationName by remember { mutableStateOf<String?>(null) }
 
     var repoURLError by remember { mutableStateOf<String?>(null) }
@@ -113,7 +114,7 @@ fun GitCloneDialog(
     }
 
     fun cloneInto() {
-        val destination = destinationUri?.toFileObject(expectedIsFile = false) ?: FileWrapper(sandboxHomeDir())
+        val destination = destinationFolder ?: FileWrapper(sandboxHomeDir())
         scope.launch {
             val repositoryName = repoURL.substringAfterLast("/").substringBeforeLast(".")
             val repositoryFolder = destination.createChild(false, repositoryName) ?: return@launch
@@ -149,8 +150,13 @@ fun GitCloneDialog(
                         )
                     }
                         .onFailure { it.printStackTrace() }
-                    destinationUri = it
-                    destinationName = it.toFileObject(expectedIsFile = false).getName()
+
+                    val folder = uri.toFileObject(expectedIsFile = false)
+                    destinationFolder = folder
+                    destinationName = folder.getName()
+                } ?: run {
+                    destinationFolder = null
+                    destinationName = null
                 }
             },
         )
@@ -175,7 +181,11 @@ fun GitCloneDialog(
             firstErrorMessage = repoURLError,
             secondErrorMessage = repoBranchError,
             onConfirm = {
-                cloneInto()
+                if (destinationFolder is FileWrapper) {
+                    Toast.makeText(context, strings.unsupported_folder_for_feature, Toast.LENGTH_SHORT).show()
+                } else {
+                    cloneInto()
+                }
             },
             onDismiss = {
                 onDismiss()


### PR DESCRIPTION
**Warning: This Pull Request's code was created by codex, since you've read this, now you may continue.**

This Pull Request adds an option to select a folder in the (Git) Clone Repo Dialog by default it's the Terminal Home. Adds i18n keys as needed. Shows a toast when the Git feature is not supported on the destination folder.

## Self Tests

- [x] Clone inside Terminal Home (Working)
- [x] Cloning inside internal storage (Working)

## Screenshots

<img width="1080" height="1378" alt="Screenshot_2026-08-12-22-02-15-453-edit_com rk xededitor debug" src="https://github.com/user-attachments/assets/be0281e6-5727-408e-b419-778026518ef5" />
