### PR TITLE
Fix state reading issue with Kotlin flows

### DIFF
--- a/core/main/src/main/java/com/rk/activities/main/MainViewModel.kt
+++ b/core/main/src/main/java/com/rk/activities/main/MainViewModel.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 
 fun List<Tab>.filterEditorTabs() = filterIsInstance<EditorTab>()
@@ -73,18 +75,19 @@ class MainViewModel : ViewModel() {
     var commandPaletteInitialPlaceholder by mutableStateOf<String?>(null)
         private set
 
-    var pendingExtensionInstall by mutableStateOf<PendingExtensionInstall?>(null)
-        private set
+    private val _pendingExtensionInstall = MutableStateFlow<PendingExtensionInstall?>(null)
+
+    val pendingExtensionInstall: StateFlow<PendingExtensionInstall?> = _pendingExtensionInstall
 
     fun openExtensionIntentDialog(manifest: ExtensionManifest, file: File, icon: File) {
-        pendingExtensionInstall = PendingExtensionInstall(manifest, file, icon)
+        _pendingExtensionInstall.value = PendingExtensionInstall(manifest, file, icon)
     }
 
     fun closeExtensionIntentDialog() {
-        val pendingInstall = pendingExtensionInstall
+        val pendingInstall = _pendingExtensionInstall.value
 
         viewModelScope.launch(Dispatchers.Main) {
-            pendingExtensionInstall = null
+            _pendingExtensionInstall.value = null
 
             withContext(Dispatchers.IO) {
                 pendingInstall?.icon?.delete()

--- a/features/extensions/src/main/java/com/rk/ExtensionFeature.kt
+++ b/features/extensions/src/main/java/com/rk/ExtensionFeature.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import java.io.File
 
 class ExtensionFeature : Feature {
@@ -101,7 +102,7 @@ class ExtensionFeature : Feature {
             DialogProvider {
                 MainActivity.instance?.let {
                     val viewModel = it.viewModel
-                    val pendingInstall = viewModel.pendingExtensionInstall ?: return@let
+                    val pendingInstall = viewModel.pendingExtensionInstall.collectAsStateWithLifecycle().value ?: return@let
                     XedInstallDialog(
                         pendingInstall.manifest,
                         pendingInstall.icon,


### PR DESCRIPTION

This pull request refactors how pending extension installations are managed in the `MainViewModel` and updates the UI to reactively observe changes using Kotlin Flows and Compose best practices. The main goal is to make state management more robust and lifecycle-aware.

**State Management Improvements:**

* Replaced the `mutableStateOf`-based `pendingExtensionInstall` property in `MainViewModel` with a `MutableStateFlow`, exposing it as an immutable `StateFlow` for safer and more reactive state handling.
* Updated methods `openExtensionIntentDialog` and `closeExtensionIntentDialog` in `MainViewModel` to use the new `StateFlow`-based implementation.

**UI and Compose Integration:**

* In `ExtensionFeature`, switched to using `collectAsStateWithLifecycle()` to observe `pendingExtensionInstall`, ensuring the dialog reacts to state changes in a lifecycle-aware manner. [[1]](diffhunk://#diff-5cf88077505709cb62fe910c1bf7a582e5ff798c7306648dcdfae9ed16293b67R43) [[2]](diffhunk://#diff-5cf88077505709cb62fe910c1bf7a582e5ff798c7306648dcdfae9ed16293b67L104-R105)

**Dependency Updates:**

* Added necessary imports for `MutableStateFlow`, `StateFlow`, and `collectAsStateWithLifecycle` to support the above changes. [[1]](diffhunk://#diff-8f985696cbf739d3214714ec7cf947c7a366fcf895c05d41b047ce702ec009baR23-R24) [[2]](diffhunk://#diff-5cf88077505709cb62fe910c1bf7a582e5ff798c7306648dcdfae9ed16293b67R43)