### PR TITLE
Fix Samsung/Android PRoot SIGSYS handling and terminal health check

### DIFF
--- a/features/terminal/proot/src/main/cpp/tracee/event.c
+++ b/features/terminal/proot/src/main/cpp/tracee/event.c
@@ -536,9 +536,11 @@ int handle_tracee_event(Tracee *tracee, int tracee_status)
 					 * and seccomp policy raises SIGSYS on -1 syscall,
 					 * set tracee flag to ignore next SIGSYS.  */
 					if (was_sysenter) {
-						tracee->skip_next_seccomp_signal = (
-								seccomp_after_ptrace_enter &&
-								get_sysnum(tracee, CURRENT) == PR_void);
+						tracee->skip_next_seccomp_signal =
+								(get_sysnum(tracee, CURRENT) == PR_void);
+					}
+					else {
+						tracee->skip_next_seccomp_signal = false;
 					}
 
 					/* Redeliver signal suppressed during
@@ -696,7 +698,7 @@ int handle_tracee_event(Tracee *tracee, int tracee_status)
 					translate_syscall(tracee);
 				}
 
-				if (tracee->skip_next_seccomp_signal || (seccomp_after_ptrace_enter && siginfo.si_syscall == SYSCALL_AVOIDER)) {
+				if (tracee->skip_next_seccomp_signal || siginfo.si_syscall == (int) SYSCALL_AVOIDER) {
 					VERBOSE(tracee, 4, "suppressed SIGSYS after void syscall");
 					tracee->skip_next_seccomp_signal = false;
 					signal = 0;

--- a/features/terminal/src/main/java/com/rk/settings/terminal/terminalChecks.kt
+++ b/features/terminal/src/main/java/com/rk/settings/terminal/terminalChecks.kt
@@ -44,10 +44,10 @@ inline fun terminalChecks(): SnapshotStateList<Check> {
                     var exitCode = 999
 
                     try {
-                        printLog("Creating a temporary sandbox environment...")
+                        printLog("Testing PRoot executable...")
 
                         val process =
-                            ProcessBuilder(libproot.absolutePath, "-0", "-r", "/", "true")
+                            ProcessBuilder(libproot.absolutePath, "--version")
                                 .apply {
                                     environment()["PROOT_TMP_DIR"] = getTempDir().absolutePath
                                     environment()["PROOT_LOADER"] = prootloader.absolutePath


### PR DESCRIPTION
# Summary
Fixes two terminal issues affecting PRoot on Samsung/Android environments.
PRoot SIGSYS handling
Xed's vendored PRoot can incorrectly expose ENOSYS (Function not implemented) when Android's outer seccomp policy raises SIGSYS for the syscall avoider used by PRoot.
This updates the event handling so SIGSYS generated for SYSCALL_AVOIDER is suppressed correctly and preserves syscall results that PRoot has already emulated.

The change corresponds to newer upstream PRoot handling for outer-seccomp environments.
# Reproduction
Tested on:
Samsung Galaxy S24 Ultra (SM-S928U)
Android 16 / SDK 36
arm64
Xed 3.3.4 terminal rootfs: Ubuntu 24.04.3 LTS

Before the patch:
stat /proc/sys/crypto/fips_enabled - No such file or directory
cat /proc/sys/crypto/fips_enabled - Function not implemented
The incorrect ENOSYS caused libgcrypt to abort and prevented APT's HTTP method from operating normally.

After rebuilding PRoot with this patch and performing a controlled A/B test using the same Xed rootfs, loaders, bind mounts, and PROOT_NO_SECCOMP=1:
stat /proc/sys/crypto/fips_enabled - No such file or directory
cat /proc/sys/crypto/fips_enabled - No such file or directory

The /proc/sys/crypto/fips_enabled file does not exist on this device. The post-patch No such file or directory result is therefore the expected result of the diagnostic probe. In normal operation, users should not see this message; libgcrypt probes the optional FIPS path internally, receives the correct ENOENT, handles the missing file normally, and continues.

After the patch, apt-get update successfully downloaded Ubuntu InRelease metadata and progressed to repository signature verification. The previous libgcrypt Function not implemented failure did not recur.
PRoot health check
The existing PRoot health check executes:
libproot.so -0 -r / true

On affected Samsung systems this attempts to execute an Android host binary under PRoot and can fail even though the actual Ubuntu PRoot environment executes successfully.
The PRoot check now uses libproot.so --version to verify that the packaged PRoot executable can run. Actual guest execution remains covered separately by the existing Ubuntu health check.

# Testing
Patched event.c compiled successfully into an arm64 PRoot binary using the native Termux clang/CMake toolchain.
Patched PRoot executed successfully through /system/bin/linker64.
Controlled installed-vs-patched A/B testing reproduced and eliminated the incorrect ENOSYS.
apt-get update progressed beyond the previous libgcrypt failure.
git diff --check passes.

The repository's Gradle/ktfmt checks were also attempted on-device. The Gradle invocation could not complete because the Android SDK-provided CMake host binary is x86_64 and cannot run natively on the arm64 Termux host. The failure occurs before Android native source configuration/compilation and is independent of these source changes. The modified PRoot source itself was compiled and runtime-tested successfully on arm64.
# Note:
All reproduction, diagnosis, compilation, A/B testing, and runtime validation described below were performed directly on the Samsung Galaxy S24 Ultra; no desktop or x86_64 build host was used.